### PR TITLE
Clean named-place-linker-button observables [#176798676]

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-button/named-place-linker-button.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-button/named-place-linker-button.component.ts
@@ -1,7 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit, Output, EventEmitter } from '@angular/core';
-import { map, switchMap } from 'rxjs/operators';
-import { combineLatest, EMPTY, Observable } from 'rxjs';
-import { LajiFormDocumentFacade } from '@laji-form/laji-form-document.facade';
+import { catchError, map, shareReplay, switchMap } from 'rxjs/operators';
+import { combineLatest, EMPTY, Observable, of } from 'rxjs';
 import { FormService } from '../../../../shared/service/form.service';
 import { TranslateService } from '@ngx-translate/core';
 import { DialogService } from '../../../../shared/service/dialog.service';
@@ -51,8 +50,11 @@ export class NamedPlaceLinkerButtonComponent implements OnInit {
   ngOnInit() {
     const document$ = this.userService.isLoggedIn$.pipe(
       switchMap(isLoggedIn => isLoggedIn
-        ? this.documentApi.findById(this.documentID, this.userService.getToken())
-        : EMPTY)
+        ? this.documentApi.findById(this.documentID, this.userService.getToken()).pipe(
+          catchError(() => EMPTY)
+        )
+        : EMPTY),
+      shareReplay(1)
     );
     const form$ = document$.pipe(
       switchMap(document => this.formService.getAllForms().pipe(
@@ -64,12 +66,16 @@ export class NamedPlaceLinkerButtonComponent implements OnInit {
       map(([document, rights, person]) => this.documentService.getReadOnly(document, rights, person)),
       map(readonly => readonly === Readonly.true || readonly === Readonly.noEdit)
     );
-    const isLinkable$ = combineLatest(document$, form$, documentReadOnly$).pipe(
-      map(([document, form, readonly]) => !readonly && form.options?.useNamedPlaces && !document?.namedPlaceID)
-    );
+    const isLinkable$ = form$.pipe(switchMap(form =>
+      form.options?.useNamedPlaces
+        ? combineLatest(document$, documentReadOnly$).pipe(
+          map(([document, readonly]) => !readonly && !document.namedPlaceID)
+        )
+        : of(false)
+    ));
 
-    this.vm$ = combineLatest(isLinkable$, form$, document$).pipe(
-      map(([isLinkable, form, document]) => ({isLinkable, formID: form.id, documentID: document.id})
+    this.vm$ = combineLatest(isLinkable$, form$).pipe(
+      map(([isLinkable, form]) => ({isLinkable, formID: form.id, documentID: this.documentID})
     ));
   }
 }


### PR DESCRIPTION
Fixes for `named-place-linker-button`:
* Sending multiple doc requests
* Throwing error on doc find fail
* Don't fetch document if no need to (e.g. form doesn't use named places)