### PR TITLE
fix shortcut arrow keys in Annotation and Images modal

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
@@ -409,22 +409,25 @@ export class DocumentAnnotationComponent implements AfterViewInit, OnChanges, On
   annotationKeyDown(e: KeyboardEvent) {
       if (e.keyCode === 37 && !this.childEvent && !this.isfocusedCommentTaxon && !this.documentToolsOpen) { // left
         if (this.result && this.indexPagination > 0) {
+          e.preventDefault();
           this.previous();
         }
       }
 
       if (e.keyCode === 39 && !this.childEvent && !this.isfocusedCommentTaxon && !this.documentToolsOpen) { // right
         if (this.result && this.indexPagination < this.result.length - 1) {
+          e.preventDefault();
           this.next();
         }
       }
 
       if (e.keyCode === 187 && e.altKey) { // alt + ? --> open shortcuts div
+        e.preventDefault();
         this.toggleShortcuts();
       }
 
     if (e.keyCode === 27 && !this.childEvent && !this.documentToolsOpen) {
-       e.stopImmediatePropagation();
+       e.preventDefault();
        this.closeDocument();
       }
 

--- a/projects/laji/src/app/shared-modules/document-viewer/user-document-tools/user-document-tools.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/user-document-tools/user-document-tools.component.ts
@@ -264,7 +264,7 @@ export class UserDocumentToolsComponent implements OnInit, OnDestroy {
   @HostListener('document:keydown', ['$event'])
   documentToolsKeyDown(e: KeyboardEvent) {
     if (e.keyCode === 27 && this.modalIsOpen) {
-      e.stopImmediatePropagation();
+       e.preventDefault();
        this.closeModal();
       }
   }

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.ts
@@ -61,19 +61,21 @@ export class ImageModalOverlayComponent {
     }, 200);
   }
 
-  @HostListener('body:keydown', ['$event'])
+  @HostListener('document:keydown', ['$event'])
   modalKeyDown(e: KeyboardEvent)  {
+    e.preventDefault();
     if (e.keyCode === 27) { // esc
-      e.stopImmediatePropagation();
+      e.preventDefault();
       this.closeGallery();
     }
-    if (e.keyCode === 37) { // left
-      e.stopImmediatePropagation();
+    if (e.keyCode === 37 && this.modalImages.length > 0 && this.currentImageIndex > this.modalImages.length - 1) { // left
+      e.preventDefault();
       this.prevImage();
     }
-    if (e.keyCode === 39) { // right
-      e.stopImmediatePropagation();
+    if (e.keyCode === 39 && this.modalImages.length > 0 && this.currentImageIndex > 0) { // right
+      e.preventDefault();
       this.nextImage();
     }
+    e.stopPropagation();
   }
 }

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.ts
@@ -22,6 +22,7 @@ export class ImageModalOverlayComponent {
 
   closeGallery() {
     if (this.close) {
+      this.modalImages = [];
       this.close();
     }
     this.cancelEvent.emit(null);
@@ -63,19 +64,18 @@ export class ImageModalOverlayComponent {
 
   @HostListener('document:keydown', ['$event'])
   modalKeyDown(e: KeyboardEvent)  {
-    e.preventDefault();
+    e.stopPropagation();
     if (e.keyCode === 27) { // esc
       e.preventDefault();
       this.closeGallery();
     }
-    if (e.keyCode === 37 && this.modalImages.length > 0 && this.currentImageIndex > this.modalImages.length - 1) { // left
+    if (e.keyCode === 37 && this.modalImages.length > 0 && this.currentImageIndex > 0) { // left
       e.preventDefault();
       this.prevImage();
     }
-    if (e.keyCode === 39 && this.modalImages.length > 0 && this.currentImageIndex > 0) { // right
+    if (e.keyCode === 39 && this.modalImages.length > 0 && this.currentImageIndex < this.modalImages.length - 1) { // right
       e.preventDefault();
       this.nextImage();
     }
-    e.stopPropagation();
   }
 }

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
@@ -166,11 +166,11 @@ export class ImageModalComponent implements OnInit, OnDestroy {
 
 
 
-  @HostListener('body:keydown', ['$event'])
+  @HostListener('document:keydown', ['$event'])
   keyEvent(e: KeyboardEvent) {
       if (e.keyCode === 73 && e.altKey) { // openImage
         if (this.shortcut) {
-          e.preventDefault();
+          e.stopImmediatePropagation();
           this.openImage(this.tmpImg['index']);
         }
       }


### PR DESCRIPTION
shortcut didn't work well in annotation modal after open image modal. Same happens when user open images in taxon images tab.
Also component image-modal-overlay still have previous array of images when user move to annotation, so that generated some problem to shortcuts too