### PR TITLE
Document editor header clears named place

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
@@ -38,9 +38,7 @@ export class DocumentFormComponent {
   @ViewChild(_DocumentFormComponent) documentComponent: _DocumentFormComponent;
 
   @Input() set namedPlace(namedPlace: NamedPlace) {
-    if (namedPlace) {
-      this.lajiFormDocumentFacade.useNamedPlace(namedPlace, this.form.id);
-    }
+    this.lajiFormDocumentFacade.useNamedPlace(namedPlace, this.form.id);
     this.npLoaded$.next(true);
     this.np = namedPlace;
   }

--- a/projects/laji/src/app/shared-modules/laji-form/document-form-header/document-form-header.component.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form-header/document-form-header.component.ts
@@ -6,7 +6,6 @@ import { Title } from '@angular/platform-browser';
 import { UserService } from '../../../shared/service/user.service';
 import { ILajiFormState } from '../laji-form-document.facade';
 import * as moment from 'moment';
-import { AreaService } from '../../../shared/service/area.service';
 import { Form } from '../../../shared/model/Form';
 
 @Component({
@@ -53,8 +52,7 @@ export class DocumentFormHeaderComponent implements OnInit, OnChanges, OnDestroy
     private formService: FormService,
     private userService: UserService,
     public translate: TranslateService,
-    private cd: ChangeDetectorRef,
-    private areaService: AreaService
+    private cd: ChangeDetectorRef
   ) { }
 
   ngOnInit() {


### PR DESCRIPTION
Makes the document form component clear the named place in laji-form-document facade, so that it won't have the previous named place in the state.

Fixes https://www.pivotaltracker.com/story/show/177181864