### PR TITLE
fix bug in taxon card content tab when switch to other specie - 177659751

### DIFF
--- a/projects/laji-ui/src/lib/tabs/tab/tab.component.ts
+++ b/projects/laji-ui/src/lib/tabs/tab/tab.component.ts
@@ -12,11 +12,11 @@ export class TabComponent {
   private _heading = '';
   @Input() set heading(h) {
     this._heading = h;
-    this.inputChange.emit();
+    this.headingChange.emit();
   }
   get heading() { return this._heading; }
 
-  @Output() inputChange = new EventEmitter<null>();
+  @Output() headingChange = new EventEmitter<null>();
 
   _active = false;
   set active(a) {

--- a/projects/laji-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/laji-ui/src/lib/tabs/tabs.component.ts
@@ -86,6 +86,7 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
         this.cdr.markForCheck();
       });
     });
+    this.selectedChange.next(this.selectedIndex);
     this.cdr.markForCheck();
   }
 }

--- a/projects/laji-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/laji-ui/src/lib/tabs/tabs.component.ts
@@ -80,9 +80,7 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
   reload() {
     this.unsubscribe$.next();
     const tabs = this.tabComponents.toArray();
-    if (tabs[this.selectedIndex]) {
-      tabs[this.selectedIndex].active = true;
-    }
+    this.updateActiveComponents(this.selectedIndex);
     tabs.forEach((tab) => {
       tab.inputChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
         this.cdr.markForCheck();

--- a/projects/laji-ui/src/lib/tabs/tabs.component.ts
+++ b/projects/laji-ui/src/lib/tabs/tabs.component.ts
@@ -82,7 +82,7 @@ export class TabsComponent implements AfterContentInit, OnDestroy {
     const tabs = this.tabComponents.toArray();
     this.updateActiveComponents(this.selectedIndex);
     tabs.forEach((tab) => {
-      tab.inputChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
+      tab.headingChange.pipe(takeUntil(this.unsubscribe$)).subscribe(() => {
         this.cdr.markForCheck();
       });
     });

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.html
@@ -67,7 +67,7 @@
         [taxon]="taxon"
       ></laji-taxon-endangerment>
     </lu-tab>
-    <lu-tab [heading]="'taxonomy.invasive' | translate" *ngIf="taxon.invasiveSpecies">
+    <lu-tab [heading]="'taxonomy.invasive' | translate" *ngIf="isInvasive">
       <laji-taxon-invasive
         *ngIf="loadedTabs.isLoaded('invasive')"
         [taxon]="taxon"

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
@@ -148,7 +148,6 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   updateRoute(id: string, tab = this.activeTab, context = this.context, replaceUrl = false) {
-    this.loadedTabs.reset();
     this.activeTab = tab;
     this.routeUpdate.emit({id: id, tab: tab, context: context, replaceUrl: replaceUrl});
     this.cd.markForCheck();
@@ -217,7 +216,6 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getIsEndangered(taxon: Taxonomy): boolean {
-    this.cd.detectChanges();
     if (!taxon.latestRedListStatusFinland) {
       return false;
     }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
@@ -98,6 +98,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
       { queryParamsHandling: 'preserve' }
     );
     this.setTitle(tabName);
+    this.cd.detectChanges();
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -292,5 +293,4 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
     metaTitle += ' | ' + this.translate.instant('taxonomy.' + tabName) + ' | ' + this.translate.instant('footer.title1');
     this.title.setTitle(metaTitle);
   }
-
 }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
@@ -31,7 +31,7 @@ const tabOrderDev = [ 'overview', 'images', 'identification', 'biology', 'taxono
                    'specimens', 'endangerment', 'invasive' ];
 const basePath = '/taxon';
 
-export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'observations'|'specimens'|'endangerment'|'invasive';
+export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'specimens'|'endangerment'|'invasive';
 
 @Component({
   selector: 'laji-info-card',
@@ -47,6 +47,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   @Input() isFromMasterChecklist: boolean;
   @Input() context: string;
   @Input() set activeTab(tab: InfoCardTabType) {
+    this.loadedTabs.reset();
     this.selectedTab = tab;
     this.loadedTabs.load(tab);
   }
@@ -101,9 +102,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.activeTab) {
-      if (this.activeTab === 'observations') {
-        this.updateRoute(this.taxon.id, 'occurrence', this.context, true);
-      } else if (!this.tabOrder.includes(this.activeTab)) {
+      if (!this.tabOrder.includes(this.activeTab)) {
         this.updateRoute(this.taxon.id, 'overview', this.context, true);
       }
       this.setTitle(this.activeTab);

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
@@ -31,7 +31,7 @@ const tabOrderDev = [ 'overview', 'images', 'identification', 'biology', 'taxono
                    'specimens', 'endangerment', 'invasive' ];
 const basePath = '/taxon';
 
-export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'specimens'|'endangerment'|'invasive';
+export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'specimens'|('endangerment'|'invasive');
 
 @Component({
   selector: 'laji-info-card',
@@ -47,7 +47,6 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   @Input() isFromMasterChecklist: boolean;
   @Input() context: string;
   @Input() set activeTab(tab: InfoCardTabType) {
-    this.loadedTabs.reset();
     this.selectedTab = tab;
     this.loadedTabs.load(tab);
   }
@@ -64,6 +63,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   hasImageData: boolean;
   hasBiologyData: boolean;
   isEndangered: boolean;
+  isInvasive: boolean;
   images = [];
 
   sub: Subscription;
@@ -126,6 +126,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
       // this.hasBiologyData = !!this.taxon.primaryHabitat || !!this.taxon.secondaryHabitats || this.taxonDescription.length > 0;
       this.hasBiologyData = this.taxonDescription.length > 0;
       this.isEndangered = this.getIsEndangered(this.taxon);
+      this.isInvasive = this.taxon.invasiveSpecies;
 
       if (
         (!this.hasBiologyData && this.activeTab === 'biology') ||
@@ -147,8 +148,12 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   updateRoute(id: string, tab = this.activeTab, context = this.context, replaceUrl = false) {
-    this.selectedTab = tab;
+    if (this.activeTab !== 'endangerment' && this.activeTab !== 'invasive') {
+      this.loadedTabs.reset();
+    } 
+    this.activeTab = tab;
     this.routeUpdate.emit({id: id, tab: tab, context: context, replaceUrl: replaceUrl});
+    this.cd.markForCheck();
   }
 
   private setImages() {
@@ -214,6 +219,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private getIsEndangered(taxon: Taxonomy): boolean {
+    this.cd.detectChanges();
     if (!taxon.latestRedListStatusFinland) {
       return false;
     }
@@ -225,7 +231,6 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
         return true;
       }
     }
-
     return false;
   }
 
@@ -236,7 +241,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
       {e: this.hasBiologyData, t: 'biology'},
       {e: this.isFromMasterChecklist, t: 'specimens'},
       {e: this.isEndangered, t: 'endangerment'},
-      {e: this.taxon && this.taxon.invasiveSpecies, t: 'invasive'},
+      {e: this.isInvasive, t: 'invasive'},
     ];
   }
 

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card.component.ts
@@ -31,7 +31,7 @@ const tabOrderDev = [ 'overview', 'images', 'identification', 'biology', 'taxono
                    'specimens', 'endangerment', 'invasive' ];
 const basePath = '/taxon';
 
-export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'specimens'|('endangerment'|'invasive');
+export type InfoCardTabType = 'overview'|'identification'|'images'|'biology'|'taxonomy'|'occurrence'|'specimens'|'endangerment'|'invasive';
 
 @Component({
   selector: 'laji-info-card',
@@ -148,9 +148,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   updateRoute(id: string, tab = this.activeTab, context = this.context, replaceUrl = false) {
-    if (this.activeTab !== 'endangerment' && this.activeTab !== 'invasive') {
-      this.loadedTabs.reset();
-    } 
+    this.loadedTabs.reset();
     this.activeTab = tab;
     this.routeUpdate.emit({id: id, tab: tab, context: context, replaceUrl: replaceUrl});
     this.cd.markForCheck();

--- a/projects/laji/src/app/shared-modules/annotations/annotations.component.ts
+++ b/projects/laji/src/app/shared-modules/annotations/annotations.component.ts
@@ -178,7 +178,6 @@ export class AnnotationsComponent implements OnInit, OnDestroy {
         (e) => {
           this.loading = false;
           this.loadingElements.emitChildEvent(false);
-          console.log(e);
         }
       );
   }


### PR DESCRIPTION
The problem is in the taxon-card and it happens when i move between tabs and later i switch to another specie.

For example:
- go to taxon MX.44058
- move between tabs (at least open "occurrences" and "specimens")
- switch to other species by using dropdown menu in breadcrumbs. 
- if the next specie i open has less tabs than the previous, for example MX.44052, the content is not correct. 

2 components are opened at same time. At least i could see "specimens" and "occurrences" or "specimens" and "taxonomy" opened at same time.