### PR TITLE
fix issue on document annotation images - [#177723306]

### DIFF
--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
@@ -10,7 +10,8 @@ import {
   Output,
   Renderer2,
   ViewContainerRef,
-  HostListener
+  HostListener,
+  OnChanges
 } from '@angular/core';
 import { IImageSelectEvent, Image } from './image.interface';
 import { ComponentLoader, ComponentLoaderFactory } from 'ngx-bootstrap/component-loader';
@@ -61,7 +62,7 @@ import { QueryParamsHandling } from '@angular/router';
   templateUrl: './image-modal.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class ImageModalComponent implements OnInit, OnDestroy {
+export class ImageModalComponent implements OnInit, OnDestroy, OnChanges {
   public opened = false;
   public img: Image;
   public loading = false;
@@ -104,13 +105,16 @@ export class ImageModalComponent implements OnInit, OnDestroy {
     } else {
       this.showRepeat = true;
     }
+  }
 
+  ngOnChanges() {
     if (this.modalImages && this.modalImages.length > 0) {
       this.tmpImg = {
         mainURL: this.modalImages[0].fullURL,
         index: 0
       };
     }
+
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
In the document-annotation document, the image component didn't change the main picture. 
User move to next or previous by shortcuts, but when the observation is loaded, the main picture is always the same.
That happens when the next or the previous are from the same observation of the same user