### PR TITLE
Remove all option in taxon list is not effecting all filters [#177772608]

### DIFF
--- a/projects/laji/src/app/+taxonomy/species/species-form/species-form.component.html
+++ b/projects/laji/src/app/+taxonomy/species/species-form/species-form.component.html
@@ -2,7 +2,7 @@
   <laji-observation-active
     [skip]="['onlyFinnish']"
     [(query)]="searchQuery.query"
-    (queryChange)="onQueryChange()"
+    (queryChange)="onQueryChange(true)"
     [queryType]="searchQuery.queryType"></laji-observation-active>
 </div>
 

--- a/projects/laji/src/app/+taxonomy/species/species-form/species-form.component.ts
+++ b/projects/laji/src/app/+taxonomy/species/species-form/species-form.component.ts
@@ -174,7 +174,10 @@ export class SpeciesFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  onQueryChange() {
+  onQueryChange(updateFormQuery?: boolean) {
+    if (updateFormQuery) {
+      this.queryToFormQuery();
+    }
     this.onSubmit();
   }
 

--- a/projects/laji/src/app/shared-modules/search-filters/active/observation-active.component.ts
+++ b/projects/laji/src/app/shared-modules/search-filters/active/observation-active.component.ts
@@ -15,10 +15,10 @@ export class ObservationActiveComponent {
   active: ActiveList[] = [];
   showList = false;
 
-  private _query: object;
+  private _query: Record<string, any> = {};
 
   @Input()
-  set query(query: object) {
+  set query(query: Record<string, any>) {
     this._query = query;
     this.updateSelectedList();
   }
@@ -60,8 +60,8 @@ export class ObservationActiveComponent {
   updateSelectedList() {
     const query = this.query;
     const keys = Object.keys(query);
-    const doubles = {};
-    const doubleKeys = {
+    const doubles: Record<string, boolean> = {};
+    const doubleKeys: Record<string, string> = {
       teamMember: 'teamMember',
       teamMemberId: 'teamMember',
       firstLoadedSameOrBefore: 'firstLoaded',
@@ -85,7 +85,7 @@ export class ObservationActiveComponent {
         result.push({field: i, value: query[i]});
       }
       return result;
-    }, []);
+    }, [] as ActiveList[]);
   }
 
 }


### PR DESCRIPTION
Testable at https://177772608.dev.laji.fi/en/taxon/list

Administrative status and Invasive species should be clearable now from the active filters list