### PR TITLE
Fix filters after navigating from named place edit view [#178035225]

### DIFF
--- a/projects/laji/e2e/src/+project-form/named-places.e2e-spec.ts
+++ b/projects/laji/e2e/src/+project-form/named-places.e2e-spec.ts
@@ -9,6 +9,7 @@ const FORM_WITH_MUNICIPALITY_FILTER = 'MHL.33';
 const FORM_WITH_BIRD_ASSOCIATION_FILTER = 'MHL.3';
 const FORM_WITH_INCLUDE_UNITS_NP = 'MNP.37866';
 const FORM_WITH_NO_MAP_TAB = 'MHL.3';
+const FORM_WITH_NO_FILTERS_EDITABLE_PLACES = 'MHL.59';
 
 const projectFormPage = new ProjectFormPage();
 const userPage = new UserPage();
@@ -165,6 +166,18 @@ describe('Project form when logged in', () => {
   it('canceling document save redirects to about named place view no history', async (done) => {
     await projectFormPage.documentFormView.$cancel.click();
     expect(await projectFormPage.namedPlacesView.$container.isDisplayed()).toBe(true);
+    done();
+  });
+
+  it('navigation from named place edit doesn\'t add filters that aren\'t in the UI', async (done) => {
+    await projectFormPage.navigateTo(FORM_WITH_NO_FILTERS_EDITABLE_PLACES, '/form/places');
+    await projectFormPage.namedPlacesView.$$listItems.first().click();
+    await projectFormPage.namedPlacesView.$editButton.click();
+    await projectFormPage.namedPlacesFormPage.$cancel.click();
+    const url = await browser.getCurrentUrl();
+    expect(url.match(/tags=/)).toBe(null);
+    expect(url.match(/municipality=/)).toBe(null);
+    expect(url.match(/birdAssociationArea=/)).toBe(null);
     done();
   });
 });

--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -13,7 +13,7 @@ import { forkJoin, Observable, of } from 'rxjs';
 import { map, mergeMap, take } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NamedPlaceComponent } from '../named-place/named-place.component';
-import { NamedPlacesRouteData, ProjectFormService } from '../../../project-form.service';
+import { NamedPlacesQuery, NamedPlacesRouteData, ProjectFormService } from '../../../project-form.service';
 import { AreaService } from '../../../../shared/service/area.service';
 import { BrowserService } from '../../../../shared/service/browser.service';
 
@@ -157,19 +157,24 @@ export class NpEditFormComponent implements OnInit {
       if (data.namedPlace) {
         levels++;
       }
+      const queryParams: NamedPlacesQuery = {
+        activeNP: namedPlace?.id || data.namedPlace?.id
+      };
+      if (data.documentForm.options?.namedPlaceOptions?.filterByMunicipality) {
+        queryParams.municipality = namedPlace?.municipality?.join(',') || data.municipality;
+      }
+      if (data.documentForm.options?.namedPlaceOptions?.filterByBirdAssociationArea) {
+        queryParams.birdAssociationArea = namedPlace?.birdAssociationArea?.join(',') || data.birdAssociationArea;
+      }
+      if (data.documentForm.options?.namedPlaceOptions?.filterByTags) {
+        queryParams.tags = (data.tags || []).join(',');
+      }
       this.router.navigate(
         [new Array(levels).fill('..').join('/')],
         {
           relativeTo: this.route,
           replaceUrl: true,
-          queryParams: {
-            municipality: namedPlace?.municipality?.join(',')
-              || data.municipality,
-            birdAssociationArea: namedPlace?.birdAssociationArea?.join(',')
-              || data.birdAssociationArea,
-            tags: (data.tags || []).join(','),
-            activeNP: namedPlace?.id || data.namedPlace?.id
-          }
+          queryParams
         }
       );
     });

--- a/projects/laji/src/app/+project-form/project-form.service.ts
+++ b/projects/laji/src/app/+project-form/project-form.service.ts
@@ -98,12 +98,10 @@ export class ProjectFormService {
             })
           )
           : this.getFormFromRoute$(route);
-        const query$ = documentForm$.pipe(map(documentForm => this.queryToModelFormat(queryParams)));
-        return combineLatest(documentForm$, namedPlace$, query$).pipe(
+        return combineLatest(documentForm$, namedPlace$).pipe(
           map(([
             documentForm,
-            namedPlace,
-            query]) => ({documentForm, namedPlace, ...query}))
+            namedPlace ]) => ({documentForm, namedPlace, ...this.queryToModelFormat(queryParams)}))
         );
       })
     );


### PR DESCRIPTION
Steps to repro:

1. Make sure that you are admin of water bird form
2. Goto https://beta.laji.fi/project/MHL.65/form/MHL.65/places
2. Select some place
3. Click named place edit button of the selected place
4. Click cancel edit on the footer

### What happens?
Query contains filters for municipality, which can't be edited in the UI
### What should happen?
Query doesn't contain filters that aren't editable in the UI
