### PR TITLE
Fix sidebar timeout bug [#178157095]

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
@@ -147,6 +147,7 @@ export class SidebarComponent implements OnDestroy, AfterViewInit {
   checkCloseOnClickListener() {
     if (this.mobile && this.open && this.contentRef && !this.destroyCloseOnClickListener) {
       setTimeout(() => {
+        this.destroyCloseOnClickListener?.();
         this.destroyCloseOnClickListener = this.renderer.listen(this.contentRef.nativeElement, 'click', this.onContentClick.bind(this));
       });
     } else if (this.destroyCloseOnClickListener) {


### PR DESCRIPTION
### Steps to reproduce:

1. Make your browser window narrower than ~700px
2. Goto https://beta.laji.fi/project/JX.652/about
3. Click "Send observations"
4. Click "Leave without saving"
5. Click "Send observations"
6. Try to click "Today" button on the form
-> The today button doesn't do anything

Fixed here: https://178157095.dev.laji.fi/project/JX.652

### Explanation for the solution

On mobile, the sidebar adds a click listener to the content of the sidebar, which prevents all click events (`onContentClick()`). The click listener is added in a timeout, and if `checkCloseOnClickListener()` is called sequantially multiple times before the timeout function executes, the click listener is added multiple times and the excess ones aren't cleaned properly, making the content unclickable.