### PR TITLE
Rm unused import (fixes lint errors)

### DIFF
--- a/projects/laji/src/app/shared-modules/select/select/select.component.ts
+++ b/projects/laji/src/app/shared-modules/select/select/select.component.ts
@@ -1,5 +1,4 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, ViewChild } from '@angular/core';
-import { select } from 'd3-selection';
 import { Subject, timer } from 'rxjs';
 import { debounceTime, take, takeUntil } from 'rxjs/operators';
 import { FilterService } from '../../../shared/service/filter.service';


### PR DESCRIPTION
Removes at least seeminly unnecessary d3 import from the select component, which causes a lint error about a shadowed variable later on. Should be merged ASAP so in the next cycle we won't have the lint errors that prevent commiting. 