### PR TITLE
Fix clicking "select current" on annotation form shows error

### DIFF
--- a/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
+++ b/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
@@ -59,7 +59,6 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
 
   @ViewChild('taxon') taxonElement: ElementRef;
   @ViewChild('comment') commentElement: ElementRef;
-  @ViewChild('annotationForm') formAnnotation: any;
   taxonAutocomplete: Observable<any>;
   error: any;
   unIdentifyable = false;
@@ -263,7 +262,6 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
         scientificNameAuthorship: taxon.scientificNameAuthorship,
       };
       this.cd.detectChanges();
-      this.formAnnotation.control.markAsDirty();
       this.inputName = 'opinion';
       this.inputType = 'blur';
     } else {


### PR DESCRIPTION
Testable here: https://2997.dev.laji.fi/en/observation/list

Fixes the bug by removing annotationForm ViewChild that doesn't exist anymore (it can be seen in [this old version](https://bitbucket.org/luomus/laji.fi-front/src/5ce0de7b21de8c918aaa888cd69381f9925d0d2c/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.html) but has been since removed).