### PR TITLE
Sorting multi columns results in incorrect order 178281906

### DIFF
--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
@@ -41,48 +41,32 @@ export class SelectedFieldGroupComponent {
     }
   }
 
-  onMoveUp(field: string | string[]) {
-    if (Array.isArray(field)) {
-      if (this.selected.indexOf(field[0]) > 0) {
-        field.forEach(column => {
-          this.moveUp.emit(column);
+  onMoveUp(field: string[]) {
+    const indexOfField = this.selected.indexOf(field[0]);
 
-          if (this.columnSelector) {
-            this.columnSelector.moveFieldByName(column, -1);
-          }
-        });
-      }
-      return;
-    }
+    if (indexOfField > 0) {
+      field.forEach(column => {
+        this.moveUp.emit(column);
 
-    this.moveUp.emit(field);
-
-    if (this.columnSelector) {
-      this.columnSelector.moveFieldByName(field, -1);
+        if (this.columnSelector) {
+          this.columnSelector.moveFieldByName(column, -1 * this.getFieldColumnArrayLength(this.selected[indexOfField - 1]));
+        }
+      });
     }
   }
 
-  onMoveDown(field: string | string[]) {
-    if (Array.isArray(field)) {
-      const lastSelected = this.selected.length - 1;
-      const lastField = field.length - 1;
+  onMoveDown(field: string[]) {
+    const lastSelected = this.selected.length - 1;
+    const indexOfField = this.selected.indexOf(field[field.length - 1]);
 
-      if (this.selected.indexOf(field[lastField]) < lastSelected) {
-        field.reverse().forEach(column => {
-          this.moveDown.emit(column);
+    if (indexOfField < lastSelected) {
+      field.reverse().forEach(column => {
+        this.moveDown.emit(column);
 
-          if (this.columnSelector) {
-            this.columnSelector.moveFieldByName(column, 1);
-          }
-        });
-      }
-      return;
-    }
-
-    this.moveDown.emit(field);
-
-    if (this.columnSelector) {
-      this.columnSelector.moveFieldByName(field, 1);
+        if (this.columnSelector) {
+          this.columnSelector.moveFieldByName(column, this.getFieldColumnArrayLength(this.selected[indexOfField + 1]));
+        }
+      });
     }
   }
 
@@ -105,6 +89,16 @@ export class SelectedFieldGroupComponent {
       ];
     } else {
       return [ field ];
+    }
+  }
+
+  getFieldColumnArrayLength(field: string) {
+    if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)\./.test(field)) {
+      return 2;
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)\./.test(field)) {
+      return 4;
+    } else {
+      return 1;
     }
   }
 

--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
@@ -43,8 +43,10 @@ export class SelectedFieldGroupComponent {
 
   onMoveUp(field: string[]) {
     const indexOfField = this.selected.indexOf(field[0]);
-    const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField - 1]);
+
     if (indexOfField > 0) {
+      const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField - 1]);
+
       field.forEach(column => {
         this.moveUp.emit(column);
 
@@ -58,9 +60,10 @@ export class SelectedFieldGroupComponent {
   onMoveDown(field: string[]) {
     const lastSelected = this.selected.length - 1;
     const indexOfField = this.selected.indexOf(field[field.length - 1]);
-    const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField + 1]);
 
     if (indexOfField < lastSelected) {
+      const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField + 1]);
+
       field.reverse().forEach(column => {
         this.moveDown.emit(column);
 
@@ -76,12 +79,14 @@ export class SelectedFieldGroupComponent {
   }
 
   getFieldColumnArray(field: string) {
-    if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)$/.test(field)) {
+    if (!field) {
+      return;
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)/.test(field)) {
       return [
         field + '.lat',
         field + '.lon'
       ];
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)$/.test(field)) {
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)/.test(field)) {
       return [
         field + '.latMin',
         field + '.latMax',
@@ -94,13 +99,7 @@ export class SelectedFieldGroupComponent {
   }
 
   getFieldColumnArrayLength(field: string) {
-    if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)\./.test(field)) {
-      return 2;
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)\./.test(field)) {
-      return 4;
-    } else {
-      return 1;
-    }
+    return this.getFieldColumnArray(field)?.length || 0;
   }
 
   getIndexArray(field: string[]) {

--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
@@ -81,12 +81,12 @@ export class SelectedFieldGroupComponent {
   getFieldColumnArray(field: string) {
     if (!field) {
       return;
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)/.test(field)) {
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)($|.(lat|lon)$)/.test(field)) {
       return [
         field + '.lat',
         field + '.lon'
       ];
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)/.test(field)) {
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)($|.(lat|lon)(Min|Max)$)/.test(field)) {
       return [
         field + '.latMin',
         field + '.latMax',

--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
@@ -81,12 +81,12 @@ export class SelectedFieldGroupComponent {
   getFieldColumnArray(field: string) {
     if (!field) {
       return;
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)($|.(lat|lon)$)/.test(field)) {
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(CenterPoint)(.(lat|lon))?$/.test(field)) {
       return [
         field + '.lat',
         field + '.lon'
       ];
-    } else if (/gathering\.conversions\.(wgs84|euref|ykj)($|.(lat|lon)(Min|Max)$)/.test(field)) {
+    } else if (/gathering\.conversions\.(wgs84|euref|ykj)(.(lat|lon)(Min|Max))?$/.test(field)) {
       return [
         field + '.latMin',
         field + '.latMax',

--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-group/selected-field-group.component.ts
@@ -43,13 +43,13 @@ export class SelectedFieldGroupComponent {
 
   onMoveUp(field: string[]) {
     const indexOfField = this.selected.indexOf(field[0]);
-
+    const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField - 1]);
     if (indexOfField > 0) {
       field.forEach(column => {
         this.moveUp.emit(column);
 
         if (this.columnSelector) {
-          this.columnSelector.moveFieldByName(column, -1 * this.getFieldColumnArrayLength(this.selected[indexOfField - 1]));
+          this.columnSelector.moveFieldByName(column, -1 * widthOfNextGroup);
         }
       });
     }
@@ -58,13 +58,14 @@ export class SelectedFieldGroupComponent {
   onMoveDown(field: string[]) {
     const lastSelected = this.selected.length - 1;
     const indexOfField = this.selected.indexOf(field[field.length - 1]);
+    const widthOfNextGroup = this.getFieldColumnArrayLength(this.selected[indexOfField + 1]);
 
     if (indexOfField < lastSelected) {
       field.reverse().forEach(column => {
         this.moveDown.emit(column);
 
         if (this.columnSelector) {
-          this.columnSelector.moveFieldByName(column, this.getFieldColumnArrayLength(this.selected[indexOfField + 1]));
+          this.columnSelector.moveFieldByName(column, widthOfNextGroup);
         }
       });
     }

--- a/projects/laji/src/app/shared-modules/observation-result/selected-field-item/selected-field-item.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/selected-field-item/selected-field-item.component.ts
@@ -15,8 +15,8 @@ export class SelectedFieldItemComponent {
   @Input() required: boolean;
 
   @Output() toggle = new EventEmitter<string>();
-  @Output() moveUp = new EventEmitter<string | string[]>();
-  @Output() moveDown = new EventEmitter<string | string[]>();
+  @Output() moveUp = new EventEmitter<string[]>();
+  @Output() moveDown = new EventEmitter<string[]>();
 
   moveFieldDown(field, event) {
     event.stopPropagation();


### PR DESCRIPTION
When selecting columns to show in observation table. if the order of columns is changed with arrow buttons now columns jump over all columns belonging to a multicolumn field, and don't split them as before. Branch build in https://178281906.dev.laji.fi/ 