### PR TITLE
Don't initialize prepopulated document with empty [#178409200]

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -203,10 +203,10 @@ export class NpEditFormComponent implements OnInit {
   }
 
   private mergePrepopulatedDocument(namedPlace, formData, asyncData: NamedPlacesRouteData) {
-    namedPlace.prepopulatedDocument = asyncData.namedPlace?.prepopulatedDocument || {};
+    namedPlace.prepopulatedDocument = asyncData.namedPlace?.prepopulatedDocument;
     if (formData.prepopulatedDocument) {
       namedPlace.prepopulatedDocument = merge(
-        namedPlace.prepopulatedDocument,
+        namedPlace.prepopulatedDocument || {},
         formData.prepopulatedDocument,
         { arrayMerge: Util.arrayCombineMerge }
       );


### PR DESCRIPTION
The new store has stricter validations, and thus a named place's `prepopulatedDocument` (of type `MY.document` in schema) with an empty object as the value is caught by the new stricter validators.

This PR makes it so that an empty `prepopulatedDocument` isn't added for all named places during creation/edit.

The fix is testable here (saving works, in beta it doesn't): http://178409200.dev.laji.fi/project/MHL.65/form/MHL.65/places/new
Task https://www.pivotaltracker.com/story/show/178409200