### PR TITLE
Named place component is more careful when calling info view methods

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
@@ -206,10 +206,10 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
     ).subscribe(([previousState, newState]) => {
       const {activeNP: prevActiveNP} = previousState || {};
       const {activeNP: newActiveNP} = newState;
-      if (newActiveNP !== prevActiveNP && this.infoView) {
-        this.infoView.npClick();
+      if (newActiveNP !== prevActiveNP) {
+        this.infoView?.npClick();
       } else if (prevActiveNP && !newActiveNP) {
-        this.infoView.hide();
+        this.infoView?.hide();
       }
     });
 
@@ -267,7 +267,7 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
   onActivePlaceChange(activeNP: string) {
     this.vm$.pipe(take(1)).subscribe(({activeNP: _activeNP}) => {
       if (activeNP && activeNP === _activeNP?.id) {
-        this.infoView.npClick();
+        this.infoView?.npClick();
       }
       this.activeIdChange.emit(activeNP);
     });


### PR DESCRIPTION
Don't know how to replicate this, but I found from the laji.fi error logs that quite often `npClick` is undefined or `infoView` is undefined. This patch makes calling the info component methods more robust.