### PR TITLE
Remove taxon download link [#178466767]

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.html
@@ -80,11 +80,6 @@
             {{ 'taxonomy.browse' | translate }}
           </a>
         </li>
-        <li>
-          <a [routerLink]="'/observation/load' | localize" [queryParams]="{target: taxon.id}">
-            {{ 'taxonomy.browse.download' | translate }}
-          </a>
-        </li>
         <li [hidden]="!taxon.hasChildren">
           <a [routerLink]="['/taxon/list'] | localize" [queryParams]="{target: (taxon.id)}">
             {{ 'taxonomy.browse.downloadSpecies' | translate }}

--- a/projects/laji/src/i18n/en.json
+++ b/projects/laji/src/i18n/en.json
@@ -1402,7 +1402,7 @@
   "taxonomy.browse.download": "Download observations",
   "taxonomy.browse.downloadSpecies": "Download list of species ",
   "taxonomy.browse.downloadSpeciesFinnish": "Download list of Finnish species",
-  "taxonomy.browse.title": "Browse and download",
+  "taxonomy.browse.title": "Browse",
   "taxonomy.browseAndDownload": "Browse and download observations",
   "taxonomy.browseSpeciesPage": "Discover species",
   "taxonomy.browseSpeciesPage.intro": "Browse species images and information",

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -1402,7 +1402,7 @@
   "taxonomy.browse.download": "Lataa havaintoja itsellesi",
   "taxonomy.browse.downloadSpecies": "Lataa lajiluettelo",
   "taxonomy.browse.downloadSpeciesFinnish": "Lataa suomalaisten lajien luettelo",
-  "taxonomy.browse.title": "Selaus ja lataus",
+  "taxonomy.browse.title": "Selaus",
   "taxonomy.browseAndDownload": "Selaa ja lataa havaintoja",
   "taxonomy.browseSpeciesPage": "Tutustu lajeihin",
   "taxonomy.browseSpeciesPage.intro": "Selaa lajien kuvia ja tietoja",

--- a/projects/laji/src/i18n/sv.json
+++ b/projects/laji/src/i18n/sv.json
@@ -1402,7 +1402,7 @@
   "taxonomy.browse.download": "Ladda ner observationer",
   "taxonomy.browse.downloadSpecies": "Hämta artlistan",
   "taxonomy.browse.downloadSpeciesFinnish": "Hämta listan av finska arter",
-  "taxonomy.browse.title": "Bläddra och ladda ner",
+  "taxonomy.browse.title": "Bläddra",
   "taxonomy.browseAndDownload": "Bläddra och ladda ner observationer",
   "taxonomy.browseSpeciesPage": "Bli bekant med arter",
   "taxonomy.browseSpeciesPage.intro": "Bläddra arternas bilder och information",


### PR DESCRIPTION
https://178466767.dev.laji.fi/en/taxon/MX.231366
https://www.pivotaltracker.com/story/show/178466767

This PR removes the download link under "Browse" section, since there isn't a download tab anymore on the observation page.