### PR TITLE
Line transect chart circles fix [#178300485]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3080,8 +3080,7 @@
     "@types/d3-selection": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-1.4.3.tgz",
-      "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA==",
-      "dev": true
+      "integrity": "sha512-GjKQWVZO6Sa96HiKO6R93VBE8DUW+DDkFpIMf9vpY5S78qZTlRRSNUsHr/afDpF7TvLDV7VxrUFOWW7vdIlYkA=="
     },
     "@types/d3-shape": {
       "version": "1.3.5",
@@ -3097,6 +3096,14 @@
       "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-1.1.1.tgz",
       "integrity": "sha512-ULX7LoqXTCYtM+tLYOaeAJK7IwCT+4Gxlm2MaH0ErKLi07R5lh8NHCAyWcDkCCmx1AfRcBEV6H9QE9R25uP7jw==",
       "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-2.0.0.tgz",
+      "integrity": "sha512-UJDzI98utcZQUJt3uIit/Ho0/eBIANzrWJrTmi4+TaKIyWL2iCu7ShP0o4QajCskhyjOA7C8+4CE3b1YirTzEQ==",
+      "requires": {
+        "@types/d3-selection": "*"
+      }
     },
     "@types/deep-diff": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "@types/d3-scale": "^2.2.0",
     "@types/d3-selection": "^1.3.4",
     "@types/d3-shape": "^1.3.2",
+    "@types/d3-transition": "^2.0.0",
     "@types/express-serve-static-core": "^4.17.18",
     "@types/file-saver": "^2.0.1",
     "@types/geojson": "7946.0.7",

--- a/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect-chart/line-transect-chart.component.ts
+++ b/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect-chart/line-transect-chart.component.ts
@@ -13,7 +13,6 @@ import { select , Selection } from 'd3-selection';
 import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { line as d3Line } from 'd3-shape';
 import { format } from 'd3-format';
-import 'd3-transition';
 
 interface LineTerms {
   slope: number;
@@ -185,11 +184,9 @@ export class LineTransectChartComponent implements AfterViewInit, OnChanges, OnD
     update.exit().remove();
 
     // update existing bars
-    this.chart.selectAll('.mark').transition()
-      .attr({
-        cx: (d) => this.xScale(d[0]),
-        cy: (d) => this.yScale(d[1])
-      });
+    this.chart.selectAll('.mark')
+      .attr('cx', (d) => this.xScale(d[0]))
+      .attr('cy', (d) => this.yScale(d[1]));
 
     // add new bars
     update

--- a/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect-chart/line-transect-chart.component.ts
+++ b/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect-chart/line-transect-chart.component.ts
@@ -9,10 +9,11 @@ import {
   OnDestroy
 } from '@angular/core';
 import { axisBottom, axisLeft } from 'd3-axis';
-import { select } from 'd3-selection';
-import { scaleLinear } from 'd3-scale';
+import { select , Selection } from 'd3-selection';
+import { scaleLinear, ScaleLinear } from 'd3-scale';
 import { line as d3Line } from 'd3-shape';
 import { format } from 'd3-format';
+import 'd3-transition';
 
 interface LineTerms {
   slope: number;
@@ -42,17 +43,17 @@ export class LineTransectChartComponent implements AfterViewInit, OnChanges, OnD
   @Input() yLabel: string;
   @Input() title: string;
   @Input() margin: { top: number, bottom: number, left: number, right: number} = { top: 30, bottom: 40, left: 40, right: 10};
-  @Input() xTickFormat: any;
+  @Input() xTickFormat: string;
   @Input() yLabelAnchor: string;
 
-  private readonly nativeElement: any;
-  private svg: any;
-  private chart: any;
+  private readonly nativeElement: HTMLDivElement;
+  private svg: Selection<SVGElement, unknown, undefined, undefined>;
+  private chart: Selection<SVGElement, unknown, undefined, undefined>;
   private width: number;
   private height: number;
-  private xScale: any;
-  private yScale: any;
-  private xAxis: any;
+  private xScale: ScaleLinear<number, number>;
+  private yScale: ScaleLinear<number, number>;
+  private xAxis: Selection<SVGElement, unknown, undefined, undefined>;
 
   constructor(
     element: ElementRef,
@@ -88,7 +89,7 @@ export class LineTransectChartComponent implements AfterViewInit, OnChanges, OnD
     const svg = this.svg = select(element).append('svg')
       .attr('width', element.offsetWidth)
       .attr('height', element.offsetHeight);
-    const g = svg.append('g').attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
+    svg.append('g').attr('transform', 'translate(' + this.margin.left + ',' + this.margin.top + ')');
 
     // chart plot area
     this.chart = svg.append('g')

--- a/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect.component.ts
+++ b/projects/laji/src/app/+project-form/submissions/statistics/line-transect/line-transect.component.ts
@@ -21,7 +21,6 @@ import { LajiMapLineTransectGeometry } from '@laji-map/laji-map.interface';
 interface LineTransectCount {
   psCouples: number;
   tsCouples: number;
-  onPs: number;
   onPsPros: number;
   routeLength?: number;
   couplesPerKm?: number;
@@ -103,7 +102,6 @@ export class LineTransectComponent implements OnChanges {
     const count: LineTransectCount = {
       psCouples: 0,
       tsCouples: 0,
-      onPs: 0,
       onPsPros: 0,
       species: [],
       couplesPerKm: 0,
@@ -132,9 +130,6 @@ export class LineTransectComponent implements OnChanges {
                 unit.unitFact &&
                 unit.unitFact.lineTransectRouteFieldType === Units.LineTransectRouteFieldTypeEnum.LineTransectRouteFieldTypeOuter ?
                   'tsCouples' : 'psCouples';
-              if (cntKey === 'psCouples') {
-                count.onPs++;
-              }
               count[cntKey] += unit.pairCount || 0;
               species[taxon][cntKey] += unit.pairCount || 0;
             }


### PR DESCRIPTION
Fixes the line transect document stat charts:

* added typing
* remove bug that causes page to crash
* fix circle markers on the charts

Demo: https://178300485.dev.laji.fi/project/MHL.1/submissions/JX.130808
Repro on beta: https://beta.laji.fi/project/MHL.1/submissions/JX.130808