### PR TITLE
Don't populate leg into empty document when using named place [#178540041]

### DIFF
--- a/projects/laji/src/app/shared-modules/laji-form/laji-form-document.facade.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/laji-form-document.facade.ts
@@ -411,10 +411,10 @@ export class LajiFormDocumentFacade implements OnDestroy {
       populate.gatheringEvent.namedPlaceNotes = np.notes;
     }
 
-    let removeList = form.excludeFromCopy || DocumentService.removableGathering;
-    if (form.options?.namedPlaceOptions?.includeUnits) {
-      removeList = removeList.filter(item => item !== 'units');
-    }
+    const removeList = [
+      ...(form.excludeFromCopy || DocumentService.removableGathering),
+      '$.gatheringEvent.leg'
+    ].filter(item => item !== 'units');
     this.updateState({..._state, namedPlaceForFormID: ''});
 
     return merge(this.documentService.removeMeta(populate, removeList), data, { arrayMerge: Util.arrayCombineMerge });

--- a/projects/laji/src/app/shared-modules/laji-form/laji-form-document.facade.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/laji-form-document.facade.ts
@@ -411,10 +411,13 @@ export class LajiFormDocumentFacade implements OnDestroy {
       populate.gatheringEvent.namedPlaceNotes = np.notes;
     }
 
-    const removeList = [
+    let removeList = [
       ...(form.excludeFromCopy || DocumentService.removableGathering),
       '$.gatheringEvent.leg'
-    ].filter(item => item !== 'units');
+    ];
+    if (form.options?.namedPlaceOptions?.includeUnits) {
+      removeList = removeList.filter(item => item !== 'units');
+    }
     this.updateState({..._state, namedPlaceForFormID: ''});
 
     return merge(this.documentService.removeMeta(populate, removeList), data, { arrayMerge: Util.arrayCombineMerge });


### PR DESCRIPTION
Affects both prepopulated & accepted document.

Steps to reproduce:
1. Goto https://beta.laji.fi/project/MHL.1/form/MHL.1/places?activeNP=MNP.27408
2. Reserve the place to yourself
3. Compare https://beta.laji.fi/project/MHL.1/form/MHL.1/places/MNP.27408 and https://178540041.dev.laji.fi/project/MHL.1/form/MHL.1/places/MNP.27408 (beta shows Ville-Matti Riihikoski and you as observer, task demo site doesn't).