### PR TITLE
Named place viewer document list on smaller-than-half-screen width

### DIFF
--- a/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
+++ b/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
@@ -75,8 +75,7 @@
     [messages]="{emptyMessage: loadError, totalMessage: totalMessage}"
     (sort)="onSort($event)"
   >
-
-    <ngx-datatable-row-detail>
+    <ngx-datatable-row-detail [rowHeight]="undefined">
       <ng-template let-row="row" ngx-datatable-row-detail-template>
         <div *ngFor="let col of useColumns | filterColumns:displayMode:true" style="padding-left: 35px">
           <span><strong>{{ 'haseka.submissions.' + col.prop | translate }}: </strong></span>
@@ -99,10 +98,10 @@
     <ngx-datatable-column [flexGrow]="" [resizeable]="false"
                           [draggable]="false" *ngIf="displayMode !== 'large'" [headerClass]="'empty-header'">
       <ng-template ngx-datatable-header-template><span></span></ng-template>
-      <ng-template let-row="row" ngx-datatable-cell-template>
+      <ng-template let-row="row" let-expanded="expanded" ngx-datatable-cell-template>
         <span class="link">
           <i class="glyphicon"
-            [ngClass]="{'glyphicon-chevron-right': !row.$$expanded, 'glyphicon-chevron-down': row.$$expanded}"
+            [ngClass]="{'glyphicon-chevron-right': !expanded, 'glyphicon-chevron-down': expanded}"
             (click)="toggleExpandRow(row)"></i>
         </span>
       </ng-template>


### PR DESCRIPTION
Got detail row to show its full contents and made the arrows indicating detail row to change correctly. Example at https://178535861.dev.laji.fi/project/MHL.1/form/MHL.1/places?activeNP=MNP.27385