### PR TITLE
Lifestage filter missing values

### DIFF
--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -367,7 +367,7 @@
       [multiple]="true"
       [useFilter]="false"
       [placeholder]="'MY.lifeStage' | label"
-      [mapToWarehouse]="true"
+      [useFilterApi]="true"
       name="lifeStage"></laji-metadata-select>
   </div>
   <div>

--- a/projects/laji/src/app/shared-modules/select/metadata-select/metadata-select.component.ts
+++ b/projects/laji/src/app/shared-modules/select/metadata-select/metadata-select.component.ts
@@ -16,6 +16,7 @@ import { AnnotationService } from '../../document-viewer/service/annotation.serv
 import { MultiLangService } from '../../lang/service/multi-lang.service';
 import { Annotation } from '../../../shared/model/Annotation';
 import { SelectOptions } from '../select-subcategories/select-subcategories.component';
+import { WarehouseApi } from '../../../shared/api/WarehouseApi';
 
 export enum SelectStyle {
   basic,
@@ -57,6 +58,7 @@ export class MetadataSelectComponent implements OnChanges, OnDestroy, ControlVal
   @Input() disabled = false;
   @Input() labelAsValue = false;
   @Input() selectStyle = SelectStyle.advanced;
+  @Input() useFilterApi = false;
 
   selectStyles = SelectStyle;
   lang: string;
@@ -83,6 +85,7 @@ export class MetadataSelectComponent implements OnChanges, OnDestroy, ControlVal
 
   constructor(
     public warehouseMapper: WarehouseValueMappingService,
+    private warehouseApi: WarehouseApi,
     protected adminStatusInfoPipe: AdminStatusInfoPipe,
     protected annotationService: AnnotationService,
     protected collectionService: CollectionService,
@@ -214,6 +217,13 @@ export class MetadataSelectComponent implements OnChanges, OnDestroy, ControlVal
   }
 
   protected getDataObservable(): Observable<any> {
+    if (this.useFilterApi) {
+      return this.warehouseApi.warehouseQueryFilterGet(this.name).pipe(
+        map(data => data.enumerations),
+        map(options => options.map(o => ({id: o.name, value: MultiLangService.getValue(o.label as any, this.lang)}))),
+      );
+    }
+
     if (this.field) {
       this._shouldSort = true;
       switch (this.field) {

--- a/projects/laji/src/app/shared/api/WarehouseApi.ts
+++ b/projects/laji/src/app/shared/api/WarehouseApi.ts
@@ -347,6 +347,24 @@ export class WarehouseApi {
     return this.http.get<PagedResult<any>>(path, {params: queryParameters});
   }
 
+  //Get filter to use in selection filters
+  public warehouseQueryFilterGet(filter: string, extraHttpRequestParams?: any): Observable<any> {
+    if (this.platformService.isServer) {
+      return EMPTY
+    }
+
+    const path = this.basePath + '/warehouse/filters/' + filter
+
+    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
+
+    // verify required parameter 'filter' is not null or undefined
+    if (filter === null || filter === undefined) {
+      throw new Error('Required parameter filter was null or undefined when calling warehouseQueryFilterGet.');
+    }
+
+    return this.http.get(path, {params: queryParameters});
+  }
+
   /**
    * Get single full document.
    * Get single full document by document URI. Contains the document, gatherings and units, including facts, media etc


### PR DESCRIPTION
Added a new method to warehouseApi to call filters-endpoint, changed metadata-select-component to use it when requested, currently used only for lifestage, but should be easily usable for any filter present in the endpoint.