### PR TITLE
Project forms respect the selected lang when navigating [#178616856]

### DIFF
--- a/projects/laji/e2e/helper.ts
+++ b/projects/laji/e2e/helper.ts
@@ -16,3 +16,7 @@ export const EC = protractor.ExpectedConditions;
 
 export const waitForVisibility = (elem: ElementFinder) => browser.wait(EC.visibilityOf(elem));
 export const waitForInvisibility = (elem: ElementFinder) => browser.wait(EC.invisibilityOf(elem));
+
+export const getAddressWithLang = (page: string, lang?: 'fi' | 'sv' | 'en'): string =>
+  ((lang && lang !== 'fi') ? '/' + lang : '') + page;
+

--- a/projects/laji/e2e/src/+project-form/project-form.e2e-spec.ts
+++ b/projects/laji/e2e/src/+project-form/project-form.e2e-spec.ts
@@ -4,6 +4,7 @@ import { VihkoHomePage } from '../+vihko/home.po';
 import { MobileFormPage } from '../+vihko/mobile-form.po';
 import { SaveObservationsPage } from '../+save-observations/save-observations.po';
 import { browser, protractor } from 'protractor';
+import { NavPage } from "../shared/nav.po";
 
 const FORM_WITH_SIMPLE_HAS_NO_CATEGORY = 'JX.519';
 const FORM_WITH_SIMPLE_HAS_CATEGORY = 'MHL.25';
@@ -20,6 +21,7 @@ const userPage = new UserPage();
 const vihkoHomePage = new VihkoHomePage();
 const mobileFormPage = new MobileFormPage();
 const saveObservationsPage = new SaveObservationsPage();
+const nav = new NavPage();
 
 async function expectLandsOnExternalLogin(form, subPage?) {
   await browser.waitForAngularEnabled(false);
@@ -123,7 +125,7 @@ describe('Project form', () =>  {
     describe('and has simple option,', () => {
 
       beforeAll(async (done) => {
-        await projectFormPage.navigateTo(FORM_WITH_SIMPLE_HAS_NO_CATEGORY);
+        await projectFormPage.navigateTo(FORM_WITH_SIMPLE_HAS_NO_CATEGORY, undefined, 'en');
         await userPage.login();
         done();
       });
@@ -138,36 +140,39 @@ describe('Project form', () =>  {
         done();
       });
 
-      it('and has no category, canceling document save redirects to Vihko home page if no history', async (done) => {
+      it('and has no category, canceling document save redirects to Vihko home page if no history and keeps lang', async (done) => {
         await projectFormPage.documentFormView.$cancel.click();
         expect (await vihkoHomePage.$content.isDisplayed()).toBe(true);
+        expect(await nav.getLang()).toBe('en');
         done();
       });
 
-      it('back navigate works away from form', async (done) => {
-        await vihkoHomePage.navigateTo();
+      it('back navigate works away from form and keeps lang', async (done) => {
+        await vihkoHomePage.navigateTo('en');
         await vihkoHomePage.clickFormById(FORM_WITH_SIMPLE_HAS_NO_CATEGORY);
         const EC = protractor.ExpectedConditions;
         await browser.wait(EC.visibilityOf(projectFormPage.documentFormView.$form));
         await browser.navigate().back();
         expect(await vihkoHomePage.$content.isDisplayed()).toBe(true, 'user wasn\'t on vihko page after back navigation');
+        expect(await nav.getLang()).toBe('en');
 
         await projectFormPage.navigateTo(FORM_WITH_SIMPLE_HAS_NO_CATEGORY);
         done();
       });
     });
 
-    it('and has simple option and has category, canceling document save redirects to save observations page if no history', async (done) => {
-      await projectFormPage.navigateTo(FORM_WITH_SIMPLE_HAS_CATEGORY);
+    it('and has simple option and has category, canceling document save redirects to save observations page and keeps lang if no history', async (done) => {
+      await projectFormPage.navigateTo(FORM_WITH_SIMPLE_HAS_CATEGORY, undefined, 'en');
       await projectFormPage.documentFormView.$cancel.click();
       expect (await saveObservationsPage.pageIsDisplayed()).toBe(true);
+      expect(await nav.getLang()).toBe('en');
       done();
     });
 
     describe('and has mobile option,', () => {
 
       beforeAll(async (done) => {
-        await projectFormPage.navigateTo(FORM_WITH_MOBILE);
+        await projectFormPage.navigateTo(FORM_WITH_MOBILE, undefined, 'en');
         done();
       });
 
@@ -192,13 +197,14 @@ describe('Project form', () =>  {
         done();
       });
 
-      it('use button goes to document form page', async (done) => {
+      it('use button goes to document form page with correct lang', async (done) => {
         await projectFormPage.mobileAboutPage.$useButton.click();
         expect(await projectFormPage.documentFormView.$container.isDisplayed()).toBe(true);
+        expect(await nav.getLang()).toBe('en');
         done();
       });
 
-      it('canceling document save redirects to about page if no history', async (done) => {
+      it('canceling document save redirects to about page and keeps lang if no history', async (done) => {
         if (process.env.HEADLESS  !== 'false') {
           console.log('Skipped since geocoding doesn\'t work on headless');
           done();
@@ -207,6 +213,7 @@ describe('Project form', () =>  {
         await mobileFormPage.fillAsEmpty();
         await mobileFormPage.documentFormView.$cancel.click();
         expect(await projectFormPage.hasAboutText()).toBe(true);
+        expect(await nav.getLang()).toBe('en');
         done();
       });
     });
@@ -214,7 +221,7 @@ describe('Project form', () =>  {
     describe('and doesn\'t have simple option,', () => {
 
       beforeAll(async (done) => {
-        await projectFormPage.navigateTo(FORM_NO_SIMPLE_NO_NAMED_PLACES);
+        await projectFormPage.navigateTo(FORM_NO_SIMPLE_NO_NAMED_PLACES, undefined, 'en');
         done();
       });
 
@@ -228,19 +235,21 @@ describe('Project form', () =>  {
         done();
       });
 
-      it('canceling document save redirects to about page if no history', async (done) => {
-        await projectFormPage.navigateTo(`${FORM_NO_SIMPLE_NO_NAMED_PLACES}/form`);
+      it('canceling document save redirects to about page and keeps lang if no history', async (done) => {
+        await projectFormPage.navigateTo(`${FORM_NO_SIMPLE_NO_NAMED_PLACES}/form`, undefined, 'en');
         await projectFormPage.documentFormView.$cancel.click();
         expect(await projectFormPage.hasAboutText()).toBe(true);
+        expect(await nav.getLang()).toBe('en');
         done();
       });
     });
   });
 
   describe('and has named places and strict access restriction and no form permission', () => {
-    it('/form page redirects to about', async (done) => {
-      await projectFormPage.navigateTo(FORM_NAMED_PLACES_STRICT_ACCESS_RESTRICTION_NO_PERMISSION, '/form');
+    it('/form page redirects to about and keeps lang', async (done) => {
+      await projectFormPage.navigateTo(FORM_NAMED_PLACES_STRICT_ACCESS_RESTRICTION_NO_PERMISSION, '/form', 'en');
       expect(await projectFormPage.hasAboutText()).toBe(true);
+      expect(await nav.getLang()).toBe('en');
       done();
     });
   });

--- a/projects/laji/e2e/src/+project-form/project-form.po.ts
+++ b/projects/laji/e2e/src/+project-form/project-form.po.ts
@@ -1,5 +1,6 @@
 import { browser, $, $$, ExpectedConditions, ElementFinder } from 'protractor';
 import { ConfirmPO } from '../shared/dialogs.po';
+import { getAddressWithLang } from "../../helper";
 
 const EC = ExpectedConditions;
 
@@ -21,8 +22,8 @@ export class ProjectFormPage {
   public readonly mobileAboutPage = new MobileAboutPage();
   public readonly namedPlaceLinker = new NamedPlaceLinker();
 
-  navigateTo(id, subPage = '') {
-    return browser.get(`/project/${id}${subPage}`) as Promise<void>;
+  navigateTo(id, subPage = '', lang?: 'fi' | 'en' | 'sv') {
+    return browser.get(getAddressWithLang(`/project/${id}${subPage}`, lang)) as Promise<void>;
   }
 
   hasFormLink() {

--- a/projects/laji/e2e/src/+vihko/home.po.ts
+++ b/projects/laji/e2e/src/+vihko/home.po.ts
@@ -1,15 +1,18 @@
 import { browser, $ } from 'protractor';
+import { getAddressWithLang } from "../../helper";
+import { NavPage } from "../shared/nav.po";
 
 export class VihkoHomePage {
 
   public readonly $content = $('.haseka-home');
 
-  async navigateTo() {
-    return browser.get('/vihko/home') as Promise<void>;
+  async navigateTo(lang?: 'fi' | 'en' | 'sv') {
+    return browser.get(getAddressWithLang('/vihko/home', lang)) as Promise<void>;
   }
 
-  clickFormById(id: string) {
-    return $(`[href="/project/${id}"`).click() as Promise<void>;
+  async clickFormById(id: string) {
+    const lang = await new NavPage().getLang();
+    return $(`[href="${getAddressWithLang(`/project/${id}`, lang)}"`).click() as Promise<void>;
   }
 
 }

--- a/projects/laji/e2e/src/shared/nav.po.ts
+++ b/projects/laji/e2e/src/shared/nav.po.ts
@@ -1,9 +1,10 @@
-import { by, element } from 'protractor';
+import { $ } from 'protractor';
 
 export class NavPage {
 
-  private vihkoLink = element(by.css('a[href$="/vihko"]'));
-  private saveObservationLink = element(by.css('a[href$="/save-observations"]'));
+  private vihkoLink = $('a[href$="/vihko"]');
+  private saveObservationLink = $('a[href$="/save-observations"]');
+  private $lang = $('.language-toggle span');
 
   moveToSaveObservation(): void {
     this.saveObservationLink.click();
@@ -11,5 +12,13 @@ export class NavPage {
 
   moveToVihko(): void {
     this.vihkoLink.click();
+  }
+
+  async getLang(): Promise<('fi' | 'sv' | 'en')> {
+    const text = (await this.$lang.getText()).trim().toLowerCase();
+    if (!['fi', 'sv', 'en'].includes(text)) {
+      throw new Error('Couldn\'t get lang');
+    }
+    return text as ('fi' | 'sv' | 'en');
   }
 }

--- a/projects/laji/src/app/+haseka/haseka.component.html
+++ b/projects/laji/src/app/+haseka/haseka.component.html
@@ -1,5 +1,5 @@
 <lu-sidebar [position]="'right'" [staticWidth]="300">
-  <main>
+  <main class="haseka-home">
       <h1>{{ 'haseka.title' | translate }}</h1>
       <ng-container *lajiBrowserOnly>
         <div class="row" *lajiLoggedIn="false">
@@ -10,7 +10,7 @@
           </div>
         </div>
       </ng-container>
-      <div [innerHtml]="'haseka.intro' | translate" class="haseka-home" *ngIf="isFront"></div>
+      <div [innerHtml]="'haseka.intro' | translate" *ngIf="isFront"></div>
       <laji-haseka-terms *ngIf="isFront"></laji-haseka-terms>
       <a [routerLink]="'/about/823' | localize" target="_blank">{{ 'haseka.instructions' | translate }}</a> |
       <a [routerLink]="'/vihko/terms-of-service' | localize" target="_blank">{{ 'haseka.termsOfService' | translate }}</a>

--- a/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
@@ -56,7 +56,7 @@ export class DocumentFormComponent {
 
   goBack() {
     if (this.form.options?.simple) {
-      this.router.navigate([this.form.category ? '/save-observations' : '/vihko']);
+      this.router.navigate(this.localizeRouterService.translateRoute([this.form.category ? '/save-observations' : '/vihko']));
       return;
     }
 
@@ -72,7 +72,7 @@ export class DocumentFormComponent {
 
   onSuccess() {
     if (this.form.options?.simple) {
-      this.router.navigate([this.form.category ? '/save-observations' : '/vihko']);
+      this.router.navigate(this.localizeRouterService.translateRoute([this.form.category ? '/save-observations' : '/vihko']));
       return;
     }
     this.browserService.goBack(() => {

--- a/projects/laji/src/app/+project-form/form/form.component.ts
+++ b/projects/laji/src/app/+project-form/form/form.component.ts
@@ -47,7 +47,7 @@ export class FormComponent implements OnInit {
               private namedPlacesService: NamedPlacesService,
               private formService: FormService,
               private translate: TranslateService,
-              private userService: UserService,
+              private userService: UserService
   ) {}
 
   ngOnInit() {
@@ -72,8 +72,8 @@ export class FormComponent implements OnInit {
               return EMPTY;
             }
             const documentID = paramsStack.pop();
-            return (_usedSubForm === form ?
-              of(form)
+            return (_usedSubForm === form
+              ? of(form)
               : this.formService.getForm(_usedSubForm.id, this.translate.currentLang)
             ).pipe(
               switchMap(usedSubForm => {

--- a/projects/laji/src/app/+project-form/guards/abstract-permission-guard.ts
+++ b/projects/laji/src/app/+project-form/guards/abstract-permission-guard.ts
@@ -7,6 +7,7 @@ import { FormService } from '../../shared/service/form.service';
 import { TranslateService } from '@ngx-translate/core';
 import { FormPermissionService, Rights } from '../../shared/service/form-permission.service';
 import { PlatformService } from '../../shared/service/platform.service';
+import { LocalizeRouterService } from '../../locale/localize-router.service';
 
 @Injectable()
 export abstract class AbstractPermissionGuard implements CanActivate {
@@ -18,6 +19,7 @@ export abstract class AbstractPermissionGuard implements CanActivate {
               private route: ActivatedRoute,
               private translate: TranslateService,
               private platformService: PlatformService,
+              private localizeRouteService: LocalizeRouterService
 ) { }
 
   canActivate(route: ActivatedRouteSnapshot): Observable<boolean> {
@@ -36,7 +38,7 @@ export abstract class AbstractPermissionGuard implements CanActivate {
 
     if (!formID) {
       console.warn('HasFormPermission guard used for non project page');
-      this.router.navigate(['/', 'project', formID]);
+      this.router.navigate(this.localizeRouteService.translateRoute(['/', 'project', formID]));
       return;
     }
 
@@ -48,7 +50,7 @@ export abstract class AbstractPermissionGuard implements CanActivate {
         if (!hasPermission) {
           return this.userService.isLoggedIn$.pipe(take(1)).subscribe(isLoggedIn => {
             if (isLoggedIn) {
-              return this.router.navigate(['/', 'project', formID]);
+              return this.router.navigate(this.localizeRouteService.translateRoute(['/', 'project', formID]));
             } else {
               return this.userService.redirectToLogin();
             }

--- a/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.ts
@@ -1,4 +1,4 @@
-import { mergeMap, switchMap, take, tap } from 'rxjs/operators';
+import { mergeMap, take, tap } from 'rxjs/operators';
 import {
   ChangeDetectionStrategy,
   ChangeDetectorRef,
@@ -27,6 +27,7 @@ import { TemplateForm } from '../../own-submissions/models/template-form';
 import { DocumentService } from '../../own-submissions/service/document.service';
 import { ModalDirective } from 'ngx-bootstrap/modal';
 import { LatestDocumentsFacade } from '../../latest-documents/latest-documents.facade';
+import { LocalizeRouterService } from '../../../locale/localize-router.service';
 
 @Component({
   selector: 'laji-document-form',
@@ -85,7 +86,8 @@ export class DocumentFormComponent implements OnChanges, OnDestroy, ComponentCan
               private documentApi: DocumentApi,
               private documentService: DocumentService,
               private latestFacade: LatestDocumentsFacade,
-              private router: Router) {
+              private router: Router,
+              private localizeRouteService: LocalizeRouterService) {
     this.vm$ = this.lajiFormFacade.vm$;
     this.footerService.footerVisible = false;
     this.formSubscription = this.vm$.subscribe(state => {
@@ -205,7 +207,7 @@ export class DocumentFormComponent implements OnChanges, OnDestroy, ComponentCan
         this.toastsService.showSuccess(this.translate.instant('template.success'));
         setTimeout(() => {
           this.templateModal.hide();
-          this.router.navigate(['/vihko/templates']);
+          this.router.navigate(this.localizeRouteService.translateRoute(['/vihko/templates']));
         }, 200);
         this.templateForm = {
           name: '',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178616856

Bug repro:
1. Go to English trip form https://laji.fi/en/vihko/home
2. Click Leave without saving

**What's the expected result?**
I'm on English page at https://laji.fi/en/vihko/home

**What's the actual result?**
I'm on Finnish page at https://laji.fi/vihko/home

Fixed all other navigation inside project form code also to translate the routes properly.