### PR TITLE
Fix annotation page showing incorrect photos

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/images/images.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/images/images.component.ts
@@ -46,18 +46,20 @@ export class ImagesComponent implements OnChanges {
       this.documentImages = this.document.media;
     }
     if (this.document.gatherings) {
-      this.document.gatherings.map(gathering => {
+      for (const gathering of this.document.gatherings) {
         if (gathering.media) {
           this.gatheringImages = this.gatheringImages.concat(gathering.media);
-        }
+         }
         if (!gathering.units) {
-          return;
+           continue;
         }
         const unit = gathering.units.find(u => u.unitId === this.highlight || (u.media || []).some(media => media.fullURL === this.highlight));
-        if (unit?.media) {
-          this.unitImages = unit.media;
+        if (unit) {
+          this.gatheringImages = gathering.media || [];
+          this.unitImages = unit.media || [];
+          break;
         }
-      });
+      }
     }
 
     this.loading = false;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/178627685

Annotation page currently shows all gathering photos, not only highlighted.

https://178627685.dev.laji.fi/view?uri=http:%2F%2Ftun.fi%2FJX.267488&highlight=http:%2F%2Ftun.fi%2FJX.267488%237&own=true&openAnnotation=true