### PR TITLE
Replace sidebar menu icon ng animation with css animation [#179447443]

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.html
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.html
@@ -41,7 +41,7 @@
       </div>
       <ng-content select="nav"></ng-content>
     </div>
-    <div tabindex="0" *ngIf="!mobile" [@sidebarOpen_menu]="open ? 'open' : 'closed'" class="open-btn" role="button" (click)="onSwitchOpen()" luKeyboardClickable>
+    <div tabindex="0" *ngIf="!mobile" class="open-btn" [ngClass]="{'hide-sidebar-button': open}" role="button" (click)="onSwitchOpen()" luKeyboardClickable>
       <!-- Open menu -->
       <lu-icon type="menu"></lu-icon>
     </div>

--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.scss
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.scss
@@ -70,9 +70,14 @@ $mobileBreakpoint: 768px;
   top: 15px;
   left: 5px;
   cursor: pointer;
+  transition: opacity 0.3s;
+  opacity: 1;
 }
 .open-btn-mobile {
   cursor: pointer;
+}
+.open-btn.hide-sidebar-button {
+  opacity: 0;
 }
 
 :host lu-button.open-btn-mobile ::ng-deep button {

--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
@@ -43,15 +43,6 @@ const mobileBreakpoint = 768;
       })),
       transition('closed<=>open', animate('300ms ease')),
     ]),
-    trigger('sidebarOpen_menu', [
-      state('closed', style({
-        opacity: 1,
-      })),
-      state('open', style({
-        opacity: 0,
-      })),
-      transition('open=>closed', animate('300ms ease')),
-    ])
   ]
 })
 export class SidebarComponent implements OnDestroy, AfterViewInit {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179447443

The ng animating for the sidebar menu icon broke SSR rendering for the sidebar. The actual reason why it broke SSR wasn't found out. The problem arose with ng update to 12. There's been an error in SSR server error log for a long time related to this, but only after the ng 12 update the error actually resulted in a crash:

```
TypeError: Cannot read property 'display' of undefined
at cloakElement (/home/olli/src/luomus/laji/dist/server/main.js:69:1981707)
at /home/olli/src/luomus/laji/dist/server/main.js:69:1981925
at Set.forEach (<anonymous>)
at cloakAndComputeStyles (/home/olli/src/luomus/laji/dist/server/main.js:69:1981893)
at /home/olli/src/luomus/laji/dist/server/main.js:69:1971883
at Map.forEach (<anonymous>)
at TransitionAnimationEngine._flushAnimations (/home/olli/src/luomus/laji/dist/server/main.js:69:1971860)
at TransitionAnimationEngine.flush (/home/olli/src/luomus/laji/dist/server/main.js:69:1966042)
at InjectableAnimationEngine.flush (/home/olli/src/luomus/laji/dist/server/main.js:69:1987302)
at InjectableAnimationEngine.ngOnDestroy (/home/olli/src/luomus/laji/dist/server/main.js:69:2022742)
```

The following "bug fix" in angular 12 might have something to do with this: https://github.com/angular/angular/commit/a31da4850788800ba9735d617e7e3bb621a79c93