### PR TITLE
Fixed nonworking taxon source link.

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.html
@@ -22,9 +22,9 @@
         <ul>
           <li *ngFor="let publication of taxon.originalPublications">
             {{ publication | publication }}
-            <ng-container *ngIf="publication | publication:'URI'">
+            <ng-container *ngIf="publication | publication:'URI' as link">
               <br>
-              <a [href]="publication | publication:'URI'" target="_blank">{{ 'taxonomy.link' | translate }}</a>
+              <a [href]="link" target="_blank">{{ 'taxonomy.link' | translate }}</a>
             </ng-container>
           </li>
         </ul>


### PR DESCRIPTION
Fixed taxonomy source links leading to laji.fi front page instead of the correct place. Branch build and example card: https://179433569.dev.laji.fi/taxon/MX.26277/taxonomy