### PR TITLE
Remove viewer print pdf button 

### DIFF
--- a/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.css
+++ b/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.css
@@ -4,9 +4,10 @@
   height: 34px;
   position: fixed;
 }
-.print-wrap {
+/*.print-wrap {
   margin-left: 100px;
 }
+*/
 .settings-wrap {
   margin-top: 49px;
   margin-left: 10px;

--- a/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.html
+++ b/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.html
@@ -14,11 +14,11 @@
 </ng-container>
 
 <ng-container *ngIf="uri">
-  <div class="pdf-wrap no-print">
+  <!--div class="pdf-wrap no-print">
     <laji-spinner [spinning]="loading" [overlay]="true">
       <button type="button" [disabled]="loading" class="btn btn-default" (click)="pdf(uri)">PDF <img src="/static/images/icons/pdf_16x16.png"></button>
     </laji-spinner>
-  </div>
+  </div-->
   <div class="print-wrap no-print">
     <button type="button" [disabled]="loading" class="btn btn-default" (click)="print()">{{ 'print' | translate }} <i class="glyphicon glyphicon-print"></i></button>
   </div>


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179218468
https://179218468.dev.laji.fi/view/print?uri=http:%2F%2Ftun.fi%2FJX.276210&own=false&showFacts=false

Remove print pdf button because pdf generation has problems (map sometimes behaves weirdly, images don't load)