### PR TITLE
Rename document form cancel event with leave

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.component.ts
@@ -21,7 +21,7 @@ import { ProjectFormService } from '../../project-form.service';
       (missingNamedplace)="goBack()"
       (success)="onSuccess()"
       (error)="goBack()"
-      (cancel)="goBack()"
+      (leave)="goBack()"
       (goBack)="goBack()"
     >
     </laji-document-form>

--- a/projects/laji/src/app/shared-modules/laji-form/document-form-footer/document-form-footer.component.html
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form-footer/document-form-footer.component.html
@@ -32,6 +32,6 @@
         {{ 'haseka.form.readonly' | translate }}
     </span>
   </div>
-  <button *ngIf="show.cancel" class="btn btn-danger pull-right" [disabled]="saving" type="submit" (click)="cancel.emit()">{{ buttonLabel('cancel') | translate }}</button>
+  <button *ngIf="show.cancel" class="btn btn-danger pull-right" [disabled]="saving" type="submit" (click)="leave.emit()">{{ buttonLabel('cancel') | translate }}</button>
   <laji-feedback *ngIf="displayFeedback" [iconOnly]="true" [fixed]="false"></laji-feedback>
 </div>

--- a/projects/laji/src/app/shared-modules/laji-form/document-form-footer/document-form-footer.component.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form-footer/document-form-footer.component.ts
@@ -21,7 +21,7 @@ export class DocumentFormFooterComponent {
   @Output() submitPublic = new EventEmitter();
   @Output() submitPrivate = new EventEmitter();
   @Output() submitTemplate = new EventEmitter();
-  @Output() cancel = new EventEmitter();
+  @Output() leave = new EventEmitter();
   @Output() lock = new EventEmitter<boolean>();
   _form: FormWithData;
   _locked: boolean;

--- a/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.html
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.html
@@ -52,7 +52,7 @@
       (submitPublic)="submitPublic()"
       (submitPrivate)="submitPrivate()"
       (submitTemplate)="submitTemplate()"
-      (cancel)="onCancel()"></laji-document-form-footer>
+      (leave)="onLeave()"></laji-document-form-footer>
   </div>
 </ng-container>
 

--- a/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/shared-modules/laji-form/document-form/document-form.component.ts
@@ -45,7 +45,7 @@ export class DocumentFormComponent implements OnChanges, OnDestroy, ComponentCan
   @Input() template = false;
   @Output() success = new EventEmitter<ISuccessEvent>();
   @Output() error = new EventEmitter();
-  @Output() cancel = new EventEmitter();
+  @Output() leave = new EventEmitter();
   @Output() accessDenied = new EventEmitter();
   @Output() missingNamedplace = new EventEmitter();
   @Output() goBack = new EventEmitter();
@@ -137,9 +137,9 @@ export class DocumentFormComponent implements OnChanges, OnDestroy, ComponentCan
     }
   }
 
-  onCancel() {
+  onLeave() {
     this.isFromCancel = true;
-    this.cancel.emit();
+    this.leave.emit();
   }
 
   onChange(formData) {


### PR DESCRIPTION
The `cancel` is a reserved event, and on Firefox it is called for the `document-form` component when laji-form file dialog is cancelled. On chrome the bug doesn't exist.

https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/cancel_event

Repro steps @ https://www.pivotaltracker.com/story/show/179412522