### PR TITLE
Identical vir prod & dev env builds

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -952,12 +952,6 @@
               ]
             },
             "dev": {
-              "budgets": [
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb"
-                }
-              ],
               "fileReplacements": [
                 {
                   "replace": "projects/vir/src/environments/environment.ts",
@@ -968,10 +962,30 @@
                   "with": "projects/vir/src/environments/environment.dev.ts"
                 }
               ],
+              "optimization": {
+                "styles": {
+                  "inlineCritical": false
+                }
+              },
               "outputHashing": "all",
+              "sourceMap": false,
+              "namedChunks": false,
               "aot": true,
+              "extractLicenses": true,
               "vendorChunk": false,
-              "buildOptimizer": true
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
             },
             "local": {
               "budgets": [


### PR DESCRIPTION
I copied the vir `prod` config to the `dev` so we'd have identical builds for prod & dev .