### PR TITLE
Remove databank owners form [#179685221]

### DIFF
--- a/projects/laji/e2e/src/+theme/datasets/datasets.e2e-spec.ts
+++ b/projects/laji/e2e/src/+theme/datasets/datasets.e2e-spec.ts
@@ -1,0 +1,34 @@
+import { UserPage } from "../../+user/user.po";
+import { DatasetsPage } from "./datasets.po";
+import { isDisplayed } from "../../../helper";
+import { ProjectFormPage } from "../../+project-form/project-form.po";
+
+const userPage = new UserPage();
+const datasetsPage = new DatasetsPage();
+const projectFormPage = new ProjectFormPage();
+
+describe('Datasets page', () => {
+  beforeAll(async (done) => {
+    await datasetsPage.navigateTo();
+    await userPage.login();
+    done();
+  });
+
+  it('displays cms content', async (done) => {
+    await datasetsPage.waitForCMS();
+    expect(await isDisplayed(datasetsPage.$cmsContent)).toBe(true, 'CMS content wasn\'t displayed');
+    done();
+  });
+
+  it('displays links to datasets', async (done) => {
+    await datasetsPage.waitForDatasets();
+    expect(await datasetsPage.$datasetLinks.count()).toBeGreaterThan(0, 'No dataset links were displayed');
+    done();
+  });
+
+  it('navigating to dataset link lands on project form page', async (done) => {
+    await datasetsPage.$datasetLinks.first().click();
+    expect(await projectFormPage.hasAboutText()).toBe(true);
+    done();
+  });
+});

--- a/projects/laji/e2e/src/+theme/datasets/datasets.e2e-spec.ts
+++ b/projects/laji/e2e/src/+theme/datasets/datasets.e2e-spec.ts
@@ -15,13 +15,11 @@ describe('Datasets page', () => {
   });
 
   it('displays cms content', async (done) => {
-    await datasetsPage.waitForCMS();
     expect(await isDisplayed(datasetsPage.$cmsContent)).toBe(true, 'CMS content wasn\'t displayed');
     done();
   });
 
   it('displays links to datasets', async (done) => {
-    await datasetsPage.waitForDatasets();
     expect(await datasetsPage.$datasetLinks.count()).toBeGreaterThan(0, 'No dataset links were displayed');
     done();
   });

--- a/projects/laji/e2e/src/+theme/datasets/datasets.po.ts
+++ b/projects/laji/e2e/src/+theme/datasets/datasets.po.ts
@@ -1,0 +1,12 @@
+import { browser, $, ExpectedConditions } from 'protractor';
+
+const EC = ExpectedConditions;
+
+export class DatasetsPage {
+  navigateTo = () => browser.get('/theme/datasets');
+  waitForCMS = () => browser.wait(EC.visibilityOf(this.$cmsContent));
+  waitForDatasets = () => browser.wait(EC.visibilityOf(this.$datasetsContainer));
+  $cmsContent = $('.laji-page');
+  $datasetsContainer = $('.dataset-items');
+  $datasetLinks = this.$datasetsContainer.$$('a');
+}

--- a/projects/laji/e2e/src/+theme/datasets/datasets.po.ts
+++ b/projects/laji/e2e/src/+theme/datasets/datasets.po.ts
@@ -4,8 +4,6 @@ const EC = ExpectedConditions;
 
 export class DatasetsPage {
   navigateTo = () => browser.get('/theme/datasets');
-  waitForCMS = () => browser.wait(EC.visibilityOf(this.$cmsContent));
-  waitForDatasets = () => browser.wait(EC.visibilityOf(this.$datasetsContainer));
   $cmsContent = $('.laji-page');
   $datasetsContainer = $('.dataset-items');
   $datasetLinks = this.$datasetsContainer.$$('a');

--- a/projects/laji/src/app/+theme/datasets/datasets.component.html
+++ b/projects/laji/src/app/+theme/datasets/datasets.component.html
@@ -13,7 +13,7 @@
     </ng-container>
     <ng-container *ngIf="forms$ | async; let forms">
       <h3>{{ 'datasets.accessTo' | translate }}</h3>
-      <ul>
+      <ul class="dataset-items">
         <li *ngIf="forms.length === 0">
           {{ 'datasets.accessNone' | translate }}
         </li>

--- a/projects/laji/src/app/+theme/datasets/datasets.component.ts
+++ b/projects/laji/src/app/+theme/datasets/datasets.component.ts
@@ -42,7 +42,7 @@ export class DatasetsComponent {
     this.forms$ = this.formService.getAllForms().pipe(
       switchMap(fs => forkJoin(
         fs.filter(f =>
-          f.options?.dataset && ![Global.forms.datasetPrimary, Global.forms.datasetSecondary].includes(f.id)
+          f.options?.dataset && ![Global.forms.databankPrimary, Global.forms.databankSecondary].includes(f.id)
         ).map(f => this.formPermissionService.getRights(f).pipe(
           map(rights => (rights.view || rights.ictAdmin) && f),
         ))

--- a/projects/laji/src/app/+theme/datasets/datasets.component.ts
+++ b/projects/laji/src/app/+theme/datasets/datasets.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { FormService } from '../../shared/service/form.service';
-import { combineLatest, forkJoin, Observable, of } from 'rxjs';
+import { from, Observable } from 'rxjs';
 import { Global } from '../../../environments/global';
 import { TranslateService } from '@ngx-translate/core';
-import {filter, map, switchMap, take, tap, toArray} from 'rxjs/operators';
+import { concatMap, filter, map, switchMap, toArray } from 'rxjs/operators';
 import { MultiLanguage } from '../../../../../laji-api-client/src/lib/models';
 import { Form } from '../../shared/model/Form';
 import { FormPermissionService } from '../../shared/service/form-permission.service';
@@ -21,7 +21,11 @@ export class DatasetsComponent {
 
   readonly breadcrumb$: Observable<Breadcrumb[]>;
   readonly forms$: Observable<Form.List[]>;
-  instructions: MultiLanguage = Global.databankCMS;
+  instructions: MultiLanguage = {
+    fi: '3513',
+    en: '3517',
+    sv: '3520'
+  };
 
   constructor(
     private formService: FormService,
@@ -34,33 +38,18 @@ export class DatasetsComponent {
     this.breadcrumb$ = this.route.data.pipe(
       map(data => data.breadcrumbs || [])
     );
-    //Doesn't work!
+
     this.forms$ = this.formService.getAllForms().pipe(
-      switchMap(fs => forkJoin(
-        ...fs.filter(f =>
-          f.options?.dataset && ![Global.forms.datasetPrimary, Global.forms.datasetSecondary].includes(f.id)
-        ).map(f => this.formPermissionService.getRights(f).pipe(
+      switchMap(forms => from(
+        forms.filter(f => f.options?.dataset && ![Global.forms.datasetPrimary, Global.forms.datasetSecondary].includes(f.id))
+      ).pipe(
+        concatMap(f => this.formPermissionService.getRights(f).pipe(
           map(rights => (rights.view || rights.ictAdmin) && f),
-          filter(f => !!f),
+          filter(_f => !!_f),
+          toArray()
         ))
-      ))
+      )),
     );
-    //Doesn't also work!
-    // this.forms$ = combineLatest(this.userService.user$, this.formService.getAllForms()).pipe(
-    //  switchMap(([person, fs]) => forkJoin(
-    //    ...fs
-    //      .filter(f =>
-    //        f.options?.dataset && ![Global.forms.datasetPrimary, Global.forms.datasetSecondary].includes(f.id)
-    //      ).map(f => (UserService.isIctAdmin(person)
-    //          ? of(true)
-    //          : this.formPermissionService.hasAccessToForm(f.id)
-    //        ).pipe(
-    //          map(hasAccess => hasAccess && f),
-    //          filter(f => !!f),
-    //        )
-    //      )
-    //  ))
-    // );
   }
 
 }

--- a/projects/laji/src/app/shared/service/form-permission.service.ts
+++ b/projects/laji/src/app/shared/service/form-permission.service.ts
@@ -44,7 +44,7 @@ export class FormPermissionService {
     );
 
     return this.formService.getAllForms(this.translateService.currentLang).pipe(
-      switchMap(forms => this.formService.getForm(forms.find(f => f.id === formID).id, this.translateService.currentLang)),
+      map(forms => forms.find(f => f.id === formID)),
       switchMap(form => (!form.collectionID || !form.options?.restrictAccess)
         ? of(true)
         : permission$(form.collectionID)

--- a/projects/laji/src/environments/global.ts
+++ b/projects/laji/src/environments/global.ts
@@ -8,9 +8,8 @@ export const Global = {
     iucn: 'iucn'
   },
   forms: {
-    datasetPrimary: 'MHL.70',
-    datasetSecondary: 'MHL.68',
-    datasets: 'MHL.67',
+    databankPrimary: 'MHL.70',
+    databankSecondary: 'MHL.68',
     default: 'JX.519',
     namedPlace: 'MHL.36',
     whichSpecies: 'MHL.9',

--- a/projects/laji/src/environments/global.ts
+++ b/projects/laji/src/environments/global.ts
@@ -8,12 +8,19 @@ export const Global = {
     iucn: 'iucn'
   },
   forms: {
+    datasetPrimary: 'MHL.70',
+    datasetSecondary: 'MHL.68',
     datasets: 'MHL.67',
     default: 'JX.519',
     namedPlace: 'MHL.36',
     whichSpecies: 'MHL.9',
     collectionContest: 'MHL.25',
     privateCollection: 'JX.5190'
+  },
+  databankCMS: {
+    fi: "3513",
+    en: "3517",
+    sv: "3520"
   },
   externalViewers: {
     'http://tun.fi/KE.3': 'https://kotka.luomus.fi/view?uri=%uri%'

--- a/projects/laji/src/environments/global.ts
+++ b/projects/laji/src/environments/global.ts
@@ -17,11 +17,6 @@ export const Global = {
     collectionContest: 'MHL.25',
     privateCollection: 'JX.5190'
   },
-  databankCMS: {
-    fi: "3513",
-    en: "3517",
-    sv: "3520"
-  },
   externalViewers: {
     'http://tun.fi/KE.3': 'https://kotka.luomus.fi/view?uri=%uri%'
   },


### PR DESCRIPTION
Currently the list of the data bank forms is the `$.options.forms` list of form `MHL.67`. This causes a bug that when navigating to edit a document of some databank form that is on that list, the URL get malformed as the project-form code interprets the data bank form being a sub form, which it isn't in this context.

To fix this, the list of the data bank forms should be derived from filtering all the forms with the `$.options.databank` option. The form with list of the data bank forms (`MHL.67`) should be removed after this.