### PR TITLE
Display kiinteistojaotus & kiinteistotunnukset layers for VIR observation map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11552,9 +11552,9 @@
       }
     },
     "laji-map": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/laji-map/-/laji-map-3.7.6.tgz",
-      "integrity": "sha512-1xRD1IXfT/ybK6VYbWr/mdbQtS+qCCKnXYRfU1vQospUFy3DoKxTtTr5Uc2HyT2dJU1fp1ILdesMqoOoSj5tPA==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/laji-map/-/laji-map-3.8.0.tgz",
+      "integrity": "sha512-FeUgmLKvuV1YRbWZwp3ZBEQPhcThJ+mWh23Mw4rdfVjbcBRo5SfZPM/Bb+fmg0IybVWHfjBc0v7dr+L9IkHm+Q==",
       "requires": {
         "@types/geojson": "*",
         "@types/leaflet": "*",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "jw-bootstrap-switch-ng2": "^2.0.5",
     "label-designer": "^4.0.3",
     "laji-form": "^12.0.21",
-    "laji-map": "^3.7.6",
+    "laji-map": "^3.8.0",
     "leaflet.sync": "^0.2.4",
     "localforage": "^1.9.0",
     "moment": "2.29.1",

--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
@@ -26,6 +26,8 @@ import { LajiMapOptions, LajiMapTileLayerName } from '@laji-map/laji-map.interfa
 import { PlatformService } from '../../../shared/service/platform.service';
 import { latLngBounds as LlatLngBounds } from 'leaflet';
 import { TileLayersOptions } from 'laji-map';
+import { ActivatedRoute } from '@angular/router';
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'laji-observation-map',
@@ -142,7 +144,12 @@ export class ObservationMapComponent implements OnChanges, OnDestroy {
     private coordinateService: CoordinateService,
     private logger: Logger,
     private changeDetector: ChangeDetectorRef,
-  ) { }
+    private route: ActivatedRoute
+  ) {
+    if (environment.type === 'vir') {
+      this._mapOptions = {...this._mapOptions, availableOverlayNameBlacklist: []};
+    }
+  }
 
   ngOnChanges(changes: SimpleChanges) {
     if (!this.platformService.isBrowser) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179620857

Note that there isn't a demo for this, since vir this concerns the vir build - hence the task isn't approved yet, so let's first review this PR and then merge to dev to get a demo running.

Latest `laji-map` version has new overlays: `kiinteistojaotus` and `kiinteistotunnukset`. They are blacklisted by default, and in this PR we clear the blacklist for the observation map in VIR env in order to display the layers.

I tried first to add the blacklist overriding to vir routing params, but unfortunately they couldn't be reached in the observation map component even with recursive search, so I hard coded the overriding to the observation map component.