### PR TITLE
Fix dialog service default values [#179849806]

### DIFF
--- a/projects/laji/src/app/shared/service/dialog.service.ts
+++ b/projects/laji/src/app/shared/service/dialog.service.ts
@@ -57,6 +57,12 @@ export class DialogService {
   }
 
   private createDialog<T extends DialogConfig, R = (boolean | (string | null))>(options: T): Observable<R> {
+    if (options.confirmLabel === undefined) {
+      delete options.confirmLabel;
+    }
+    if (options.promptValue === undefined) {
+      delete options.promptValue;
+    }
     const initialState: InitialState = {showCancel: true, prompt: false,  promptValue: '', ...options};
     const modalRef = this.modalService.show(ConfirmModalComponent, {
         backdrop: 'static',


### PR DESCRIPTION
Repro steps at https://www.pivotaltracker.com/story/show/179849806
Demo page https://179743577.dev.laji.fi/user

The `ConfirmModalComponent` was initialized with undefined values for optional properties of the `DialogConfig`.