### PR TITLE
Fix canceling named place editing

### DIFF
--- a/projects/laji/e2e/src/+project-form/named-places.e2e-spec.ts
+++ b/projects/laji/e2e/src/+project-form/named-places.e2e-spec.ts
@@ -2,6 +2,7 @@ import { ProjectFormPage } from './project-form.po';
 import { UserPage } from '../+user/user.po';
 import { InvasiveSpeciesPlaceFormPage } from './invasive-species-place-form.po';
 import { browser } from 'protractor';
+import { isDisplayed } from '../../helper';
 
 const FORM_WITH_INCLUDE_UNITS = 'MHL.33';
 const FORM_WITH_NAMED_PLACES = 'MHL.33';
@@ -21,6 +22,7 @@ describe('Project form when logged in', () => {
     await userPage.login();
     done();
   });
+
   describe('named places', () => {
     it('view can be navigated to and is displayed', async (done) => {
       await projectFormPage.$formLink.click();
@@ -169,15 +171,29 @@ describe('Project form when logged in', () => {
     done();
   });
 
-  it('navigation from named place edit doesn\'t add filters that aren\'t in the UI', async (done) => {
-    await projectFormPage.navigateTo(FORM_WITH_NO_FILTERS_EDITABLE_PLACES, '/form/places');
-    await projectFormPage.namedPlacesView.$$listItems.first().click();
-    await projectFormPage.namedPlacesView.$editButton.click();
-    await projectFormPage.namedPlacesFormPage.$cancel.click();
-    const url = await browser.getCurrentUrl();
-    expect(url.match(/tags=/)).toBe(null);
-    expect(url.match(/municipality=/)).toBe(null);
-    expect(url.match(/birdAssociationArea=/)).toBe(null);
-    done();
+  describe('navigation from named place edit ', () => {
+
+    let url: string;
+    beforeAll(async (done) => {
+      await projectFormPage.navigateTo(FORM_WITH_NO_FILTERS_EDITABLE_PLACES, '/form/places');
+      await projectFormPage.namedPlacesView.$$listItems.first().click();
+      await projectFormPage.namedPlacesView.$editButton.click();
+      await projectFormPage.namedPlacesFormPage.$cancel.click();
+      url = await browser.getCurrentUrl();
+      done();
+    });
+
+    it('navigates to named places view', async (done) => {
+      expect(await isDisplayed(projectFormPage.namedPlacesView.$container)).toBe(true);
+      done();
+    });
+
+    it('doesn\'t add filters that aren\'t in the UI', async (done) => {
+      expect(url.match(/tags=/)).toBe(null);
+      expect(url.match(/municipality=/)).toBe(null);
+      expect(url.match(/birdAssociationArea=/)).toBe(null);
+      done();
+    });
   });
+
 });

--- a/projects/laji/src/app/+haseka/form/haseka-form.component.html
+++ b/projects/laji/src/app/+haseka/form/haseka-form.component.html
@@ -9,7 +9,7 @@
         (accessDenied)="onAccessDenied($event)"
         (missingNamedplace)="onMissingNamedplace($event)"
         (error)="onError()"
-        (cancel)="onCancel()"
+        (leave)="onCancel()"
         [formId]="formId"
         [documentId]="documentId"
         [template]="template"

--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.html
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.html
@@ -15,7 +15,7 @@
       [edit]="!!data.namedPlace"
       (submitPublic)="submitPublic()"
       (submitPrivate)="submitPrivate()"
-      (cancel)="discard()"
+      (leave)="discard()"
     ></laji-document-form-footer>
   </ng-container>
 </div>

--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -141,13 +141,9 @@ export class NpEditFormComponent implements OnInit {
   }
 
   discard() {
-    this.dialogService.confirm(this.translate.instant('haseka.form.discardConfirm')).subscribe(
-      (confirm) => {
-        if (!this.hasChanges || confirm) {
-          this.navigateToNPsView();
-        }
-      }
-    );
+    this.hasChanges
+      ? this.dialogService.confirm(this.translate.instant('haseka.form.discardConfirm')).subscribe(() => this.navigateToNPsView())
+      : this.navigateToNPsView();
   }
 
   navigateToNPsView(_namedPlace?: NamedPlace) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/179788441

The bug was caused by #183 - the IDE automatic renaming of the `cancel` -> `leave` had failed for the named place edit component.