### PR TITLE
Named place edit form doesn't wrap geometry to GeometryCollection [#178391265]

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -275,8 +275,6 @@ export class NpEditFormComponent implements OnInit {
     if (namedPlace) {
       const npData = Util.clone(namedPlace);
 
-      npData['geometry'] = {type: 'GeometryCollection', geometries: [npData.geometry]};
-
       if (npData.prepopulatedDocument && npData.prepopulatedDocument.gatherings && npData.prepopulatedDocument.gatherings[0]) {
         const gathering = npData.prepopulatedDocument.gatherings[0];
         if (gathering.locality) {


### PR DESCRIPTION
Editing a named place now wraps the named place's geometry inside a GeometryCollection -> inconsistent data. Fixes probably multiple bugs, at least found this old pivotal ask:

https://www.pivotaltracker.com/story/show/178391265

Also after editing e.g. winter bird routes, the route list doesn't display the YKJ coordinates for the route because it's trying to show `geometry.coordinateVerbatim`, and the path is now `geometry.geometries[0].coordinateVerbatim` (after a second edit it'd be geometry.geometries[0].geometries[0].coordinateVerbatim`) 

Demo: https://178391265.dev.laji.fi/project/MHL.3