### PR TITLE
Fix named place edit leave confirmation [#180290817]

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -141,7 +141,7 @@ export class NpEditFormComponent implements OnInit {
       ? this.dialogService.confirm(
         this.translate.instant('haseka.form.discardConfirm'),
         this.translate.instant('haseka.form.leaveConfirm.confirm')
-      ).subscribe(() => this.navigateToNPsView())
+      ).subscribe((confirmed) => confirmed && this.navigateToNPsView())
       : this.navigateToNPsView();
   }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180290817
https://180290817.dev.laji.fi/project/MHL.45 (or any other form with named places editing enabled)

Not related to release 49 btw, so no need to include in that release

## Repro:
1. go edit some named place
2. make some changes
3. click "leave without saving"
4. click "cancel"

## What happens?
You are redirected back to where you came from, so the confirmation dialog is pointless.

## What should happen?
Canceling closes confirmation dialog and doesn't redirect user