### PR TITLE
Document request done only once on document form page [#180292736]

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -347,7 +347,7 @@ export class DocumentFormFacade {
     return this.userService.user$.pipe(
       take(1),
       mergeMap(person => this.documentStorage.getItem(documentID, person).pipe(
-        mergeMap(local => this.documentApi.findById(documentID, this.userService.getToken()).pipe(
+        mergeMap(local => this.documentService.findById(documentID).pipe(
           map((document: Document) => {
             if (document.isTemplate) {
               const doc = this.documentService.removeMeta(document, ['isTemplate', 'templateName', 'templateDescription']);

--- a/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-button/named-place-linker-button.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-button/named-place-linker-button.component.ts
@@ -50,7 +50,7 @@ export class NamedPlaceLinkerButtonComponent implements OnInit {
   ngOnInit() {
     const document$ = this.userService.isLoggedIn$.pipe(
       switchMap(isLoggedIn => isLoggedIn && this.documentID
-        ? this.documentApi.findById(this.documentID, this.userService.getToken()).pipe(
+        ? this.documentService.findById(this.documentID).pipe(
           catchError(() => EMPTY)
         )
         : EMPTY),

--- a/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit, Output, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormService } from '../../../shared/service/form.service';
 import { Form } from '../../../shared/model/Form';
 import { catchError, map, switchMap, take } from 'rxjs/operators';
@@ -53,7 +53,7 @@ export class NamedPlaceLinkerComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.document$ = this.documentApi.findById(this.documentID, this.userService.getToken());
+    this.document$ = this.documentService.findById(this.documentID);
 
     const form$ = this.document$.pipe(switchMap(document => this.formService.getForm(document.formID)));
     const rights$ = form$.pipe(switchMap(form => this.formPermissionService.getRights(form)));
@@ -61,9 +61,9 @@ export class NamedPlaceLinkerComponent implements OnInit, OnDestroy {
       map(([document, rights, person]) => this.documentService.getReadOnly(document, rights, person)),
       map(readonly => readonly === Readonly.true || readonly === Readonly.noEdit)
     );
-    const isLinked$ = combineLatest(this.document$, form$).pipe(map(([document, form]) =>  !!document?.namedPlaceID));
+    const isLinked$ = this.document$.pipe(map(document => !!document?.namedPlaceID));
 
-    this.vm$ = combineLatest(this.document$, form$, documentReadOnly$, isLinked$).pipe(
+    this.vm$ = combineLatest([this.document$, form$, documentReadOnly$, isLinked$]).pipe(
       map(([document, form, isReadonly, isLinked]) => ({document, form, isLinkable: !isReadonly, isLinked}))
     );
   }


### PR DESCRIPTION
Repro:

1. Goto https://180292736.dev.laji.fi/vihko/ownSubmissions
2. Open network tab to see the requests made
3. Open some of your trip report documents

#### What's the expected result?
- /document data is fetched one time

#### What's the expected result?
- /document data is fetched two time

I fixed this by adding a `findById` method with a cache to the document service, which the document form facade and the named place linker both use, so that the request is done only once.