### PR TITLE
Enable strict bind call apply 180206625

### DIFF
--- a/projects/laji/src/app/+project-form/results/wbc-result/wbc-species-charts/wbc-species-linecharts/wbc-species-linecharts.component.ts
+++ b/projects/laji/src/app/+project-form/results/wbc-result/wbc-species-charts/wbc-species-linecharts/wbc-species-linecharts.component.ts
@@ -298,9 +298,9 @@ export class WbcSpeciesLinechartsComponent implements OnInit, OnChanges {
     this.lineChartData[season][0]['label'] = 'Yksilöm./laskentoja';
     this.lineChartLabels[season] = [];
 
-    const yearsTotal = Object.keys(data);
+    const yearsTotal = Object.keys(data).map(y => parseInt(y, 10));
     const range = (start, stop, step) => Array.from({ length: (stop - start) / step + 1}, (_, i) => start + (i * step));
-    const years = range(Math.min.apply(Math, yearsTotal), Math.max.apply(Math, yearsTotal), 1);
+    const years = range(Math.min(...yearsTotal), Math.max(...yearsTotal), 1);
     years.sort();
 
     let prevYear;

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
@@ -1,12 +1,10 @@
-<laji-spinner [spinning]="!selectedInformalGroup">
-  <laji-informal-list-breadcrumb *ngIf="showBreadcrumb && selectedInformalGroup"
+<laji-spinner [spinning]="!selectedInformalGroup && !informalGroups">
+  <laji-informal-list-breadcrumb *ngIf="showBreadcrumb"
                                  [informalGroup]="selectedInformalGroup"
-                                 [groups]="groups"
+                                 [parentGroups]="parentGroups"
                                  (informalGroupSelect)="informalGroupSelect.emit($event)">
-
   </laji-informal-list-breadcrumb>
-  <laji-informal-list *ngIf="selectedInformalGroup"
-                      [tree]="selectedInformalGroup"
+  <laji-informal-list [informalTaxonGroups]="informalGroups"
                       [showAll]="showAll"
                       (informalGroupSelect)="informalGroupSelect.emit($event)">
   </laji-informal-list>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
@@ -60,6 +60,6 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
     });
 
     this.informalTaxonService.informalTaxonGroupGetParents(this.id, this.translate.currentLang)
-      .subscribe(data => this.parentGroups = data);
+      .subscribe(data => this.parentGroups = data, () => {});
   }
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
@@ -1,13 +1,8 @@
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { combineLatest, Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { InformalTaxonGroupApi } from '../../../shared/api/InformalTaxonGroupApi';
 import { InformalTaxonGroup } from '../../../shared/model/InformalTaxonGroup';
-
-export interface InformalGroup extends InformalTaxonGroup {
-  results: InformalTaxonGroup[];
-}
 
 @Component({
   selector: 'laji-informal-group-select',
@@ -20,9 +15,11 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
   @Input() showAll = false;
   @Output() informalGroupSelect = new EventEmitter<string>();
 
-  public selectedInformalGroup: InformalGroup;
-  public groups: Array<InformalTaxonGroup> = [];
-  private subTrans: Subscription;
+  public selectedInformalGroup: InformalTaxonGroup | undefined;
+  public informalGroups: InformalTaxonGroup[] = [];
+  public parentGroups: InformalTaxonGroup[] = [];
+
+  private sub = new Subscription();
 
   constructor(
     public translate: TranslateService,
@@ -31,7 +28,7 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
 
   ngOnInit() {
     this.refreshInformalGroups();
-    this.subTrans = this.translate.onLangChange.subscribe(this.refreshInformalGroups.bind(this));
+    this.sub.add(this.translate.onLangChange.subscribe(this.refreshInformalGroups.bind(this)));
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -41,42 +38,28 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
   }
 
   ngOnDestroy() {
-    if (this.subTrans) {
-      this.subTrans.unsubscribe();
-    }
+    this.sub.unsubscribe();
   }
 
   private refreshInformalGroups() {
-    this.groups = [];
-    this.selectedInformalGroup = null;
+    this.parentGroups = [];
+    this.selectedInformalGroup = undefined;
 
     if (!this.id) {
-      this.informalTaxonService
-        .informalTaxonGroupFindRoots(this.translate.currentLang)
-        .subscribe(this.setSelectedInformalGroup.bind(this));
-    } else {
-      combineLatest(
-        this.informalTaxonService.informalTaxonGroupGetChildren(this.id, this.translate.currentLang),
-        this.informalTaxonService.informalTaxonGroupFindById(this.id, this.translate.currentLang)
-      ).pipe(
-        map(this.parseInformalTaxonGroup.bind(this))
-      ).subscribe(this.setSelectedInformalGroup.bind(this), () => {});
-      this.informalTaxonService.informalTaxonGroupGetParents(this.id, this.translate.currentLang)
-        .subscribe(data => {
-          this.groups = data;
-        }, () => {
-          this.groups = [];
-        });
+      this.informalTaxonService.informalTaxonGroupFindRoots(this.translate.currentLang)
+        .subscribe(data => this.informalGroups = data.results);
+      return;
     }
-  }
 
-  private parseInformalTaxonGroup(data) {
-    const { results } = data[0];
-    const { id, name } = data[1];
-    return { results, id, name };
-  }
+    combineLatest(
+      this.informalTaxonService.informalTaxonGroupGetChildren(this.id, this.translate.currentLang),
+      this.informalTaxonService.informalTaxonGroupFindById(this.id, this.translate.currentLang)
+    ).subscribe(data => {
+      this.informalGroups = data[0].results;
+      this.selectedInformalGroup = data[1];
+    });
 
-  private setSelectedInformalGroup(data: InformalGroup) {
-    this.selectedInformalGroup = data;
+    this.informalTaxonService.informalTaxonGroupGetParents(this.id, this.translate.currentLang)
+      .subscribe(data => this.parentGroups = data);
   }
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
@@ -2,7 +2,7 @@
   <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
     <a (click)="informalGroupSelect.emit()" tabindex="0" role="button" luKeyboardClickable>{{ 'observation.active.informalTaxonGroupAll' | translate }}</a>
   </li>
-  <li *ngFor="let group of groups; let i = index; let active = last;">
+  <li *ngFor="let group of parentGroups; let i = index; let active = last;">
     <a (click)="informalGroupSelect.emit(group.id)" tabindex="0" role="button" luKeyboardClickable>{{ group.name }}</a>
   </li>
   <li *ngIf="informalGroup" class="active">

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
@@ -8,9 +8,7 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 })
 
 export class InformalListBreadcrumbComponent {
-
   @Input() informalGroup: InformalTaxonGroup;
-  @Input() groups: Array<InformalTaxonGroup>;
+  @Input() parentGroups: Array<InformalTaxonGroup>;
   @Output() informalGroupSelect = new EventEmitter<string>();
-
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
@@ -1,14 +1,5 @@
 <div class="d-flex flex-wrap">
-  <!--div *ngIf="showAll" class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
-    <a (click)="informalGroupSelect.emit('')" class="niks thumbnail panel panel-default link">
-      <div class="panel-heading">
-        <div style="background-image: url('/static/images/icons/species.svg');" class="informal-group-image">
-          <h3 style="height: 50px;" class="panel-title caption">{{ 'species.form.all' | translate }}</h3>
-        </div>
-      </div>
-    </a>
-  </div-->
-  <a *ngFor="let group of tree.results" (click)="informalGroupSelect.emit(group.id)" class="group d-flex flex-nowrap items-center mr-3 mb-3" tabindex="0" role="button" luKeyboardClickable>
+  <a *ngFor="let group of informalTaxonGroups" (click)="informalGroupSelect.emit(group.id)" class="group d-flex flex-nowrap items-center mr-3 mb-3" tabindex="0" role="button" luKeyboardClickable>
     <img class="group-image" [src]="'static/images/informalGroups/' + group.id + '.svg'" alt="">
     <div class="group-name">{{ group.name }}</div>
   </a>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.ts
@@ -1,5 +1,4 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { PagedResult } from '../../../../shared/model/PagedResult';
 import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup';
 
 @Component({
@@ -9,9 +8,7 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 
 })
 export class InformalListComponent {
-
-  @Input() tree: { results: InformalTaxonGroup[]};
+  @Input() informalTaxonGroups: InformalTaxonGroup[];
   @Input() showAll = false;
   @Output() informalGroupSelect = new EventEmitter<string>();
-
 }

--- a/projects/laji/src/app/shared/navbar/notifications/notifications.facade.ts
+++ b/projects/laji/src/app/shared/navbar/notifications/notifications.facade.ts
@@ -131,7 +131,7 @@ export class NotificationsFacade {
     notification.seen = true;
     return subscribeWithWrapper(
       this.lajiApi.update(LajiApi.Endpoints.notifications, notification, {personToken: this.userService.getToken()}),
-      this.localUnseenCountReducer.bind(this, [1])
+      this.localUnseenCountReducer.bind(this, 1)
     );
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
       "es2018",
       "dom"
     ],
+    "strictBindCallApply": true,
     "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Enables the strictBindCallApply tsc option (one of the options included in strict mode) and fixes all related errors.

There were also some confusing names and stuff in `informal-group-select` that I refactored as byproduct.

https://www.pivotaltracker.com/story/show/180206625
