### PR TITLE
Short doc no named place requests [#180292750]

### DIFF
--- a/projects/laji/src/app/+project-form/project-form.component.html
+++ b/projects/laji/src/app/+project-form/project-form.component.html
@@ -14,6 +14,7 @@
           <laji-haseka-latest [forms]="[vm.form.id]"
                               [tmpOnly]="false"
                               (showViewer)="showDocumentViewer($event)"
+                              [showFormNames]="false"
                               *ngIf="(userService.isLoggedIn$ | async)">
           </laji-haseka-latest>
         </nav>

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
@@ -14,7 +14,7 @@ import { ILatestDocument, LatestDocumentsFacade } from '../latest-documents.faca
 export class UsersLatestComponent implements OnInit, OnChanges {
   @Input() tmpOnly = false;
   @Input() forms: string[];
-  @Input() showFormNames: boolean;
+  @Input() showFormNames = true;
   @Input() complainLocality: boolean;
   @Input() staticWidth: number = undefined;
 

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.html
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.html
@@ -5,7 +5,7 @@
   </div>
 
   <header>
-    <h1>{{ locality }}</h1>
+    <h1 *ngIf="locality">{{ locality }}</h1>
     <div class="label label-warning" *ngIf="document.publicityRestrictions === publicity.publicityRestrictionsPrivate">
       {{ 'result.latestObservationsLabel' | translate }}
     </div>

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.html
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.html
@@ -5,7 +5,7 @@
   </div>
 
   <header>
-    <h1>{{ getLocality$() | async }}</h1>
+    <h1>{{ locality }}</h1>
     <div class="label label-warning" *ngIf="document.publicityRestrictions === publicity.publicityRestrictionsPrivate">
       {{ 'result.latestObservationsLabel' | translate }}
     </div>

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.ts
@@ -1,15 +1,12 @@
-import { delay, switchMap, tap } from 'rxjs/operators';
+import { delay, tap } from 'rxjs/operators';
 import { Component, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output } from '@angular/core';
-import { Router } from '@angular/router';
 import { Document } from '../../../shared/model/Document';
 import { FormService } from '../../../shared/service/form.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import { DocumentInfoService } from '../../../shared/service/document-info.service';
 import { LocalizeRouterService } from '../../../locale/localize-router.service';
-import { getLocality$ } from '../../own-submissions/own-submissions.component';
-import { TriplestoreLabelService } from '../../../shared/service/triplestore-label.service';
-import { DialogService } from '../../../shared/service/dialog.service';
+import { getLocality } from '../../own-submissions/own-submissions.component';
 import { Form } from '../../../shared/model/Form';
 
 
@@ -33,9 +30,7 @@ export class ShortDocumentComponent implements OnInit, OnChanges, OnDestroy {
   public newUnitsLength: number;
   public gatheringDates: {start: string, end: string};
   public publicity = Document.PublicityRestrictionsEnum;
-  public locality;
-  public dateEdited;
-  public namedPlaceID;
+  public locality: string;
 
   public showList = false;
   public changingLocale = true;
@@ -45,11 +40,8 @@ export class ShortDocumentComponent implements OnInit, OnChanges, OnDestroy {
 
   constructor(
     public formService: FormService,
-    private router: Router,
     private translate: TranslateService,
-    private labelService: TriplestoreLabelService,
     private localizeRouterService: LocalizeRouterService,
-    private dialogService: DialogService
   ) {}
 
   ngOnInit() {
@@ -81,13 +73,9 @@ export class ShortDocumentComponent implements OnInit, OnChanges, OnDestroy {
     this.newUnitsLength = gatheringInfo.unsavedUnitCount;
     this.gatheringDates = {start: gatheringInfo.dateBegin, end: gatheringInfo.dateEnd};
     this.editDocumentRoute = this.getEditDocumentRoute(this.document.formID, this.document.id);
+    this.locality = getLocality(this.translate, DocumentInfoService.getGatheringInfo(this.document, this.form));
 
     this.loading = false;
-  }
-
-  getLocality$() {
-    const gatheringInfo = DocumentInfoService.getGatheringInfo(this.document, this.form);
-    return getLocality$(this.translate, this.labelService, gatheringInfo, this.document);
   }
 
   getEditDocumentRoute(formId, documentId) {

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/short-document.component.ts
@@ -6,9 +6,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { Subscription } from 'rxjs';
 import { DocumentInfoService } from '../../../shared/service/document-info.service';
 import { LocalizeRouterService } from '../../../locale/localize-router.service';
-import { getLocality } from '../../own-submissions/own-submissions.component';
 import { Form } from '../../../shared/model/Form';
-
 
 @Component({
   selector: 'laji-short-document',
@@ -73,7 +71,7 @@ export class ShortDocumentComponent implements OnInit, OnChanges, OnDestroy {
     this.newUnitsLength = gatheringInfo.unsavedUnitCount;
     this.gatheringDates = {start: gatheringInfo.dateBegin, end: gatheringInfo.dateEnd};
     this.editDocumentRoute = this.getEditDocumentRoute(this.document.formID, this.document.id);
-    this.locality = getLocality(this.translate, DocumentInfoService.getGatheringInfo(this.document, this.form));
+    this.locality = DocumentInfoService.getLocality(gatheringInfo);
 
     this.loading = false;
   }

--- a/projects/laji/src/app/shared-modules/own-submissions/own-submissions.component.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/own-submissions.component.ts
@@ -398,7 +398,7 @@ export class OwnSubmissionsComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   private getLocality(gatheringInfo: any): string {
-    return getLocality(this.translate, gatheringInfo);
+    return DocumentInfoService.getLocality(gatheringInfo) || this.translate.instant('haseka.users.latest.localityMissing');
   }
 
   private getObservers(userArray: string[] = []): Observable<string> {
@@ -447,10 +447,4 @@ export class OwnSubmissionsComponent implements OnChanges, OnInit, OnDestroy {
       })
     ).subscribe();
   }
-}
-
-export function getLocality(translate: TranslateService,
-                             gatheringInfo: any): string {
-  return [gatheringInfo.municipality, gatheringInfo.locality].filter(s => !!s).join(', ')
-    || translate.instant('haseka.users.latest.localityMissing');
 }

--- a/projects/laji/src/app/shared/service/document-info.service.ts
+++ b/projects/laji/src/app/shared/service/document-info.service.ts
@@ -103,4 +103,8 @@ export class DocumentInfoService {
 
     return true;
   }
+
+  public static getLocality(gatheringInfo: any): string {
+    return [gatheringInfo.municipality, gatheringInfo.locality].filter(s => !!s).join(', ');
+  }
 }


### PR DESCRIPTION
Pivotal task https://www.pivotaltracker.com/story/show/180292750
Demo: https://180292750.dev.laji.fi/vihko/home

Currently the short docs (=document viewers in the sidebar on e.g. `/vihko/home`) made a named place request if the document had a named place ID. This made the page increasingly unresponsive. With this PR, the short doc doesn't do any requests.

I also fixed a bug that made the short doc never display the form name. The problem was that even though `showFormName` was `true` by default, the short doc is always wrapped inside a `haseka-user-latest` which didn't have a default value, making the value `undefined`. Short docs under project forms don't display the form name, as it's already implicit.