### PR TITLE
history service filters route with replaceUrl [#180291183]

### DIFF
--- a/projects/laji/e2e/src/+project-form/project-form.e2e-spec.ts
+++ b/projects/laji/e2e/src/+project-form/project-form.e2e-spec.ts
@@ -17,6 +17,8 @@ const FORM_NAMED_PLACES_STRICT_ACCESS_RESTRICTION = 'MHL.45';
 const FORM_NAMED_PLACES_STRICT_ACCESS_RESTRICTION_NO_PERMISSION = 'MHL.50';
 const FORM_DISABLED = 'MHL.90';
 const FORM_ALLOW_TEMPLATES = 'MHL.6';
+const FORM_MULTIPLE_FORMS_OWN_SUBMISSONS = 'MHL.45';
+const FORM_MULTIPLE_FORMS_OWN_SUBMISSONS_DOC = 'JX.282874';
 
 const projectFormPage = new ProjectFormPage();
 const userPage = new UserPage();
@@ -149,7 +151,7 @@ describe('Project form', () =>  {
         done();
       });
 
-      it('back navigate works away from form and keeps lang', async (done) => {
+      it('back navigate navigates away from form and keeps lang', async (done) => {
         await vihkoHomePage.navigateTo('en');
         await vihkoHomePage.clickFormById(FORM_WITH_SIMPLE_HAS_NO_CATEGORY);
         const EC = protractor.ExpectedConditions;
@@ -243,6 +245,22 @@ describe('Project form', () =>  {
         expect(await projectFormPage.hasAboutText()).toBe(true);
         expect(await nav.getLang()).toBe('en');
         done();
+      });
+
+      describe(', and has multiple forms', () => {
+        it('navigating to doc without subform specified redirects to subform', async (done) => {
+          const form = FORM_MULTIPLE_FORMS_OWN_SUBMISSONS;
+          const doc = FORM_MULTIPLE_FORMS_OWN_SUBMISSONS_DOC;
+          await projectFormPage.navigateTo(`${form}/form/${doc}`, undefined, 'en');
+          expect(await browser.getCurrentUrl()).toMatch(`/${form}/form/${form}/${doc}`);
+          done();
+        });
+
+        it('saving doc when no history goes to submissions page', async (done) => {
+          await projectFormPage.documentFormView.save();
+          expect(await isDisplayed(projectFormPage.submissionsPage.$container)).toBe(true);
+          done();
+        });
       });
 
       describe('and has allowTemplates option', () => {

--- a/projects/laji/e2e/src/+project-form/project-form.po.ts
+++ b/projects/laji/e2e/src/+project-form/project-form.po.ts
@@ -1,7 +1,7 @@
 import { browser, $, $$, ExpectedConditions, ElementFinder } from 'protractor';
 import { ConfirmPO } from '../shared/dialogs.po';
 import { getAddressWithLang } from "../../helper";
-import { SubmissionsPage } from '../+vihko/submissions.po';
+import { SubmissionsPage as GenericSubmissionsPage } from '../+vihko/submissions.po';
 const fiTranslations = require('../../../src/i18n/fi.json');
 const enTranslations = require('../../../src/i18n/en.json');
 const svTranslations = require('../../../src/i18n/sv.json');
@@ -27,6 +27,7 @@ export class ProjectFormPage {
   public readonly mobileAboutPage = new MobileAboutPage();
   public readonly namedPlaceLinker = new NamedPlaceLinker();
   public readonly templatePage = new TemplatePage();
+  public readonly submissionsPage = new SubmissionsPage();
 
   navigateTo(id, subPage = '', lang?: 'fi' | 'en' | 'sv') {
     return browser.get(getAddressWithLang(`/project/${id}${subPage}`, lang)) as Promise<void>;
@@ -154,9 +155,12 @@ class MobileAboutPage extends AboutPage { // tslint:disable-line max-classes-per
 }
 
 class TemplatePage {
-  public readonly datatable = new SubmissionsPage().datatable;
+  public readonly datatable = new GenericSubmissionsPage().datatable;
 }
 
+class SubmissionsPage {
+  $container = $('laji-submissions');
+}
 
 class DisabledPage { // tslint:disable-line max-classes-per-file
   public $container = $('laji-project-form-disabled')

--- a/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
+++ b/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
@@ -115,7 +115,7 @@
       <ng-template let-row="row" let-value="value" ngx-datatable-cell-template>
         <div class="mb-2 mr-2" *ngIf="(actions | includes:'view') && onlyTemplates === false && value === publicity.publicityRestrictionsPublic">
           <button
-            class="btn btn-success btn-xs"
+            class="btn btn-success btn-xs view-button"
             (click)="showViewer(row.id)">
             <i class="glyphicon glyphicon-eye-open"></i>
             <span class="text-button">{{ 'haseka.submissions.view' | translate }}</span>

--- a/projects/laji/src/app/shared/service/history.service.ts
+++ b/projects/laji/src/app/shared/service/history.service.ts
@@ -22,7 +22,9 @@ export class HistoryService implements OnDestroy {
     this.routeSub = this.router.events.pipe(
       filter(event => event instanceof NavigationEnd)
     ).subscribe(({urlAfterRedirects}: NavigationEnd) => {
-      if (urlAfterRedirects.match(/\/user\/(login|logout)/) || this.history[this.history.length - 1] === urlAfterRedirects) {
+      if (this.router.getCurrentNavigation().extras.replaceUrl
+        || urlAfterRedirects.match(/\/user\/(login|logout)/)
+        || this.history[this.history.length - 1] === urlAfterRedirects) {
         return;
       }
       if (this.history[this.history.length - 2] === urlAfterRedirects) {


### PR DESCRIPTION
Fixes the following bug: https://www.pivotaltracker.com/story/show/180291183
Demo https://180291183.dev.laji.fi/project/MHL.45/submissions

The issue was that the history service pushed navigations with `replaceUrl: true` to the history stack. [The docs state that it shouldn't push to the history](https://angular.io/api/router/NavigationBehaviorOptions#skipLocationChange). I took the technique for checking the `replaceUrl` in the history service from this [angular PR comment](https://github.com/angular/angular/pull/22739#issuecomment-647773274)

The only other place where `replaceUrl` is used is the taxon pages. I tested the back navigation on the taxon pages manually and it works ok.