### PR TITLE
Parse default meta img from news content

### DIFF
--- a/projects/laji/src/app/+news/news.component.ts
+++ b/projects/laji/src/app/+news/news.component.ts
@@ -1,4 +1,5 @@
-import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 import { News } from '../shared/model/News';
@@ -20,7 +21,8 @@ export class NewsComponent implements OnInit {
   constructor(private route: ActivatedRoute,
               private newsFacade: NewsFacade,
               private headerService: HeaderService,
-              private title: Title
+              private title: Title,
+              @Inject(PLATFORM_ID) private platformId
   ) {}
 
   ngOnInit() {
@@ -48,6 +50,13 @@ export class NewsComponent implements OnInit {
       this.headerService.setHeaders({
         image: news.featuredImage
       });
+    } else if (isPlatformServer(this.platformId)) {
+      const matches = news.content.match(/<img.+?src="(.*?)"/);
+      if (matches[1]?.length > 0) {
+        this.headerService.setHeaders({
+          image: matches[1]
+        });
+      }
     }
   }
 }


### PR DESCRIPTION
If a news item has no featuredImage, parses through the html to find the first image of the article and uses that in meta tags. The meta tags should only be necessary on the server.