### PR TITLE
Own obs form refactor ("Cannot deselect"-task)

### DIFF
--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -103,9 +103,12 @@
 <section class="laji-panel" *lajiLoggedIn="true" laji-panel [title]="'observation.form.own' | translate" [autoToggle]="true" [open]="visible['own']">
   <laji-own-observations-filter
     [asObserver]="formQuery.asObserver"
+    (asObserverChange)="onAsObserverChange($event)"
     [asEditor]="formQuery.asEditor"
+    (asEditorChange)="onAsEditorChange($event)"
+    [asNotEditorOrObserver]="formQuery.asNotEditorOrObserver"
+    (asNotEditorOrObserverChange)="onAsNotEditorOrObserverChange($event)"
     [includeQualityIssues]="query.qualityIssues"
-    (ownFilterChange)="onOwnObservationsFilterChange($event)"
     (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">
   </laji-own-observations-filter>
 </section>

--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -104,7 +104,7 @@
   <laji-own-observations-filter
     [asObserver]="formQuery.asObserver"
     [asEditor]="formQuery.asEditor"
-    [includeQualityIssues]="getOwnQualityIssuesFilterState()"
+    [includeQualityIssues]="query.qualityIssues"
     (ownFilterChange)="onOwnObservationsFilterChange($event)"
     (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">
   </laji-own-observations-filter>

--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -102,7 +102,8 @@
 <!-- OWN OBSERVATIONS -->
 <section class="laji-panel" *lajiLoggedIn="true" laji-panel [title]="'observation.form.own' | translate" [autoToggle]="true" [open]="visible['own']">
   <laji-own-observations-filter
-    [asObserverOrEditor]="getOwnObservationsFilterState()"
+    [asObserver]="formQuery.asObserver"
+    [asEditor]="formQuery.asEditor"
     [includeQualityIssues]="getOwnQualityIssuesFilterState()"
     (ownFilterChange)="onOwnObservationsFilterChange($event)"
     (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">

--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -101,7 +101,13 @@
 
 <!-- OWN OBSERVATIONS -->
 <section class="laji-panel" *lajiLoggedIn="true" laji-panel [title]="'observation.form.own' | translate" [autoToggle]="true" [open]="visible['own']">
-  <fieldset>
+  <laji-own-observations-filter
+    [asObserverOrEditor]="getOwnObservationsFilterState()"
+    [includeQualityIssues]="getOwnQualityIssuesFilterState()"
+    (ownFilterChange)="onOwnObservationsFilterChange($event)"
+    (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">
+  </laji-own-observations-filter>
+<!--   <fieldset>
     <div>
       <label>
         <laji-checkbox [(value)]="formQuery.asObserver" (valueChange)="ownItemSelected('asObserver')"></laji-checkbox>
@@ -142,7 +148,7 @@
         {id: 'NO_ISSUES', value: ('observation.form.qualityIssuesNO_ISSUES' | translate)},
         {id: 'ONLY_ISSUES', value: ('observation.form.qualityIssuesONLY_ISSUES' | translate)}
       ]"></laji-select>
-  </ng-container>
+  </ng-container> -->
 </section>
 
 <!-- DATE -->

--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -107,48 +107,6 @@
     (ownFilterChange)="onOwnObservationsFilterChange($event)"
     (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">
   </laji-own-observations-filter>
-<!--   <fieldset>
-    <div>
-      <label>
-        <laji-checkbox [(value)]="formQuery.asObserver" (valueChange)="ownItemSelected('asObserver')"></laji-checkbox>
-        {{ 'observation.form.asObserver' | translate }}
-      </label>
-      <laji-info>
-        {{ 'observation.info.asObserver' | translate }}
-      </laji-info>
-    </div>
-    <div>
-      <label>
-        <laji-checkbox [(value)]="formQuery.asEditor" (valueChange)="ownItemSelected('asEditor')"></laji-checkbox>
-        {{ 'observation.form.asEditor' | translate }}
-      </label>
-      <laji-info>
-        {{ 'observation.info.asEditor' | translate }}
-      </laji-info>
-    </div>
-  </fieldset>
-
-  <hr>
-  <div>
-    <p>{{ 'observation.intro.noOwnObservations' | translate }}</p>
-    <label><laji-checkbox [value]="formQuery.asNotEditorOrObserver" (valueChange)="ownItemSelected(ownStatutes, false)"></laji-checkbox>{{ 'observation.form.excludeOwn' | translate }}</label>
-    <laji-info>{{ 'observation.info.asNotEditororObserver' | translate }}</laji-info>
-  </div>
-
-  <ng-container *ngIf="formQuery.asEditor || formQuery.asObserver || query.qualityIssues">
-    <laji-select
-      [selected]="[query.qualityIssues]"
-      (selectedChange)="indirectQueryChange('qualityIssues', $event[0])"
-      [multiple]="false"
-      [useFilter]="false"
-      [title]="'observation.form.qualityIssues' | translate"
-      [info]="'observation.info.qualityIssues' | translate"
-      [options]="[
-        {id: 'BOTH', value: ('observation.form.qualityIssuesBOTH' | translate)},
-        {id: 'NO_ISSUES', value: ('observation.form.qualityIssuesNO_ISSUES' | translate)},
-        {id: 'ONLY_ISSUES', value: ('observation.form.qualityIssuesONLY_ISSUES' | translate)}
-      ]"></laji-select>
-  </ng-container> -->
 </section>
 
 <!-- DATE -->

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -323,46 +323,6 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  ownItemSelected(field: string | string[], selectValue = true) {
-    this.ownStatutes = this.query.editorPersonToken && this.query.observerPersonToken  ? ['asEditor', 'asObserver'] :
-    (this.query.editorPersonToken ? ['asEditor'] : (this.query.observerPersonToken ? ['asObserver'] : []));
-
-    if (Array.isArray(field)) {
-      if (selectValue === true) {
-        this.formQuery.asEditor = undefined;
-        this.formQuery.asObserver = undefined;
-        this.formQuery.asNotEditorOrObserver = true;
-        this.ownStatutes = this.ownStatutes.length === 2 ? [] : ['asEditor', 'asObserver'];
-      } else {
-        this.formQuery.asEditor = undefined;
-        this.formQuery.asObserver = undefined;
-        this.formQuery.asNotEditorOrObserver = this.formQuery.asNotEditorOrObserver ? undefined : true;
-        this.query.qualityIssues = undefined;
-        this.ownStatutes = selectValue ? this.ownStatutes : [] ;
-      }
-    } else {
-    if (this.ownStatutes.length === 0) {
-      this.formQuery.asEditor = undefined;
-      this.formQuery.asObserver = undefined;
-    }
-    if (this.ownStatutes.indexOf(field) === -1) {
-      this.ownStatutes.push(field);
-      this.formQuery.asNotEditorOrObserver = undefined;
-    } else {
-      const index = this.ownStatutes.indexOf(field);
-      this.ownStatutes.splice(index, 1);
-    }
-    this.ownStatutes.forEach(element => {
-      this.formQuery[element] = true;
-    });
-
-    if (this.ownStatutes.length === 2) {
-      this.query.qualityIssues = 'BOTH';
-    }
-  }
-    this.onFormQueryChange();
-  }
-
   getOwnObservationsFilterState(): OwnFilterState {
     if (this.formQuery.asObserver && this.formQuery.asEditor) {
       return 'asBoth';

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -10,7 +10,7 @@ import { Area } from '../../shared/model/Area';
 import { isRelativeDate } from './date-form/date-form.component';
 import { TaxonAutocompleteService } from '../../shared/service/taxon-autocomplete.service';
 import { BrowserService } from 'projects/laji/src/app/shared/service/browser.service';
-import { OwnFilterState, QualityIssuesFilterState } from './own-observations-filter/own-observations-filter.component';
+import { OwnFilterModel, QualityIssuesFilterState } from './own-observations-filter/own-observations-filter.component';
 
 interface ISections {
   taxon?: Array<keyof WarehouseQueryInterface>;
@@ -322,49 +322,14 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  getOwnObservationsFilterState(): OwnFilterState {
-    if (this.formQuery.asObserver && this.formQuery.asEditor) {
-      return 'asBoth';
-    }
-    if (this.formQuery.asNotEditorOrObserver) {
-      return 'asNone';
-    }
-    if (this.formQuery.asObserver) {
-      return 'asObserver';
-    }
-    if (this.formQuery.asEditor) {
-      return 'asEditor';
-    }
-    return 'unset';
-  }
-
   getOwnQualityIssuesFilterState(): QualityIssuesFilterState {
-    return this.query.qualityIssues ? <QualityIssuesFilterState>this.query.qualityIssues : 'BOTH';
+    return this.query.qualityIssues ? <QualityIssuesFilterState>this.query.qualityIssues : undefined;
   }
 
-  onOwnObservationsFilterChange(state: OwnFilterState) {
-    this.formQuery.asObserver = undefined;
-    this.formQuery.asEditor = undefined;
-    this.formQuery.asNotEditorOrObserver = undefined;
-
-    switch (state) {
-      case 'asBoth':
-        this.formQuery.asObserver = true;
-        this.formQuery.asEditor = true;
-        break;
-      case 'asObserver':
-        this.formQuery.asObserver = true;
-        break;
-      case 'asEditor':
-        this.formQuery.asEditor = true;
-        break;
-      case 'asNone':
-        this.formQuery.asNotEditorOrObserver = true;
-        break;
-      case 'unset':
-        break;
-    }
-
+  onOwnObservationsFilterChange(state: OwnFilterModel) {
+    this.formQuery.asObserver = state.asObserver;
+    this.formQuery.asEditor = state.asEditor;
+    this.formQuery.asNotEditorOrObserver = state.asNotEditorOrObserver;
     this.onFormQueryChange();
   }
 

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -380,7 +380,7 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
   }
 
   getOwnQualityIssuesFilterState(): QualityIssuesFilterState {
-    return <QualityIssuesFilterState>this.query.qualityIssues;
+    return this.query.qualityIssues ? <QualityIssuesFilterState>this.query.qualityIssues : 'BOTH';
   }
 
   onOwnObservationsFilterChange(state: OwnFilterState) {

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -10,7 +10,7 @@ import { Area } from '../../shared/model/Area';
 import { isRelativeDate } from './date-form/date-form.component';
 import { TaxonAutocompleteService } from '../../shared/service/taxon-autocomplete.service';
 import { BrowserService } from 'projects/laji/src/app/shared/service/browser.service';
-import { OwnFilterModel, QualityIssuesFilterState } from './own-observations-filter/own-observations-filter.component';
+import { OwnFilterModel } from './own-observations-filter/own-observations-filter.component';
 
 interface ISections {
   taxon?: Array<keyof WarehouseQueryInterface>;
@@ -322,10 +322,6 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  getOwnQualityIssuesFilterState(): QualityIssuesFilterState {
-    return this.query.qualityIssues ? <QualityIssuesFilterState>this.query.qualityIssues : undefined;
-  }
-
   onOwnObservationsFilterChange(state: OwnFilterModel) {
     this.formQuery.asObserver = state.asObserver;
     this.formQuery.asEditor = state.asEditor;
@@ -333,7 +329,7 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onFormQueryChange();
   }
 
-  onOwnQualityIssuesFilterChange(state: QualityIssuesFilterState) {
+  onOwnQualityIssuesFilterChange(state: string) {
     this.query.qualityIssues = state;
     this.onQueryChange();
   }

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -75,7 +75,6 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
   drawing = false;
   drawingShape: string;
   mediaStatutes: string[] = [];
-  ownStatutes: string[] = [];
 
   areaType = Area.AreaType;
   dataSource: Observable<any>;

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -322,15 +322,23 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  onOwnObservationsFilterChange(state: OwnFilterModel) {
-    this.formQuery.asObserver = state.asObserver;
-    this.formQuery.asEditor = state.asEditor;
-    this.formQuery.asNotEditorOrObserver = state.asNotEditorOrObserver;
+  onAsObserverChange(value: boolean) {
+    this.formQuery.asObserver = value;
     this.onFormQueryChange();
   }
 
-  onOwnQualityIssuesFilterChange(state: string) {
-    this.query.qualityIssues = state;
+  onAsEditorChange(value: boolean) {
+    this.formQuery.asEditor = value;
+    this.onFormQueryChange();
+  }
+
+  onAsNotEditorOrObserverChange(value: boolean) {
+    this.formQuery.asNotEditorOrObserver = value;
+    this.onFormQueryChange();
+  }
+
+  onOwnQualityIssuesFilterChange(value: string) {
+    this.query.qualityIssues = value;
     this.onQueryChange();
   }
 

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -10,6 +10,7 @@ import { Area } from '../../shared/model/Area';
 import { isRelativeDate } from './date-form/date-form.component';
 import { TaxonAutocompleteService } from '../../shared/service/taxon-autocomplete.service';
 import { BrowserService } from 'projects/laji/src/app/shared/service/browser.service';
+import { OwnFilterState, QualityIssuesFilterState } from './own-observations-filter/own-observations-filter.component';
 
 interface ISections {
   taxon?: Array<keyof WarehouseQueryInterface>;
@@ -322,7 +323,7 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onQueryChange();
   }
 
-  ownItemSelected(field, selectValue: any = true) {
+  ownItemSelected(field: string | string[], selectValue = true) {
     this.ownStatutes = this.query.editorPersonToken && this.query.observerPersonToken  ? ['asEditor', 'asObserver'] :
     (this.query.editorPersonToken ? ['asEditor'] : (this.query.observerPersonToken ? ['asObserver'] : []));
 
@@ -360,6 +361,57 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     }
   }
     this.onFormQueryChange();
+  }
+
+  getOwnObservationsFilterState(): OwnFilterState {
+    if (this.formQuery.asObserver && this.formQuery.asEditor) {
+      return 'asBoth';
+    }
+    if (this.formQuery.asNotEditorOrObserver) {
+      return 'asNone';
+    }
+    if (this.formQuery.asObserver) {
+      return 'asObserver';
+    }
+    if (this.formQuery.asEditor) {
+      return 'asEditor';
+    }
+    return 'unset';
+  }
+
+  getOwnQualityIssuesFilterState(): QualityIssuesFilterState {
+    return <QualityIssuesFilterState>this.query.qualityIssues;
+  }
+
+  onOwnObservationsFilterChange(state: OwnFilterState) {
+    this.formQuery.asObserver = undefined;
+    this.formQuery.asEditor = undefined;
+    this.formQuery.asNotEditorOrObserver = undefined;
+
+    switch (state) {
+      case 'asBoth':
+        this.formQuery.asObserver = true;
+        this.formQuery.asEditor = true;
+        break;
+      case 'asObserver':
+        this.formQuery.asObserver = true;
+        break;
+      case 'asEditor':
+        this.formQuery.asEditor = true;
+        break;
+      case 'asNone':
+        this.formQuery.asNotEditorOrObserver = true;
+        break;
+      case 'unset':
+        break;
+    }
+
+    this.onFormQueryChange();
+  }
+
+  onOwnQualityIssuesFilterChange(state: QualityIssuesFilterState) {
+    this.query.qualityIssues = state;
+    this.onQueryChange();
   }
 
   onFormQueryChange() {

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
@@ -1,8 +1,7 @@
 <div>
   <label>
     <laji-checkbox
-      [value]="state.asObserver"
-      (valueChange)="onAsObserverChange($event)">
+      [value]="asObserver" (valueChange)="onAsObserverChange($event)">
     </laji-checkbox>
     {{ 'observation.form.asObserver' | translate }}
   </label>
@@ -12,8 +11,7 @@
 </div>
 <div>
   <label>
-    <laji-checkbox [value]="state.asEditor"
-      (valueChange)="onAsEditorChange($event)">
+    <laji-checkbox [value]="asEditor" (valueChange)="onAsEditorChange($event)">
     </laji-checkbox>
     {{ 'observation.form.asEditor' | translate }}
   </label>
@@ -23,8 +21,7 @@
 </div>
 <div>
   <label>
-    <laji-checkbox [value]="state.asNotEditorOrObserver"
-      (valueChange)="OnAsNotEditorOrObserver($event)">
+    <laji-checkbox [value]="asNotEditorOrObserver" (valueChange)="onAsNotEditorOrObserverChange($event)">
     </laji-checkbox>
     {{ 'observation.form.excludeOwn' | translate }}
   </label>
@@ -32,10 +29,10 @@
     {{ 'observation.info.asNotEditororObserver' | translate }}
   </laji-info>
 </div>
-<ng-container *ngIf="state.asEditor || state.asObserver || state.quality">
+<ng-container *ngIf="asEditor || asObserver || includeQualityIssues">
   <laji-select
-    [selected]="state.quality ? [state.quality] : []"
-    (selectedChange)="onIncludeQualityIssuesChange($event)"
+    [selected]="includeQualityIssues ? [includeQualityIssues] : []"
+    (selectedChange)="onIncludeQualityIssuesChange($event[0])"
     [multiple]="false"
     [useFilter]="false"
     [title]="'observation.form.qualityIssues' | translate"

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
@@ -1,0 +1,50 @@
+<div>
+	<label>
+		<laji-checkbox
+			[value]="asObserverOrEditor === 'asObserver' || asObserverOrEditor === 'asBoth'"
+			(valueChange)="onOwnFilterStateCheckboxChange('asObserver', $event)">
+		</laji-checkbox>
+		{{ 'observation.form.asObserver' | translate }}
+	</label>
+	<laji-info>
+		{{ 'observation.info.asObserver' | translate }}
+	</laji-info>
+</div>
+<div>
+	<label>
+		<laji-checkbox [value]="asObserverOrEditor === 'asEditor'  || asObserverOrEditor === 'asBoth'"
+			(valueChange)="onOwnFilterStateCheckboxChange('asEditor', $event)">
+		</laji-checkbox>
+		{{ 'observation.form.asEditor' | translate }}
+	</label>
+	<laji-info>
+		{{ 'observation.info.asEditor' | translate }}
+	</laji-info>
+</div>
+<div>
+<!-- 	<p>{{ 'observation.intro.noOwnObservations' | translate }}</p> -->
+	<label>
+		<laji-checkbox [value]="asObserverOrEditor === 'asNone'"
+			(valueChange)="onOwnFilterStateCheckboxChange('exclude', $event)">
+		</laji-checkbox>
+		{{ 'observation.form.excludeOwn' | translate }}
+	</label>
+	<laji-info>
+		{{ 'observation.info.asNotEditororObserver' | translate }}
+	</laji-info>
+</div>
+
+<ng-container *ngIf="asObserverOrEditor === 'asEditor' || asObserverOrEditor === 'asObserver' || asObserverOrEditor === 'asBoth'">
+	<laji-select
+		[selected]="[includeQualityIssues]"
+		(selectedChange)="onIncludeQualityIssuesChange($event)"
+		[multiple]="false"
+		[useFilter]="false"
+		[title]="'observation.form.qualityIssues' | translate"
+		[info]="'observation.info.qualityIssues' | translate"
+		[options]="[
+			{id: 'BOTH', value: ('observation.form.qualityIssuesBOTH' | translate)},
+			{id: 'NO_ISSUES', value: ('observation.form.qualityIssuesNO_ISSUES' | translate)},
+			{id: 'ONLY_ISSUES', value: ('observation.form.qualityIssuesONLY_ISSUES' | translate)}
+		]"></laji-select>
+</ng-container>

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.html
@@ -1,50 +1,48 @@
 <div>
-	<label>
-		<laji-checkbox
-			[value]="asObserverOrEditor === 'asObserver' || asObserverOrEditor === 'asBoth'"
-			(valueChange)="onOwnFilterStateCheckboxChange('asObserver', $event)">
-		</laji-checkbox>
-		{{ 'observation.form.asObserver' | translate }}
-	</label>
-	<laji-info>
-		{{ 'observation.info.asObserver' | translate }}
-	</laji-info>
+  <label>
+    <laji-checkbox
+      [value]="state.asObserver"
+      (valueChange)="onAsObserverChange($event)">
+    </laji-checkbox>
+    {{ 'observation.form.asObserver' | translate }}
+  </label>
+  <laji-info>
+    {{ 'observation.info.asObserver' | translate }}
+  </laji-info>
 </div>
 <div>
-	<label>
-		<laji-checkbox [value]="asObserverOrEditor === 'asEditor'  || asObserverOrEditor === 'asBoth'"
-			(valueChange)="onOwnFilterStateCheckboxChange('asEditor', $event)">
-		</laji-checkbox>
-		{{ 'observation.form.asEditor' | translate }}
-	</label>
-	<laji-info>
-		{{ 'observation.info.asEditor' | translate }}
-	</laji-info>
+  <label>
+    <laji-checkbox [value]="state.asEditor"
+      (valueChange)="onAsEditorChange($event)">
+    </laji-checkbox>
+    {{ 'observation.form.asEditor' | translate }}
+  </label>
+  <laji-info>
+    {{ 'observation.info.asEditor' | translate }}
+  </laji-info>
 </div>
 <div>
-<!-- 	<p>{{ 'observation.intro.noOwnObservations' | translate }}</p> -->
-	<label>
-		<laji-checkbox [value]="asObserverOrEditor === 'asNone'"
-			(valueChange)="onOwnFilterStateCheckboxChange('exclude', $event)">
-		</laji-checkbox>
-		{{ 'observation.form.excludeOwn' | translate }}
-	</label>
-	<laji-info>
-		{{ 'observation.info.asNotEditororObserver' | translate }}
-	</laji-info>
+  <label>
+    <laji-checkbox [value]="state.asNotEditorOrObserver"
+      (valueChange)="OnAsNotEditorOrObserver($event)">
+    </laji-checkbox>
+    {{ 'observation.form.excludeOwn' | translate }}
+  </label>
+  <laji-info>
+    {{ 'observation.info.asNotEditororObserver' | translate }}
+  </laji-info>
 </div>
-
-<ng-container *ngIf="asObserverOrEditor === 'asEditor' || asObserverOrEditor === 'asObserver' || asObserverOrEditor === 'asBoth'">
-	<laji-select
-		[selected]="[includeQualityIssues]"
-		(selectedChange)="onIncludeQualityIssuesChange($event)"
-		[multiple]="false"
-		[useFilter]="false"
-		[title]="'observation.form.qualityIssues' | translate"
-		[info]="'observation.info.qualityIssues' | translate"
-		[options]="[
-			{id: 'BOTH', value: ('observation.form.qualityIssuesBOTH' | translate)},
-			{id: 'NO_ISSUES', value: ('observation.form.qualityIssuesNO_ISSUES' | translate)},
-			{id: 'ONLY_ISSUES', value: ('observation.form.qualityIssuesONLY_ISSUES' | translate)}
-		]"></laji-select>
+<ng-container *ngIf="state.asEditor || state.asObserver || state.quality">
+  <laji-select
+    [selected]="state.quality ? [state.quality] : []"
+    (selectedChange)="onIncludeQualityIssuesChange($event)"
+    [multiple]="false"
+    [useFilter]="false"
+    [title]="'observation.form.qualityIssues' | translate"
+    [info]="'observation.info.qualityIssues' | translate"
+    [options]="[
+      {id: 'BOTH', value: ('observation.form.qualityIssuesBOTH' | translate)},
+      {id: 'NO_ISSUES', value: ('observation.form.qualityIssuesNO_ISSUES' | translate)},
+      {id: 'ONLY_ISSUES', value: ('observation.form.qualityIssuesONLY_ISSUES' | translate)}
+    ]"></laji-select>
 </ng-container>

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
@@ -1,83 +1,11 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ObservationFormQuery } from '../observation-form-query.interface';
 
-export type OwnFilterState = 'asObserver' | 'asEditor' | 'asBoth' | 'asNone' | 'unset';
 export type QualityIssuesFilterState = 'BOTH' | 'NO_ISSUES' | 'ONLY_ISSUES';
 
-type OwnFilterChangeLookup = {
-  [checkbox in ('asObserver' | 'asEditor' | 'exclude')]: {
-    [currentState in OwnFilterState]: {
-      [checkboxVal in ('true' | 'false')]: OwnFilterState
-    }
-  }
-};
-const ownFilterChangeLookup: OwnFilterChangeLookup = {
-  'asObserver': { // checkbox
-    'asObserver': { // current state
-      true: 'asObserver', // next state
-      false: 'unset'
-    },
-    'asEditor': {
-      true: 'asBoth',
-      false: 'asEditor'
-    },
-    'asBoth': {
-      true: 'asBoth',
-      false: 'asEditor'
-    },
-    'asNone': {
-      true: 'asObserver',
-      false: 'asNone'
-    },
-    'unset': {
-      true: 'asObserver',
-      false: 'unset'
-    }
-  },
-  'asEditor': { // checkbox
-    'asObserver': { // current state
-      true: 'asBoth', // next state
-      false: 'asObserver'
-    },
-    'asEditor': {
-      true: 'asEditor',
-      false: 'unset'
-    },
-    'asBoth': {
-      true: 'asBoth',
-      false: 'asObserver'
-    },
-    'asNone': {
-      true: 'asEditor',
-      false: 'asNone'
-    },
-    'unset': {
-      true: 'asEditor',
-      false: 'unset'
-    }
-  },
-  'exclude': { // checkbox
-    'asObserver': { // current state
-      true: 'asNone', // next state
-      false: 'asObserver'
-    },
-    'asEditor': {
-      true: 'asNone',
-      false: 'asEditor'
-    },
-    'asBoth': {
-      true: 'asNone',
-      false: 'asBoth'
-    },
-    'asNone': {
-      true: 'asNone',
-      false: 'unset'
-    },
-    'unset': {
-      true: 'asNone',
-      false: 'unset'
-    }
-  }
-};
+export type OwnFilterModel = Pick<ObservationFormQuery, 'asObserver' | 'asEditor' | 'asNotEditorOrObserver'>;
+
+type State = OwnFilterModel & { quality: QualityIssuesFilterState };
 
 @Component({
   selector: 'laji-own-observations-filter',
@@ -85,23 +13,65 @@ const ownFilterChangeLookup: OwnFilterChangeLookup = {
   styleUrls: ['./own-observations-filter.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class OwnObservationsFilterComponent {
-  @Input() asObserverOrEditor: OwnFilterState = 'unset';
-  @Input() includeQualityIssues: QualityIssuesFilterState = 'BOTH';
-  @Output() ownFilterChange = new EventEmitter<OwnFilterState>();
+export class OwnObservationsFilterComponent implements OnInit {
+  @Input() asObserver: ObservationFormQuery['asObserver'];
+  @Input() asEditor: ObservationFormQuery['asEditor'];
+  @Input() asNotEditorOrObserver: ObservationFormQuery['asNotEditorOrObserver'];
+  @Input() includeQualityIssues: QualityIssuesFilterState;
+  @Output() ownFilterChange = new EventEmitter<OwnFilterModel>();
   @Output() qualityIssuesFilterChange = new EventEmitter<QualityIssuesFilterState>();
+
+  state: State;
 
   constructor(private cdr: ChangeDetectorRef) {}
 
-  onOwnFilterStateCheckboxChange(cb: 'asObserver' | 'asEditor' | 'exclude', value: boolean) {
-    this.asObserverOrEditor = ownFilterChangeLookup[cb][this.asObserverOrEditor][value.toString()];
-    this.ownFilterChange.emit(this.asObserverOrEditor);
+  ngOnInit(): void {
+    this.state = {
+      asObserver: this.asObserver,
+      asEditor: this.asEditor,
+      asNotEditorOrObserver: this.asNotEditorOrObserver,
+      quality: this.includeQualityIssues
+    };
+  }
+
+  private updateState(state: Partial<State>) {
+    const nextState = {...this.state, ...state};
+    const {quality, ...ownFilter} = nextState;
+    console.log(nextState);
+    this.ownFilterChange.emit(ownFilter);
+    if (quality !== this.state.quality) {
+      this.qualityIssuesFilterChange.emit(quality);
+    }
+    this.state = nextState;
     this.cdr.markForCheck();
   }
 
+  private obsFormChange(state: Partial<OwnFilterModel>) {
+    const nextState = {...this.state, ...state};
+    const observerAndEditorSelected = (!this.state.asObserver || !this.state.asEditor) && nextState.asObserver && nextState.asEditor;
+    if (observerAndEditorSelected) {
+      nextState.quality = 'BOTH';
+    }
+    this.updateState(nextState);
+  }
+
+  onAsObserverChange(value: boolean) {
+    this.obsFormChange({asObserver: value, asNotEditorOrObserver: false});
+  }
+
+  onAsEditorChange(value: boolean) {
+     this.obsFormChange({asEditor: value, asNotEditorOrObserver: false});
+  }
+
+  OnAsNotEditorOrObserver(value: boolean) {
+    this.obsFormChange(value
+      ? {asObserver: false, asEditor: false, asNotEditorOrObserver: value}
+      : {asNotEditorOrObserver: value}
+    );
+  }
+
   onIncludeQualityIssuesChange(state: QualityIssuesFilterState[]) {
-    this.includeQualityIssues = state[0];
-    this.qualityIssuesFilterChange.emit(this.includeQualityIssues);
-    this.cdr.markForCheck();
+    console.log(state);
+    this.updateState({quality: state[0]});
   }
 }

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
@@ -1,11 +1,9 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { ObservationFormQuery } from '../observation-form-query.interface';
 
-export type QualityIssuesFilterState = 'BOTH' | 'NO_ISSUES' | 'ONLY_ISSUES';
-
 export type OwnFilterModel = Pick<ObservationFormQuery, 'asObserver' | 'asEditor' | 'asNotEditorOrObserver'>;
 
-type State = OwnFilterModel & { quality: QualityIssuesFilterState };
+type State = OwnFilterModel & { quality: string };
 
 @Component({
   selector: 'laji-own-observations-filter',
@@ -17,9 +15,9 @@ export class OwnObservationsFilterComponent implements OnInit {
   @Input() asObserver: ObservationFormQuery['asObserver'];
   @Input() asEditor: ObservationFormQuery['asEditor'];
   @Input() asNotEditorOrObserver: ObservationFormQuery['asNotEditorOrObserver'];
-  @Input() includeQualityIssues: QualityIssuesFilterState;
+  @Input() includeQualityIssues: string;
   @Output() ownFilterChange = new EventEmitter<OwnFilterModel>();
-  @Output() qualityIssuesFilterChange = new EventEmitter<QualityIssuesFilterState>();
+  @Output() qualityIssuesFilterChange = new EventEmitter<string>();
 
   state: State;
 
@@ -37,7 +35,6 @@ export class OwnObservationsFilterComponent implements OnInit {
   private updateState(state: Partial<State>) {
     const nextState = {...this.state, ...state};
     const {quality, ...ownFilter} = nextState;
-    console.log(nextState);
     this.ownFilterChange.emit(ownFilter);
     if (quality !== this.state.quality) {
       this.qualityIssuesFilterChange.emit(quality);
@@ -70,8 +67,7 @@ export class OwnObservationsFilterComponent implements OnInit {
     );
   }
 
-  onIncludeQualityIssuesChange(state: QualityIssuesFilterState[]) {
-    console.log(state);
+  onIncludeQualityIssuesChange(state: string[]) {
     this.updateState({quality: state[0]});
   }
 }

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
@@ -1,0 +1,107 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, Output } from '@angular/core';
+
+export type OwnFilterState = 'asObserver' | 'asEditor' | 'asBoth' | 'asNone' | 'unset';
+export type QualityIssuesFilterState = 'BOTH' | 'NO_ISSUES' | 'ONLY_ISSUES';
+
+type OwnFilterChangeLookup = {
+  [checkbox in ('asObserver' | 'asEditor' | 'exclude')]: {
+    [currentState in OwnFilterState]: {
+      [checkboxVal in ('true' | 'false')]: OwnFilterState
+    }
+  }
+};
+const ownFilterChangeLookup: OwnFilterChangeLookup = {
+  'asObserver': { // checkbox
+    'asObserver': { // current state
+      true: 'asObserver', // next state
+      false: 'unset'
+    },
+    'asEditor': {
+      true: 'asBoth',
+      false: 'asEditor'
+    },
+    'asBoth': {
+      true: 'asBoth',
+      false: 'asEditor'
+    },
+    'asNone': {
+      true: 'asObserver',
+      false: 'asNone'
+    },
+    'unset': {
+      true: 'asObserver',
+      false: 'unset'
+    }
+  },
+  'asEditor': { // checkbox
+    'asObserver': { // current state
+      true: 'asBoth', // next state
+      false: 'asObserver'
+    },
+    'asEditor': {
+      true: 'asEditor',
+      false: 'unset'
+    },
+    'asBoth': {
+      true: 'asBoth',
+      false: 'asObserver'
+    },
+    'asNone': {
+      true: 'asEditor',
+      false: 'asNone'
+    },
+    'unset': {
+      true: 'asEditor',
+      false: 'unset'
+    }
+  },
+  'exclude': { // checkbox
+    'asObserver': { // current state
+      true: 'asNone', // next state
+      false: 'asObserver'
+    },
+    'asEditor': {
+      true: 'asNone',
+      false: 'asEditor'
+    },
+    'asBoth': {
+      true: 'asNone',
+      false: 'asBoth'
+    },
+    'asNone': {
+      true: 'asNone',
+      false: 'unset'
+    },
+    'unset': {
+      true: 'asNone',
+      false: 'unset'
+    }
+  }
+};
+
+@Component({
+  selector: 'laji-own-observations-filter',
+  templateUrl: `./own-observations-filter.component.html`,
+  styleUrls: ['./own-observations-filter.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class OwnObservationsFilterComponent {
+  @Input() asObserverOrEditor: OwnFilterState = 'unset';
+  @Input() includeQualityIssues: QualityIssuesFilterState = 'BOTH';
+  @Output() ownFilterChange = new EventEmitter<OwnFilterState>();
+  @Output() qualityIssuesFilterChange = new EventEmitter<QualityIssuesFilterState>();
+
+  constructor(private cdr: ChangeDetectorRef) {}
+
+  onOwnFilterStateCheckboxChange(cb: 'asObserver' | 'asEditor' | 'exclude', value: boolean) {
+    this.asObserverOrEditor = ownFilterChangeLookup[cb][this.asObserverOrEditor][value.toString()];
+    this.ownFilterChange.emit(this.asObserverOrEditor);
+    this.cdr.markForCheck();
+  }
+
+  onIncludeQualityIssuesChange(state: QualityIssuesFilterState[]) {
+    this.includeQualityIssues = state[0];
+    this.qualityIssuesFilterChange.emit(this.includeQualityIssues);
+    this.cdr.markForCheck();
+  }
+}

--- a/projects/laji/src/app/+observation/observation-component.module.ts
+++ b/projects/laji/src/app/+observation/observation-component.module.ts
@@ -38,6 +38,7 @@ import { TechnicalNewsModule } from '../shared-modules/technical-news/technical-
 import { InfoPageModule } from '../shared-modules/info-page/info-page.module';
 import {SelectModule} from '../shared-modules/select/select.module';
 import { SelectCollectionsModule } from '../shared-modules/select-collections/select-collections.module';
+import { OwnObservationsFilterComponent } from './form/own-observations-filter/own-observations-filter.component';
 
 @NgModule({
   imports: [
@@ -81,7 +82,8 @@ import { SelectCollectionsModule } from '../shared-modules/select-collections/se
     ToSafeQueryPipe,
     FormSampleComponent,
     HorizontalChartComponent,
-    DateFormComponent
+    DateFormComponent,
+    OwnObservationsFilterComponent
   ],
   exports: [
     ObservationViewComponent

--- a/projects/laji/src/app/+observation/search-query.service.ts
+++ b/projects/laji/src/app/+observation/search-query.service.ts
@@ -277,7 +277,16 @@ export class SearchQueryService implements SearchQueryInterface {
       result['target'] = (result['target'] as string[]).map(target => target.replace(/http:\/\/tun\.fi\//g, ''));
     }
 
-    if (result.editorPersonToken && result.observerPersonToken && result.observerPersonToken === result.editorPersonToken) {
+    if (
+      (result.editorOrObserverPersonToken && (result.editorPersonToken || result.observerPersonToken))
+      || result.editorOrObserverIsNotPersonToken
+    ) {
+      delete result.editorOrObserverPersonToken;
+    } else if (
+      result.editorPersonToken
+      && result.observerPersonToken
+      && result.observerPersonToken === result.editorPersonToken
+    ) {
       result.editorOrObserverPersonToken = result.observerPersonToken;
       delete result.editorPersonToken;
       delete result.observerPersonToken;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180269525

Extracted a component from observation-form and refactored the logic as well as fixed the "cannot deselect" bug.

About the `ownFilterChangeLookup`... I think a state lookup table like this is much easier to read than some `if` spaghetti (like we used to have and I really struggled to comprehend), even if there's some redundancy.