### PR TITLE
Project form latest docs fix [#180618581]

### DIFF
--- a/projects/laji/src/app/+project-form/about/about.component.html
+++ b/projects/laji/src/app/+project-form/about/about.component.html
@@ -36,7 +36,7 @@
         {{ 'haseka.mobile.newObservation' | translate }}
       </button>
     </ng-container>
-    <laji-haseka-latest [forms]="[data.form.id]"
+    <laji-haseka-latest [formID]="data.form.id"
                         [showFormNames]="false"
                         [complainLocality]="false"
                         (showViewer)="showDocumentViewer($event)"

--- a/projects/laji/src/app/+project-form/project-form.component.html
+++ b/projects/laji/src/app/+project-form/project-form.component.html
@@ -11,7 +11,7 @@
             <small *ngIf="vm.form.options?.secondaryCopy"><br>{{ 'datasets.secondary.subtitle' | translate }}</small>
           </h5>
           <ng-container *ngTemplateOutlet="sidebarLinks; context:{ $implicit: vm.navLinks}"></ng-container>
-          <laji-haseka-latest [forms]="[vm.form.id]"
+          <laji-haseka-latest [formID]="vm.form.id"
                               [tmpOnly]="false"
                               (showViewer)="showDocumentViewer($event)"
                               [showFormNames]="false"

--- a/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
@@ -47,7 +47,10 @@ export class LatestDocumentsFacade implements OnDestroy {
 
   private readonly localUpdateSub: Subscription;
   private updateSub: Subscription;
+  private updateSubKey: string | undefined;
   private remoteRefresh;
+
+  private formID: string | undefined;
 
   constructor(
     private documentApi: DocumentApi,
@@ -69,7 +72,12 @@ export class LatestDocumentsFacade implements OnDestroy {
     }
   }
 
-  update(): void {
+  update(formID?: string): void {
+    this.formID = formID;
+    this._update();
+  }
+
+  private _update(): void {
     this.updateLocal();
     this.updateRemote();
     if (this.remoteRefresh) {
@@ -86,7 +94,7 @@ export class LatestDocumentsFacade implements OnDestroy {
     this.userService.user$.pipe(
       take(1),
       mergeMap(person => this.documentStorage.removeItem(id, person)),
-      tap(() => this.update())
+      tap(() => this._update())
     ).subscribe();
   }
 
@@ -94,6 +102,7 @@ export class LatestDocumentsFacade implements OnDestroy {
     this.userService.user$.pipe(
       take(1),
       mergeMap(p => this.documentStorage.getAll(p, 'onlyTmp').pipe(
+        map(tmps => this.formID ? tmps.filter(tmp => tmp.formID === this.formID) : tmps),
         mergeMap(tmps => this.getAllForms().pipe(
           map(forms => tmps.map(tmp => ({
             document: tmp,
@@ -106,11 +115,12 @@ export class LatestDocumentsFacade implements OnDestroy {
   }
 
   private updateRemote() {
-    if (this.updateSub) {
+    if (this.updateSub && this.updateSubKey === this.getSubKey()) {
       return;
     }
+    this.updateSubKey = this.getSubKey();
     this.updateState({..._state, loading: true});
-    this.updateSub = this.documentApi.findAll(this.userService.getToken(), '1', '10').pipe(
+    this.updateSub = this.documentApi.findAll(this.userService.getToken(), '1', '10', {formID: this.formID}).pipe(
       map(docRes => docRes.results),
       mergeMap(documents => this.checkForLocalData(documents)),
       catchError((e) => {
@@ -121,6 +131,10 @@ export class LatestDocumentsFacade implements OnDestroy {
       this.updateState({..._state, latest, loading: false});
       delete this.updateSub;
     });
+  }
+
+  getSubKey() {
+    return this.formID;
   }
 
   private getAllForms(): Observable<{[id: string]: Form.List}> {

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
@@ -1,8 +1,7 @@
-import { map } from 'rxjs/operators';
-import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnChanges, OnInit, Output } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Document } from '../../../shared/model/Document';
 import { Observable } from 'rxjs';
-import { ILatestDocument, LatestDocumentsFacade } from '../latest-documents.facade';
+import { LatestDocumentsFacade } from '../latest-documents.facade';
 
 
 @Component({
@@ -11,9 +10,9 @@ import { ILatestDocument, LatestDocumentsFacade } from '../latest-documents.faca
   styleUrls: ['./haseka-users-latest.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class UsersLatestComponent implements OnInit, OnChanges {
+export class UsersLatestComponent implements OnInit {
   @Input() tmpOnly = false;
-  @Input() forms: string[];
+  @Input() formID: string;
   @Input() showFormNames = true;
   @Input() complainLocality: boolean;
   @Input() staticWidth: number = undefined;
@@ -21,8 +20,8 @@ export class UsersLatestComponent implements OnInit, OnChanges {
   @Output() showViewer = new EventEmitter<Document>();
 
   public loading$: Observable<boolean>;
-  public tmpDocuments$: Observable<ILatestDocument[]>;
-  public latest$: Observable<ILatestDocument[]>;
+  public tmpDocuments$ = this.latestFacade.tmpDocuments$;
+  public latest$ = this.latestFacade.latest$;
   public formsById = {};
 
   constructor(
@@ -32,26 +31,7 @@ export class UsersLatestComponent implements OnInit, OnChanges {
   }
 
   ngOnInit(): void {
-    this.latestFacade.update();
-    this.updateDocumentList();
-    this.updateTempDocumentList();
-  }
-
-  ngOnChanges() {
-    this.updateDocumentList();
-    this.updateTempDocumentList();
-  }
-
-  updateTempDocumentList() {
-    this.tmpDocuments$ = this.latestFacade.tmpDocuments$.pipe(
-      map(documents => this.forms ? documents.filter(res => this.forms.indexOf(res.document.formID) > -1) : documents)
-    );
-  }
-
-  updateDocumentList() {
-    this.latest$ = this.latestFacade.latest$.pipe(
-      map(documents => this.forms ? documents.filter(res => this.forms.indexOf(res.document.formID) > -1) : documents)
-    );
+    this.latestFacade.update(this.formID);
   }
 
   discardTempDocument(document) {

--- a/projects/laji/src/app/shared-modules/own-submissions/own-submissions.component.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/own-submissions.component.ts
@@ -321,11 +321,13 @@ export class OwnSubmissionsComponent implements OnChanges, OnInit, OnDestroy {
     if (this.namedPlace) {
       _query.namedPlace = this.namedPlace;
     }
+    if (query.year) {
+      _query.observationYear = String(query.year);
+    }
     return this.documentApi.findAll(
       this.userService.getToken(),
       String(page),
       String(10000),
-      query.year ? String(query.year) : undefined,
       _query
     ).pipe(
       switchMap(result => {

--- a/projects/laji/src/app/shared/api/DocumentApi.ts
+++ b/projects/laji/src/app/shared/api/DocumentApi.ts
@@ -101,7 +101,7 @@ export class DocumentApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public findAll(userToken: string, page?: string, pageSize?: string, observationYear?: string, extraHttpRequestParams?: any): Observable<PagedResult<Document>> {
+  public findAll(userToken: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<Document>> {
     const path = this.basePath + '/documents';
 
     const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
@@ -126,10 +126,6 @@ export class DocumentApi {
         results: [],
         total: 0
       });
-    }
-
-    if (observationYear !== undefined) {
-      queryParameters['observationYear'] = observationYear;
     }
 
     return this.http.get<PagedResult<Document>>(path, {params: queryParameters});


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/180618581
Demo: https://180618581.dev.laji.fi/project/MHL.51

The project form page is supposed the latest docs in the sidebar (or if the form is a mobile form, on the about page). It worked ok for local tmp docs, but the remote docs showed only the form's docs if they happened to be very recent (in the 10 docs you have last reported). The fix was to pass the formID to the query being made.