### PR TITLE
Observation year chart doesn't skip years that don't have data

### DIFF
--- a/projects/laji/src/app/shared-modules/observation-result/observation-year-chart/observation-year-chart.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-year-chart/observation-year-chart.component.ts
@@ -162,26 +162,37 @@ export class ObservationYearChartComponent implements OnChanges, OnDestroy, OnIn
 
       this.allDataNew = [{data: [], backgroundColor: [], label: this.translate.instant('all') }];
       let prevYear: number;
+
       res.map(r => {
         const year = parseInt(r.aggregateBy['gathering.conversions.year'], 10);
         const count = r.count;
         const individual = r.individualCountSum;
 
-        this.allSubData.push(this.onlyCount === null ? count : this.onlyCount ? count : individual);
-        this.subBarChartLabels.push('' + year);
-        this.resultList.push({'count': count, 'individualCountSum': individual, 'year': year});
-        if (year < 1970) {
-          this.splitIdx++;
+        let nextYear = prevYear ? prevYear + 1 : year;
+        while (nextYear < year) {
+          this.addYearToResults(nextYear, 0, 0);
+          nextYear += 1;
         }
+        this.addYearToResults(year, count, individual);
 
         prevYear = year;
       });
+
       this.createSubArrayChart();
       this.hasData.emit(this.allDataNew[0].data.length > 0);
       // check emit
       this.cd.markForCheck();
     });
     this.barChartOptionsYear.animation.duration = 0;
+  }
+
+  private addYearToResults(year: number, count: number, individual: number) {
+    this.allSubData.push(this.onlyCount === null ? count : this.onlyCount ? count : individual);
+    this.subBarChartLabels.push('' + year);
+    this.resultList.push({'count': count, 'individualCountSum': individual, 'year': year});
+    if (year < 1970) {
+      this.splitIdx++;
+    }
   }
 
   xAxisTickFormatting(value: number) {


### PR DESCRIPTION
"Observations per year" chart shows also years that don't have data.

Task:
https://www.pivotaltracker.com/story/show/180570592

Testable here:
https://180570592.dev.laji.fi/en/observation/statistics?informalTaxonGroupId=MVL.582