### PR TITLE
Fix prefilled forms can be only used once

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -376,7 +376,7 @@ export class DocumentFormFacade {
         mergeMap(local => this.documentService.findById(documentID).pipe(
           map((document: Document) => {
             if (document.isTemplate) {
-              const doc = this.documentService.removeMeta(Util.clone(document), ['isTemplate', 'templateName', 'templateDescription']);
+              const doc = this.documentService.removeMeta(document, ['isTemplate', 'templateName', 'templateDescription']);
               return {
                 document: form.options?.prepopulatedDocument
                   ? deepmerge(form.options?.prepopulatedDocument, doc, { arrayMerge: Util.arrayCombineMerge })

--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -376,7 +376,7 @@ export class DocumentFormFacade {
         mergeMap(local => this.documentService.findById(documentID).pipe(
           map((document: Document) => {
             if (document.isTemplate) {
-              const doc = this.documentService.removeMeta(document, ['isTemplate', 'templateName', 'templateDescription']);
+              const doc = this.documentService.removeMeta(Util.clone(document), ['isTemplate', 'templateName', 'templateDescription']);
               return {
                 document: form.options?.prepopulatedDocument
                   ? deepmerge(form.options?.prepopulatedDocument, doc, { arrayMerge: Util.arrayCombineMerge })

--- a/projects/laji/src/app/+project-form/submissions/statistics/common/accepted-document-approval/accepted-document-approval.component.ts
+++ b/projects/laji/src/app/+project-form/submissions/statistics/common/accepted-document-approval/accepted-document-approval.component.ts
@@ -205,8 +205,8 @@ export class AcceptedDocumentApprovalComponent implements OnChanges {
       }, []).sort((a, b) => b.path.join('.').localeCompare(a.path.join('')));
     };
 
-    const document = this.documentService.removeMeta(JSON.parse(JSON.stringify(this.document)), diffIgnoredFields);
-    const acceptedDocument = this.documentService.removeMeta(JSON.parse(JSON.stringify(this.namedPlace.acceptedDocument || {})), diffIgnoredFields);
+    const document = this.documentService.removeMeta(this.document, diffIgnoredFields);
+    const acceptedDocument = this.documentService.removeMeta(this.namedPlace.acceptedDocument || {}, diffIgnoredFields);
     const geometryDiffers = !equals(getGeometry(this.document), getGeometry((this.namedPlace.acceptedDocument || {})));
     const otherwiseDiffers = !equals(document, acceptedDocument);
     const differs = otherwiseDiffers || geometryDiffers;

--- a/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
@@ -62,8 +62,7 @@ export class DocumentService {
 
   saveTemplate(templateData: TemplateForm): Observable<Document> {
     return this.formService.getForm(templateData.document.formID).pipe(switchMap(form => {
-      const template: Document = Util.clone(templateData.document);
-      this.removeMeta(template, form.excludeFromCopy);
+      const template: Document = this.removeMeta(templateData.document, form.excludeFromCopy);
       template.isTemplate = true;
       template.templateName = templateData.name;
       template.templateDescription = templateData.description;
@@ -72,6 +71,8 @@ export class DocumentService {
   }
 
   removeMeta(document: any, remove = []): any {
+    document = Util.clone(document);
+
     if (['$.id', '$..id'].every(idField => remove.indexOf(idField) === -1)) {
       remove = [...remove, '$..id', '$..dateEdited', '$..dateCreated', '$..publicityRestrictions', '$..locked'];
     }


### PR DESCRIPTION
Pivotal task: https://www.pivotaltracker.com/story/show/180748974
Testable here: https://180748974.dev.laji.fi/vihko/templates

Fixes a bug where prefilled forms can only be used once without logging out or refreshing the page. The problem was that the `documentService.removeMeta` function modifies the document object directly so we need to make a copy of it before calling it.