### PR TITLE
Omnisearch bold bug [#180807563]

### DIFF
--- a/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
+++ b/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
@@ -99,7 +99,7 @@ export class TaxonAutocompleteService {
   }
 
   private addBold(original: string, substring: string): string {
-    return original.replace(new RegExp(`(${substring})`, 'i'), '<b>$1</b>');
+    return substring.split(' ').reduce((o, word) => o.replace(new RegExp(`(${word})`, 'i'), '<b>$1</b>'), original);
   }
 
   private capitalizeFirstLetter(string: string) {

--- a/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
+++ b/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
@@ -99,16 +99,7 @@ export class TaxonAutocompleteService {
   }
 
   private addBold(original: string, substring: string): string {
-    const words = substring.split(' ');
-    words.forEach(el => {
-      const newOriginal = original.toLowerCase();
-      const newString = el.toLowerCase();
-      const index = newOriginal.indexOf(newString);
-      original = index > -1 ?
-      (original.slice(0, index) + '<b>' + original.slice(index, index + el.length) + '</b>' + original.slice(index + el.length))
-      : original;
-    });
-    return original;
+    return original.replace(new RegExp(`(${substring})`, 'i'), '<b>$1</b>');
   }
 
   private capitalizeFirstLetter(string: string) {

--- a/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
+++ b/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
@@ -99,7 +99,27 @@ export class TaxonAutocompleteService {
   }
 
   private addBold(original: string, substring: string): string {
-    return substring.split(' ').reduce((o, word) => o.replace(new RegExp(`(${word})`, 'i'), '<b>$1</b>'), original);
+    // Pairs of bolded words and whether they've been bolded already (goal is to bold words only once).
+    const boldedWords: [string, boolean][] = original.split(' ').map(w => [w, false]);
+
+    substring.split(' ').forEach(w => {
+      wordLoop: for (const i in boldedWords) { // tslint:disable-line forin
+        const [_w, bolded] = boldedWords[i];
+        if (bolded) {
+          continue;
+        }
+        const startRegexp = new RegExp(`^(${w})`, 'i');
+        const endRegexp = new RegExp(`(${w})$`, 'i');
+        for (const regexp of [startRegexp, endRegexp]) {
+          const match = _w.match(regexp);
+          if (match) {
+            boldedWords[i] = [_w.replace(regexp, '<b>$1</b>'), true];
+            break wordLoop;
+          }
+        }
+      }
+    });
+    return boldedWords.reduce((joined, [w]) => joined.concat(' ', w), '');
   }
 
   private capitalizeFirstLetter(string: string) {


### PR DESCRIPTION
Task https://www.pivotaltracker.com/story/show/180807563
Demo https://180807563.dev.laji.fi/

This PR improves the omni search bolding search word matches by following ways:

1. Fixes bug when searching "rosa b" (`<b>` tags messed up in results)
2. Tokenizes the search words, so that search for "ly ly" bolds both words from the result "**Ly**rella **ly**ra"
3. Bolds start or end of word (e.g. search for "rosa a" bolds as "**Rosa a**lba" and "**Rosa** bland**a**")