### PR TITLE
Latest docs bug on project form [#180846101]

### DIFF
--- a/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
@@ -72,12 +72,12 @@ export class LatestDocumentsFacade implements OnDestroy {
     }
   }
 
-  update(formID?: string): void {
+  setFormID(formID?: string): void {
     this.formID = formID;
-    this._update();
+    this.update();
   }
 
-  private _update(): void {
+  update(): void {
     this.updateLocal();
     this.updateRemote();
     if (this.remoteRefresh) {
@@ -94,7 +94,7 @@ export class LatestDocumentsFacade implements OnDestroy {
     this.userService.user$.pipe(
       take(1),
       mergeMap(person => this.documentStorage.removeItem(id, person)),
-      tap(() => this._update())
+      tap(() => this.update())
     ).subscribe();
   }
 

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
@@ -31,7 +31,7 @@ export class UsersLatestComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.latestFacade.update(this.formID);
+    this.latestFacade.setFormID(this.formID);
   }
 
   discardTempDocument(document) {


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/180846101
Demo: https://180846101.dev.laji.fi/project/MHL.3/form

The bug being fixed here is after submitting a new document for a project form, the latest docs in the sidebar will show all documents instead of just that form's documents. I added a `setFormID()` method to the latest docs facade, so that the `update()` method can be called without resetting the formID (previously the `update()` method updated the formID for the facade). 