### PR TITLE
Taxon identification fix 180717763

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-children-data-source.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-children-data-source.ts
@@ -36,8 +36,7 @@ export class IdentificationChildrenDataSource extends DataSource<Taxonomy> {
   connect(collectionViewer: CollectionViewer): Observable<Taxonomy[]> {
     return collectionViewer.viewChange.pipe(
       takeUntil(this.unsubscribe$),
-      map(range => clampRange(range, 0, this.children.length - 1)),
-      map(range => Array.from(rangeToIter(range))),
+      map(range => this.children.length > 0 ? Array.from(rangeToIter(clampRange(range, 0, this.children.length - 1))) : []),
       concatMap(indices => forkJoin(...indices.map(i => this.childByIdx$(i))))
     );
   }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
@@ -30,7 +30,7 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
 
   private children$: Observable<Taxonomy[]> = this.facade.childDataSource$.pipe(
     filter(d => d !== undefined),
-    tap(() => this.loading = false),
+    tap(() => { this.loading = false; this.cdr.markForCheck(); }),
     switchMap(d => d.connect(this.collectionViewer)),
     distinctUntilChanged()
   );

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges, Vi
 import { Taxonomy } from '../../../../shared/model/Taxonomy';
 import { TaxonIdentificationFacade } from './taxon-identification.facade';
 import { Observable, merge, Subscription, BehaviorSubject, fromEvent, Subject } from 'rxjs';
-import { map, switchMap, distinctUntilChanged, filter, startWith, take } from 'rxjs/operators';
+import { map, switchMap, distinctUntilChanged, filter, startWith, take, tap } from 'rxjs/operators';
 import { DOCUMENT } from '@angular/common';
 import { CollectionViewer } from '@angular/cdk/collections';
 import { WINDOW } from '@ng-toolkit/universal';
@@ -26,9 +26,11 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
 
   children: Taxonomy[] = [];
   totalChildren$: Observable<number> = this.facade.totalChildren$;
+  loading = true;
 
   private children$: Observable<Taxonomy[]> = this.facade.childDataSource$.pipe(
     filter(d => d !== undefined),
+    tap(() => this.loading = false),
     switchMap(d => d.connect(this.collectionViewer)),
     distinctUntilChanged()
   );
@@ -54,8 +56,6 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
     )
   };
 
-  loading = true;
-
   constructor(
     private facade: TaxonIdentificationFacade,
     private cdr: ChangeDetectorRef,
@@ -77,7 +77,6 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
     this.subscription.add(
       this.children$.subscribe((t) => {
         this.children = t;
-        this.loading = false;
         this.cdr.markForCheck();
         this.totalChildren$.pipe(take(1)).subscribe(total => {
           if (this.children.length < total) {

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 import { Observable, BehaviorSubject, Subject, of } from 'rxjs';
-import { map, distinctUntilChanged, tap, takeUntil, switchMap } from 'rxjs/operators';
+import { map, distinctUntilChanged, tap, takeUntil, switchMap, take } from 'rxjs/operators';
 import { Taxonomy } from 'projects/laji/src/app/shared/model/Taxonomy';
 import { Taxon } from '../../../../../../../laji-api-client/src/lib/models';
 import { TaxonomyApi } from 'projects/laji/src/app/shared/api/TaxonomyApi';
@@ -70,7 +70,7 @@ export class TaxonIdentificationFacade implements OnDestroy {
   }
 
   loadChildDataSource(root: Taxonomy) {
-    this.childDataSource$.pipe(takeUntil(this.unsubscribe$)).subscribe(d => {
+    this.childDataSource$.pipe(take(1)).subscribe(d => {
       if (d) {
         d.disconnect();
       }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
@@ -33,12 +33,12 @@ const isMainRank = (r: Taxon.TaxonRankEnum): boolean => {
   return rankWhiteList.includes(r);
 };
 
-const findNearestParentMainRankIdx = (root: Taxon.TaxonRankEnum): number => {
-    const ranks = Object.values(Taxon.TaxonRankEnum);
-    const idx = ranks.indexOf(root);
-    const rank0 = ranks.slice(idx).find(rank => isMainRank(rank));
-    return rankWhiteList.findIndex(r => r === rank0) - 1;
+const taxonEnumReversed = Object.values(Taxon.TaxonRankEnum).reverse();
 
+const findNearestParentMainRankIdx = (root: Taxon.TaxonRankEnum): number => {
+    const idx = taxonEnumReversed.indexOf(root);
+    const parent = taxonEnumReversed.slice(idx + 1).find(rank => isMainRank(rank));
+    return rankWhiteList.findIndex(r => r === parent);
 };
 
 const getSubMainRank = (root: Taxon.TaxonRankEnum): Taxon.TaxonRankEnum => {
@@ -48,7 +48,7 @@ const getSubMainRank = (root: Taxon.TaxonRankEnum): Taxon.TaxonRankEnum => {
     // find the closest parent that is mainrank instead
     rootIdx = findNearestParentMainRankIdx(root);
   }
-  return rankWhiteList[rootIdx + 1];
+  return rankWhiteList[rootIdx + 1] || rankWhiteList[rootIdx];
 };
 
 @Injectable()
@@ -95,7 +95,7 @@ export class TaxonIdentificationFacade implements OnDestroy {
       }
     ).pipe(
       switchMap(res => {
-        if (res.total > 0) {
+        if (res.total > 0 || rank === 'MX.species') {
           return of({...res, rank});
         } else {
           return this.getTaxaObservable$(id, getSubMainRank(rank));


### PR DESCRIPTION
- Refactored sub-mainrank finding logic (the closest main rank that is below the rank of the taxon)
- Fixed behavior when taxon rank is below the lowest mainrank
- Fixed old data source being potentially disconnected more than once
- Made sure the loader disappears after the sub-mainrank has been received regardless of if there are any child species

https://www.pivotaltracker.com/story/show/180717763
https://180717763.dev.laji.fi/taxon/MX.5073946/identification