### PR TITLE
Fix null pointer for tree select modal [#181170753]

### DIFF
--- a/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.ts
+++ b/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.ts
@@ -50,7 +50,7 @@ export abstract class ExtendedGroupSelectComponent<T extends Group> implements O
   }
 
   set value(v: any) {
-    if (v !== this.includedOptions[0]) {
+    if (v && v !== this.includedOptions[0]) {
       this.includedOptions[0] = v;
       this.excludedOptions = [];
     }

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select-modal/tree-select-modal.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select-modal/tree-select-modal.component.ts
@@ -99,6 +99,10 @@ export class TreeSelectModalComponent implements OnInit {
     this.includedOptions.forEach(key => {
       const node = this.treeModel.getNodeById(key);
 
+      if (!node) {
+        return;
+      }
+
       this.initializeNode(this.treeModel, node, 'initalizing', 'included');
       this.expandParents(this.treeModel, node, null);
     });


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181170753

Not entirely sure if there could be more bugs related to this (the issue seems to stem from that `includedOptions` and the `treeModel` ids are out of sync?), but at least the null pointer is fixed.