### PR TITLE
Fix observation-form taxon list changes are handled in separate method [#182206341]

### DIFF
--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -397,13 +397,17 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     }
   }
 
-  updateSearchQuery(field, value) {
-    this.query[field] = value;
+  onTaxonListChange(value) {
     this.selectedNameTaxon = this.selectedNameTaxon.filter(item => {
       if (value.indexOf(item.id) > -1) {
         return item;
       }
     });
+    this.updateSearchQuery('target', value);
+  }
+
+  updateSearchQuery(field, value) {
+    this.query[field] = value;
     this.onQueryChange();
   }
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/182206341

The problem was that the `observation-form` taxon pill list changes were handled with `updateSearchQuery()` method, which is used by many other parts of the component to update the search query. The bug surfaced only now because `updateSearchQuery()` has before the polygon search feature received only `string` values (now it receives a `number` from the coordinates intersection buttons, and the `value.indexOf` check fails.