### PR TITLE
Fix document-form annotation cache

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -509,11 +509,11 @@ export class DocumentFormFacade {
   }
 
   private getAnnotations(documentID: string, page = 1, results = []): Observable<Annotation[]> {
-    if (this.annotationCache[documentID]) {
-      return this.annotationCache[documentID];
+    if (this.annotationCache[this.getAnnotationCacheKey(documentID, page)]) {
+      return this.annotationCache[this.getAnnotationCacheKey(documentID, page)];
     }
 
-    this.annotationCache[documentID] = (!documentID || FormService.isTmpId(documentID))
+    this.annotationCache[this.getAnnotationCacheKey(documentID, page)] = (!documentID || FormService.isTmpId(documentID))
     ?  of([])
     : this.lajiApi.getList(
       LajiApi.Endpoints.annotations,
@@ -526,6 +526,10 @@ export class DocumentFormFacade {
       shareReplay(),
     );
 
-    return this.annotationCache[documentID];
+    return this.annotationCache[this.getAnnotationCacheKey(documentID, page)];
+  }
+
+  private getAnnotationCacheKey(documentID: string, page: number) {
+    return documentID + page;
   }
 }

--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -509,11 +509,12 @@ export class DocumentFormFacade {
   }
 
   private getAnnotations(documentID: string, page = 1, results = []): Observable<Annotation[]> {
-    if (this.annotationCache[this.getAnnotationCacheKey(documentID, page)]) {
-      return this.annotationCache[this.getAnnotationCacheKey(documentID, page)];
+    const cacheKey = documentID + page;
+    if (this.annotationCache[cacheKey]) {
+      return this.annotationCache[cacheKey];
     }
 
-    this.annotationCache[this.getAnnotationCacheKey(documentID, page)] = (!documentID || FormService.isTmpId(documentID))
+    this.annotationCache[cacheKey] = (!documentID || FormService.isTmpId(documentID))
     ?  of([])
     : this.lajiApi.getList(
       LajiApi.Endpoints.annotations,
@@ -526,10 +527,6 @@ export class DocumentFormFacade {
       shareReplay(),
     );
 
-    return this.annotationCache[this.getAnnotationCacheKey(documentID, page)];
-  }
-
-  private getAnnotationCacheKey(documentID: string, page: number) {
-    return documentID + page;
+    return this.annotationCache[cacheKey];
   }
 }


### PR DESCRIPTION
Document form failed for documents that had so many annotations that they resulted in multiple paged requests. I added the page to the annotation cache key, so it works.

This is hard to debug, but I think the error is so obvious that a simple code review is enough. I tested that it works. 