### PR TITLE
Protractor tests fail on console errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16939,6 +16939,15 @@
         }
       }
     },
+    "protractor-console-plugin": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/protractor-console-plugin/-/protractor-console-plugin-0.1.1.tgz",
+      "integrity": "sha1-dJ2pWwaV3t5DtQ/vP6+fC2KkfJY=",
+      "dev": true,
+      "requires": {
+        "q": "^1.4.1"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -206,6 +206,7 @@
     "patch-package": "^6.4.7",
     "postinstall-prepare": "^1.0.1",
     "protractor": "^7.0.0",
+    "protractor-console-plugin": "^0.1.1",
     "redis": "^3.1.2",
     "redlock": "^4.2.0",
     "regexp-replace-loader": "^1.0.1",

--- a/projects/laji/e2e/protractor.conf.js
+++ b/projects/laji/e2e/protractor.conf.js
@@ -66,9 +66,15 @@ exports.config = {
     jasmine.getEnv().addReporter(junitReporter);
     browser.driver.manage().window().setSize(width, height);
   },
-  onComplete() {
-    browser.driver.close().then(function(){
-      browser.driver.quit();
-    });
-  }
+  plugins: [{
+    package: 'protractor-console-plugin',
+    exclude: [
+      /node_modules_laji-form/, // laji-form internal bug
+      /reading '_leaflet_pos'/, // Leaflet internal bug
+      /Failed to load resource: the server responded with a status of /, // Behaviour of failing resources might be intentionally tested.
+      /fbcdn/, // Facebook widget
+      /Error while waiting for Protractor/ // Test framework bugs are not bugs in the app
+    ],
+    logWarnings: false
+  }],
 };


### PR DESCRIPTION
Easy way to catch more bugs. I excluded some 3rd party issues, and removed the `onComplete` hook from protractor config since it caused the `protractor-console-plugin` not to work and I don't see why the hook would be necessary.