### PR TITLE
Fix form permission service logic for admins [#182329892]

### DIFF
--- a/projects/laji/src/app/shared/service/form-permission.service.ts
+++ b/projects/laji/src/app/shared/service/form-permission.service.ts
@@ -104,18 +104,14 @@ export class FormPermissionService {
       ictAdmin: false,
       view: form.options?.restrictAccess !== RestrictAccess.restrictAccessStrict
     };
-    const noRestrictFeature$ = this.userService.user$.pipe(map(user => user ? {
-      edit: true,
-      view: true,
-      admin: false,
-      ictAdmin: UserService.isIctAdmin(user)
-    } : notLoggedIn));
     const {collectionID} = form;
-    if (!collectionID) {
-      return noRestrictFeature$;
-    }
-    if (!form.options?.restrictAccess) {
-      return noRestrictFeature$;
+    if (!collectionID || (!form.options?.restrictAccess && !form.options?.hasAdmins)) {
+      return this.userService.user$.pipe(map(user => user ? {
+        edit: true,
+        view: true,
+        admin: false,
+        ictAdmin: UserService.isIctAdmin(user)
+      } : notLoggedIn));
     }
     return this.userService.isLoggedIn$.pipe(
       take(1),


### PR DESCRIPTION
Repro: https://www.pivotaltracker.com/story/show/182329892

In release56, the form permission service logic was changed so that the `formPermissionService.getRights()` returned `admin: false` for a form that had `form.options.hasAdmins` but not `form.options.restrictAccess`. A link for these changes is a bit hard to show, as it's complicately in multiple commits. You can go here: https://github.com/luomus/laji/compare/v55...v56#, click "view files" and look for the part with "noRestrictFeature".

I made the logic similar to how API checks that the admins check makes sense:

https://bitbucket.org/luomus/lajiapi/src/67dca78ccb739fc49f3427eea0dc3fbbf0f76dbc/server/models/formPermission.js#lines-342:348