### PR TITLE
HTML-bug showing species name em-dash incorrectly in hovertext

### DIFF
--- a/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
+++ b/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
@@ -18,9 +18,9 @@
   <span *ngIf="value">
     <span style="display: inline"
           *ngIf="value.linkings && value.linkings.taxon && (value.linkings.taxon.id || value.linkings.taxon.qname); else taxonVerbatim"
-          title="{{(value.linkings.taxon.vernacularName ? (value.linkings.taxon.vernacularName | multiLang:false) : '')
+          [title]="(value.linkings.taxon.vernacularName ? (value.linkings.taxon.vernacularName | multiLang:false) : '')
                 + (value.linkings.taxon.vernacularName && value.linkings.taxon.scientificName ? ' &mdash; ': '')
-                + (value.linkings.taxon.scientificName ? value.linkings.taxon.scientificName : '')}}"
+                + (value.linkings.taxon.scientificName ? value.linkings.taxon.scientificName : '')"
     >
       {{ value.linkings.taxon.vernacularName | multiLang:false }}
       <span class="inline" *ngIf="value.linkings.taxon.vernacularName && value.linkings.taxon.scientificName && (value.linkings.taxon.vernacularName | multiLang:false)"> &mdash; </span>
@@ -50,9 +50,9 @@
     <ng-template #taxonLinkings let-taxon>
       <span class="inline"
             *ngIf="value.linkings && value.linkings[taxon] && (value.linkings[taxon].id || value.linkings[taxon].qname); else originalTaxonVerbatim"
-            title="{{(value.linkings[taxon].vernacularName ? (value.linkings[taxon].vernacularName | multiLang) : '')
+            [title]="(value.linkings[taxon].vernacularName ? (value.linkings[taxon].vernacularName | multiLang) : '')
                 + (value.linkings[taxon].vernacularName && value.linkings[taxon].scientificName ? ' &mdash; ': '')
-                + (value.linkings[taxon].scientificName ? value.linkings[taxon].scientificName : '')}}"
+                + (value.linkings[taxon].scientificName ? value.linkings[taxon].scientificName : '')"
       >
         {{ value.linkings[taxon].vernacularName | multiLang }}
         <span class="inline" *ngIf="value.linkings[taxon].vernacularName && value.linkings[taxon].scientificName"> &mdash; </span>
@@ -81,9 +81,9 @@
   <span *ngIf="value" title="{{value.taxonVerbatim}}">
     <span class="inline"
           *ngIf="value.linkings && value.linkings.taxon && value.linkings.taxon.speciesId; else taxonVerbatim"
-          title="{{(value.linkings.taxon.speciesVernacularName ? (value.linkings.taxon.speciesVernacularName | multiLang) : '')
+          [title]="(value.linkings.taxon.speciesVernacularName ? (value.linkings.taxon.speciesVernacularName | multiLang) : '')
                 + (value.linkings.taxon.speciesVernacularName && value.linkings.taxon.speciesScientificName ? ' &mdash; ': '')
-                + (value.linkings.taxon.speciesScientificName ? value.linkings.taxon.speciesScientificName : '')}}"
+                + (value.linkings.taxon.speciesScientificName ? value.linkings.taxon.speciesScientificName : '')"
     >
       {{ value.linkings.taxon.speciesVernacularName | multiLang }}
       <span class="inline" *ngIf="value.linkings.taxon.speciesVernacularName && value.linkings.taxon.speciesScientificName"> &mdash; </span>


### PR DESCRIPTION
Fixed three datatable templates which would manifest the same bug. Task: https://www.pivotaltracker.com/story/show/181544383, branch: https://181544383.dev.laji.fi/observation/list.