### PR TITLE
Use semicolon as field separator inside light download file cells

### DIFF
--- a/projects/laji/src/app/shared-modules/datatable/service/datatable-util.service.ts
+++ b/projects/laji/src/app/shared-modules/datatable/service/datatable-util.service.ts
@@ -35,7 +35,7 @@ export class DatatableUtil {
       return from(value).pipe(
         concatMap(val => this.getVisibleValue(val, row, templateName)),
         toArray(),
-        map(values => values.join(', '))
+        map(values => values.join('; '))
       );
     }
 


### PR DESCRIPTION
Hopefully changes all datatable download array-type columns separators to semicolon, task: https://www.pivotaltracker.com/story/show/182010275, branch: https://182010275.dev.laji.fi/taxon/list