### PR TITLE
Show species rank on breadcumb

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card-header/info-card-header.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card-header/info-card-header.component.html
@@ -8,7 +8,7 @@
 
 <div class="d-flex items-end flex-wrap my-3 mx-5">
   <laji-spinner class="parents-spinner" [spinning]="loadingParent" *ngFor="let parents of parent">
-    <div *ngIf="parents.taxonRank==='MX.kingdom' || parents.taxonRank==='MX.phylum' || parents.taxonRank==='MX.order' || parents.taxonRank==='MX.class' || parents.taxonRank==='MX.family' || parents.taxonRank==='MX.genus'">
+    <div *ngIf="parents.taxonRank==='MX.kingdom' || parents.taxonRank==='MX.phylum' || parents.taxonRank==='MX.order' || parents.taxonRank==='MX.class' || parents.taxonRank==='MX.family' || parents.taxonRank==='MX.genus' || parents.taxonRank==='MX.species'">
       <a *ngIf="!loadingParent && parents && taxon.hasParent" [routerLink]="'/taxon/' + parents.id + (activeTab === 'overview' ? '' : '/' + activeTab) | localize" [queryParams]="{context: null}" [queryParamsHandling]="'merge'">
         <laji-taxon-name [taxon]="parents" [capitalizeName]="true" [addLink]="false"></laji-taxon-name>
         <i class="glyphicon glyphicon-chevron-right"></i>


### PR DESCRIPTION
Allowed the breadcrumb rendering html to show items in taxon rank, task: https://www.pivotaltracker.com/story/show/182260001, branch: https://182260001.dev.laji.fi/taxon/MX.214519/occurrence