### PR TITLE
Allow showing all routes

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/area-select/area-select.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/area-select/area-select.component.ts
@@ -19,6 +19,8 @@ export class AreaSelectComponent implements OnInit {
   @Input() value: string[] = [];
   @Input() selectOptionEnabled = true;
   @Input() allOptionEnabled = false;
+  @Input() allOptionLast = false;
+  @Input() allOptionLabel = 'area-select.all';
 
   @Output() areaSelect = new EventEmitter<string>();
 
@@ -47,11 +49,13 @@ export class AreaSelectComponent implements OnInit {
         if (!this.multiselect && this.selectOptionEnabled) {
           options.push({id: undefined, value: 'select', translate: true});
         }
-        if (!this.multiselect && this.allOptionEnabled) {
-          options.push({id: 'all', value: 'area-select.all', translate: true});
+        if (!this.allOptionLast && !this.multiselect && this.allOptionEnabled) {
+          options.push({id: 'all', value: this.allOptionLabel, translate: true});
         }
         this.options = [...options, ...data.sort((a, b) => a.value.localeCompare(b.value))];
-
+        if (this.allOptionLast && !this.multiselect && this.allOptionEnabled) {
+          this.options.push({id: 'all', value: this.allOptionLabel, translate: true});
+        }
         this.cd.markForCheck();
       });
   }

--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.html
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.html
@@ -47,6 +47,9 @@
           </div>
           <laji-area-select class="col-sm-12 col-md-4 col-lg-3"
                             [field]="areaTypes.BirdAssociationArea"
+                            [allOptionEnabled]="true"
+                            [allOptionLabel]="'area-select.allRoutes'"
+                            [allOptionLast]="true"
                             (areaSelect)="onBirdAssociationAreaChange($event)"
                             [value]="[data.birdAssociationArea]"></laji-area-select>
         </div>

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -69,6 +69,7 @@
   "annotation.titlePlural": "Kommenttia",
   "annotation.titleSingle": "Kommentti",
   "area-select.all": "Kaikki",
+  "area-select.allRoutes": "Kaikki reitit",
   "asIs": "Arvo sellaisenaan",
   "audio.openSpectrum": "Avaa spektrogrammi",
   "audio.spectrum": "Äänite ja spektrogrammi",


### PR DESCRIPTION
Added to parameters of area-select component to control label and position of all-option, if not used behaves as thus far, task: https://www.pivotaltracker.com/story/show/182154213, branch: https://182154213.dev.laji.fi/.