### PR TITLE
Make filter subtitle localizable

### DIFF
--- a/projects/laji/src/app/+observation/form/conservation-filter/conservation-filter.component.html
+++ b/projects/laji/src/app/+observation/form/conservation-filter/conservation-filter.component.html
@@ -14,7 +14,7 @@
   [(ngModel)]="administrativeStatus"
   (ngModelChange)="administrativeStatusChange.emit($event)"
   [multiple]="true"
-  [placeholder]="'MX.hasAdminStatus' | label"
+  [placeholder]="'observation.form.administrativeStatus'"
   name="administrativeStatusId"
   [alt]="'MX.adminStatusEnum'"></laji-metadata-select>
 <laji-metadata-select


### PR DESCRIPTION
Currently can't change the filter section header "Administrative status"
in Crowdin. This fix should make that possible.