### PR TITLE
Notification queries 180080394

### DIFF
--- a/projects/laji/src/app/shared/navbar/navbar.component.ts
+++ b/projects/laji/src/app/shared/navbar/navbar.component.ts
@@ -75,7 +75,7 @@ export class NavbarComponent implements OnInit, OnDestroy {
     });
     this.notificationsTotal$ = this.notificationsFacade.total$;
     this.ngZone.runOutsideAngular(() => {
-      timer(1000, 60000).pipe(
+      timer(1000, 300000).pipe( // every 5 minutes
         switchMap(() => this.browserService.visibility$),
         filter(visible => visible),
         switchMap(() => this.userService.isLoggedIn$),

--- a/projects/laji/src/app/shared/navbar/notifications/notifications.facade.ts
+++ b/projects/laji/src/app/shared/navbar/notifications/notifications.facade.ts
@@ -81,15 +81,22 @@ export class NotificationsFacade {
   ) {}
 
   private notificationsReducer(notifications: PagedResult<Notification>) {
-      this.store$.next({
-        ...this.store$.getValue(), notifications
-      });
+    this.store$.next({
+      ...this.store$.getValue(), notifications
+    });
+  }
+
+  private totalReducer(total: number) {
+    const curr = this.store$.getValue();
+    this.store$.next({
+      ...curr, notifications: { ...curr.notifications, total }
+    });
   }
 
   private unseenCountReducer(unseenCount: number) {
-      this.store$.next({
-        ...this.store$.getValue(), unseenCount
-      });
+    this.store$.next({
+      ...this.store$.getValue(), unseenCount
+    });
   }
 
   private localUnseenCountReducer(amount = 1) {
@@ -159,10 +166,20 @@ export class NotificationsFacade {
       catchError(() => of({unseenCount: {total: 0}, notifications: {total: 0, results: []}}))
     ).subscribe((data) => {
       this.unseenCountReducer(data.unseenCount.total);
+      const curr = this.store$.getValue();
+
+      // get total count from graphql to avoid api query until the dropdown is opened
+      if (curr.notifications.total === 0 && data.notifications.total !== 0) {
+        this.totalReducer(data.notifications.total);
+      }
+
+      // reload if new notifications are detected
       if (
         data.notifications &&
         data.notifications.total > 0 &&
-        this.store$.getValue().notifications?.[0]?.id !== data.notifications.results[0].id
+        // no need to reload notifications if the dropdown has not been opened
+        curr.notifications?.pageSize > 0 &&
+        curr.notifications?.results[0]?.id !== data.notifications.results[0].id
       ) {
         this.loadNotifications(1);
       }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180080394

Fixes (most instances of) double notification queries and changes the time interval to 5min. From pivotal:

>Updating unseen notifications is done through regular graphql queries (now at 5 minute intervals), but once the notifications dropdown is opened the list (which uses virtual scrolling) uses the regular api.