### PR TITLE
Vihko import fix

### DIFF
--- a/projects/laji/src/app/shared-modules/spreadsheet/importer/erroneous-first.pipe.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/importer/erroneous-first.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'erroneousFirst'
+})
+export class ErroneousFirstPipe implements PipeTransform {
+
+  transform(value: any): any {
+    if (Array.isArray(value)) {
+      return [...value].sort((val1, val2) => {
+        const val1Sort = ['invalid', 'error'].includes(val1?._status?.status) ? 0 : 1;
+        const val2Sort = ['invalid', 'error'].includes(val2?._status?.status) ? 0 : 1;
+        return val1Sort - val2Sort;
+      });
+    }
+    return value;
+  }
+
+}

--- a/projects/laji/src/app/shared-modules/spreadsheet/importer/importer.component.html
+++ b/projects/laji/src/app/shared-modules/spreadsheet/importer/importer.component.html
@@ -225,10 +225,10 @@
 </ng-template>
 
 <ng-template #importData>
-  <button type="button" (click)="openMapModal()" class="btn btn-default mb-3"> 
+  <button type="button" (click)="openMapModal()" class="btn btn-default mb-3">
     {{ 'excel.import.step4.showObservationMap' | translate }}
   </button>
-  
+
   <laji-datatable
     #dataTable
     class="import-table"
@@ -237,7 +237,7 @@
     [virtualScrolling]="true"
     [clientSideSorting]="false"
     [height]="'50vh'"
-    [rows]='mappedData | onlyErroneous:showOnlyErroneous'
+    [rows]='mappedData | onlyErroneous:showOnlyErroneous | erroneousFirst'
     [count]="mappedData.length"
     [page]="1"
     [pageSize]="mappedData.length"

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
@@ -224,13 +224,18 @@ export class ImportService {
         if (!this.hasValue(value)) {
           return;
         }
+
         const parent = this.getParent(field, combineBy);
-        if (!parentData[parent]) {
-          parentData[parent] = {
-            rowIdx,
-            hash: '' + rowIdx,
-            data: {}
-          };
+
+        // Initialize data for required levels if it isn't initialized yet (document level should never be empty)
+        for (let level of [LEVEL_DOCUMENT, parent]) {
+          if (!parentData[level]) {
+            parentData[level] = {
+              rowIdx,
+              hash: '' + rowIdx,
+              data: {}
+            };
+          }
         }
 
         // Check if array value has values that should be ignored

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
@@ -182,7 +182,7 @@ export class ImportService {
 
   private findDocumentData(data: ILevelData[]): IData {
     const l = (data || []).length;
-    for (let i = 0; i <= l; i++) {
+    for (let i = 0; i < l; i++) {
       if (data[i].document) {
         return data[i].document;
       }

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
@@ -228,7 +228,7 @@ export class ImportService {
         const parent = this.getParent(field, combineBy);
 
         // Initialize data for required levels if it isn't initialized yet (document level should never be empty)
-        for (let level of [LEVEL_DOCUMENT, parent]) {
+        for (const level of [LEVEL_DOCUMENT, parent]) {
           if (!parentData[level]) {
             parentData[level] = {
               rowIdx,

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/mapping.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/mapping.service.ts
@@ -430,16 +430,17 @@ export class MappingService {
 
   private analyzeGeometry(value: any) {
     if (typeof value === 'string') {
-      value = value.replace(/\s/g, '');
-      if (value.match(/^[0-9]{3,7}:[0-9]{3,7}$/)) {
-        const ykjParts = value.split(':');
+      value = value.trim();
+      const valueWithoutSpaces = value.replace(/\s/g, '');
+      if (valueWithoutSpaces.match(/^[0-9]{3,7}:[0-9]{3,7}$/)) {
+        const ykjParts = valueWithoutSpaces.split(':');
         if (ykjParts[0].length === ykjParts[1].length) {
           try {
             return convertYkjToGeoJsonFeature(ykjParts[0], ykjParts[1]).geometry;
           } catch (e) {}
         }
-      } else if (value.match(/^-?[0-9]{1,2}(\.[0-9]+)?,-?1?[0-9]{1,2}(\.[0-9]+)?$/)) {
-        const wgsParts = value.split(',');
+      } else if (valueWithoutSpaces.match(/^-?[0-9]{1,2}(\.[0-9]+)?,-?1?[0-9]{1,2}(\.[0-9]+)?$/)) {
+        const wgsParts = valueWithoutSpaces.split(',');
         return {
           type: 'Point',
           coordinates: [+wgsParts[1], +wgsParts[0]]

--- a/projects/laji/src/app/shared-modules/spreadsheet/spreadsheet.module.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/spreadsheet.module.ts
@@ -37,6 +37,7 @@ import { FieldItemComponent } from './excel-generator/field-item/field-item.comp
 import { OnlyErroneousPipe } from './importer/only-erroneous.pipe';
 import { ImportMapComponent } from './importer/import-map/import-map.component';
 import { LajiUiModule } from 'projects/laji-ui/src/public-api';
+import { ErroneousFirstPipe } from './importer/erroneous-first.pipe';
 
 @NgModule({
   declarations: [
@@ -63,7 +64,8 @@ import { LajiUiModule } from 'projects/laji-ui/src/public-api';
     UserMappingButtonComponent,
     FieldItemComponent,
     OnlyErroneousPipe,
-    ImportMapComponent
+    ImportMapComponent,
+    ErroneousFirstPipe
   ],
     exports: [ImporterComponent, ExcelGeneratorComponent, StepperComponent],
   imports: [


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/182750980
https://www.pivotaltracker.com/story/show/183101256

Fixes Vihko import failing silently with data that is missing document/gathering/unit level data. This pull request also changes the order of rows in the summary table so that the erroneous rows are shown first.