### PR TITLE
Changed PAP navbar title. [#183697660]

### DIFF
--- a/projects/vir/i18n/fi.json
+++ b/projects/vir/i18n/fi.json
@@ -5,6 +5,7 @@
   "navigation.observation": "Havaintotieto",
   "navigation.saveVirObservations": "Tallenna havaintoja",
   "navigation.taxonomy": "Lajitieto",
+  "navigation.title": "Viranomaisportaali",
   "navigation.usage": "Aineistojen käyttö",
   "observation.download.api": "Pyydä API-avain",
   "observation.download.api.btn": "Lähetä",

--- a/projects/vir/src/app/component/nav-bar/nav-bar.component.html
+++ b/projects/vir/src/app/component/nav-bar/nav-bar.component.html
@@ -12,7 +12,7 @@
           </button>
           <a class="navbar-brand" [routerLink]="['/'] | localize">
             <div class="env" [ngClass]="{dev: devRibbon}"></div>
-            <span>LAJI.FI</span>
+            <span>{{ ('navigation.title' | translate).toUpperCase() }}</span>
           </a>
           <div class="visible-xs-inline-block pull-right search">
             <laji-omni-search


### PR DESCRIPTION
Now the title in PAP has a translation, which is shown in uppercase letters. Fixes 2022.