### PR TITLE
Missing dev-ribbon added to PAP. [#183711188]

### DIFF
--- a/projects/laji/src/app/shared/navbar/navbar.component.ts
+++ b/projects/laji/src/app/shared/navbar/navbar.component.ts
@@ -10,6 +10,7 @@ import {
 import { UserService } from '../service/user.service';
 import { NavigationEnd, Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
+import { environment as virEnvironment } from '../../../../../vir/src/environments/environment';
 import { LocalizeRouterService } from '../../locale/localize-router.service';
 import { TranslateService } from '@ngx-translate/core';
 import { timer, Subject, Observable } from 'rxjs';
@@ -54,7 +55,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
     private ngZone: NgZone
   ) {
     this.navId = environment.type + '-nav';
-    this.devRibbon = !environment.production || environment.type === Global.type.beta;
+    this.devRibbon = environment.type === Global.type.vir ?
+      virEnvironment.displayDevRibbon :
+      !environment.production || environment.type === Global.type.beta;
     this.redTheme = environment.type === Global.type.vir || environment.type === Global.type.iucn;
     this.containerClass = environment.type === Global.type.iucn ? 'container' : 'container-fluid';
   }

--- a/projects/vir/src/environments/environment.dev.ts
+++ b/projects/vir/src/environments/environment.dev.ts
@@ -83,5 +83,5 @@ export const environment = {
   },
   geoserver: 'https://geoserver-dev.laji.fi',
   observationMapOptions: {availableOverlayNameBlacklist: []},
-  displayDevRibbon: 'true'
+  displayDevRibbon: true
 };

--- a/projects/vir/src/environments/environment.dev.ts
+++ b/projects/vir/src/environments/environment.dev.ts
@@ -82,5 +82,6 @@ export const environment = {
     },
   },
   geoserver: 'https://geoserver-dev.laji.fi',
-  observationMapOptions: {availableOverlayNameBlacklist: []}
+  observationMapOptions: {availableOverlayNameBlacklist: []},
+  displayDevRibbon: 'true'
 };

--- a/projects/vir/src/environments/environment.prod.ts
+++ b/projects/vir/src/environments/environment.prod.ts
@@ -81,5 +81,6 @@ export const environment = {
     },
   },
   geoserver: 'https://geoserver.laji.fi',
-  observationMapOptions: {availableOverlayNameBlacklist: []}
+  observationMapOptions: {availableOverlayNameBlacklist: []},
+  displayDevRibbon: false
 };

--- a/projects/vir/src/environments/environment.ts
+++ b/projects/vir/src/environments/environment.ts
@@ -87,5 +87,6 @@ export const environment = {
     },
   },
   geoserver: 'https://geoserver-dev.laji.fi',
-  observationMapOptions: {availableOverlayNameBlacklist: []}
+  observationMapOptions: {availableOverlayNameBlacklist: []},
+  displayDevRibbon: true
 };


### PR DESCRIPTION
Not sure how to check if this works on production. Caught a bug where dev-ribbon was not shown on PAP's dev website. This was because the environment variables on PAP, such as environment.production function unintuitively, so the dev-ribbon display logic did not work as expected. A new env-variable was added to check whether to display the dev-ribbon on PAP, while applying the previous logic to other services in the monorepo.