### PR TITLE
Always show selected dataset in hierarchy 183624947

### DIFF
--- a/projects/laji/src/app/shared-modules/dataset-metadata/dataset-metadata-browser/dataset-metadata-browser.component.ts
+++ b/projects/laji/src/app/shared-modules/dataset-metadata/dataset-metadata-browser/dataset-metadata-browser.component.ts
@@ -69,10 +69,12 @@ export class DatasetMetadataBrowserComponent implements OnInit {
   buildCollectionTree(trees: ICollectionsTreeNode[], aggregates: ICollectionAggregate[]) {
     const collectionsWithChildren = [];
 
-    const aggregate = aggregates.find(elem => elem.id === this.selected);
+    if (this.selected) {
+      const aggregate = aggregates.find(elem => elem.id === this.selected);
 
-    if (!aggregate || aggregate.count === 0) {
-      this.showEmpty = true;
+      if (!aggregate || aggregate.count === 0) {
+        this.showEmpty = true;
+      }
     }
 
     trees.forEach(tree => {

--- a/projects/laji/src/app/shared-modules/dataset-metadata/dataset-metadata-browser/dataset-metadata-browser.component.ts
+++ b/projects/laji/src/app/shared-modules/dataset-metadata/dataset-metadata-browser/dataset-metadata-browser.component.ts
@@ -62,12 +62,18 @@ export class DatasetMetadataBrowserComponent implements OnInit {
       this.collectionService.getCollectionsTree$(),
       this.collectionService.getCollectionsAggregate$(),
     ).pipe(
-      map(([ tree, agregates ]) => this.buildCollectionTree(tree, agregates))
+      map(([ tree, aggregates ]) => this.buildCollectionTree(tree, aggregates))
     );
   }
 
   buildCollectionTree(trees: ICollectionsTreeNode[], aggregates: ICollectionAggregate[]) {
     const collectionsWithChildren = [];
+
+    const aggregate = aggregates.find(elem => elem.id === this.selected);
+
+    if (!aggregate || aggregate.count === 0) {
+      this.showEmpty = true;
+    }
 
     trees.forEach(tree => {
       const prunedTree = this.buildTree(tree, aggregates);
@@ -97,6 +103,14 @@ export class DatasetMetadataBrowserComponent implements OnInit {
       return undefined;
     }
 
+    if ((this.selected && tree.id === this.selected) && (tree.hasChildren || aggregate || this.showEmpty)) {
+      this.selectedOption = [{
+        id: this.selected,
+        value: tree.longName,
+        type: 'included',
+      }];
+    }
+
     if (tree.hasChildren) {
       const children = [];
       let childCount = 0;
@@ -121,14 +135,6 @@ export class DatasetMetadataBrowserComponent implements OnInit {
         });
 
         this.collectionsCount++;
-
-        if (this.selected && tree.id === this.selected) {
-          this.selectedOption = [{
-            id: this.selected,
-            value: tree.longName,
-            type: 'included',
-          }];
-        }
 
         return {
           id: tree.id,


### PR DESCRIPTION
If page is loaded with an empty collection selected the tree switches to showing empty collections and selects it from the hierarchy, opening the tree to its level. Testable branch https://183624947.dev.laji.fi/theme/dataset-metadata/. 