### PR TITLE
Identify-tab image viewer [#183720157]

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.html
@@ -1,6 +1,16 @@
+<ng-container *ngIf="taxon.species">
+  <ng-container *ngIf="taxon.multimedia?.length > 0; else noImage">
+    <ng-container *ngFor="let multimedia of taxon.multimedia; index as i">
+      <img lajiLazyImage (click)="openImage(i)" [src]="taxon.multimedia[i].largeURL">
+      <ng-container *ngTemplateOutlet="imageCopyright; context:{ $implicit: taxon.multimedia[i] }"></ng-container>
+    </ng-container>
+  </ng-container>
+</ng-container>
+
 <ng-container *ngIf="taxon.children?.length === 0">
   <ng-container *ngIf="taxon.multimedia?.length > 0; else noImage">
-    <img [src]="taxon.multimedia[0].largeURL">
+    <img (click)="openImage()" [src]="taxon.multimedia[0].largeURL">
+    <ng-container *ngTemplateOutlet="imageCopyright; context:{ $implicit: taxon.multimedia[0] }"></ng-container>
   </ng-container>
 </ng-container>
 
@@ -39,5 +49,25 @@
     <h4 class="no-image-title">
       {{ 'annotation.noImages' | translate }}
     </h4>
+  </div>
+</ng-template>
+
+<ng-template #imageCopyright let-multimedia>
+  <div class="image-copyright" *ngIf="multimedia">
+    <div *ngIf="multimedia.copyrightOwner">
+      <b>{{ 'taxonomy.multimedia.copyrightOwner' | translate }}:</b>
+      {{ multimedia.copyrightOwner }}
+    </div>
+    <div *ngIf="multimedia.licenseAbbreviation">
+      <b>{{ 'taxonomy.multimedia.licenseAbbreviation' | translate }}:</b>
+      {{ multimedia.licenseAbbreviation }}
+    </div>
+    <div *ngIf="multimedia.taxonDescriptionCaption">
+      <b>{{ 'taxonomy.multimedia.taxonDescriptionCaption' | translate }}:</b>
+      {{ multimedia.taxonDescriptionCaption | multiLang }}
+    </div>
+    <ng-container *ngIf="multimedia.licenseId">
+      <laji-license type={{multimedia.licenseId}}></laji-license>
+    </ng-container>
   </div>
 </ng-template>

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.html
@@ -45,7 +45,7 @@
 
 <ng-template #noImage>
   <div class="no-image">
-    <img [src]="'static/images/icons/x-octagon.png'">
+    <img class="no-image-icon" [src]="'static/images/icons/x-octagon.png'">
     <h4 class="no-image-title">
       {{ 'annotation.noImages' | translate }}
     </h4>

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.scss
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.scss
@@ -1,5 +1,17 @@
 @import 'projects/laji-ui/src/lib/vars';
 
+img {
+  &:not(.no-image-icon) {
+    cursor: pointer;
+    transition: box-shadow 200ms;
+    box-shadow: 0 0 0 0 rgba($neutral-9, 0);
+
+    &:hover {
+      box-shadow: 0 4px 16px 0 rgba($neutral-9, .5);
+    }
+  }
+}
+
 .image-copyright {
   margin-top: $sp-4;
   margin-bottom: $sp-6;
@@ -67,6 +79,11 @@
   min-width: 250px;
 }
 
+.species-img-container > img {
+  max-width: 400px;
+  max-height: 400px;
+}
+
 .species-no-img-container {
   align-items: center;
   box-shadow: inset 0 1px 3px 0 rgba(#000,.2);
@@ -75,19 +92,6 @@
   flex-grow: 1;
   justify-content: center;
   min-width: 250px;
-}
-
-.species-img-container > img {
-  max-width: 400px;
-  max-height: 400px;
-
-  cursor: pointer;
-  transition: box-shadow 200ms;
-  box-shadow: 0 0 0 0 rgba($neutral-9, 0);
-
-  &:hover {
-    box-shadow: 0 4px 16px 0 rgba($neutral-9, .5);
-  }
 }
 
 ::-webkit-scrollbar {

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.scss
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.scss
@@ -1,5 +1,10 @@
 @import 'projects/laji-ui/src/lib/vars';
 
+.image-copyright {
+  margin-top: $sp-4;
+  margin-bottom: $sp-6;
+}
+
 .species-container-container {
   position: relative;
 }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.ts
@@ -87,24 +87,50 @@ export class IdentificationListComponent implements OnDestroy {
     this.destroyMouseupListener();
   }
 
-  openImage(index) {
+  openImage(index?: number) {
     this.overlayLoader
       .attach(ImageModalOverlayComponent)
       .to('body')
       .show({isAnimated: false});
     this.showOverlay = true;
     this.overlayRef = this.overlayLoader._componentRef;
-    const [filteredIndex, filteredChildren] = indexAndArrAfterFilter(
-      index, this.taxon.children,
-      taxonomy => taxonomy.multimedia && taxonomy.multimedia.length > 0
-    );
-    this.overlayRef.instance.modalImages = filteredChildren.map(taxonomy => <Image>{
-        ...taxonomy.multimedia[0],
-        taxonId: taxonomy.id,
-        vernacularName: taxonomy.vernacularName,
-        scientificName: taxonomy.scientificName
+
+    if (this?.taxon?.species) {
+      const modalImages = [];
+      this.taxon.multimedia.forEach((media, i) => {
+        modalImages.push(<Image>{
+          ...this.taxon.multimedia[i],
+          taxonId: this.taxon.id,
+          vernacularName: this.taxon.vernacularName,
+          scientificName: this.taxon.scientificName
+        });
       });
-    this.overlayRef.instance.showImage(filteredIndex);
+      this.overlayRef.instance.modalImages = modalImages;
+      this.overlayRef.instance.showImage(index);
+
+    } else if (this.taxon.children?.length === 0) {
+      this.overlayRef.instance.modalImages = [<Image>{
+        ...this.taxon.multimedia[0],
+        taxonId: this.taxon.id,
+        vernacularName: this.taxon.vernacularName,
+        scientificName: this.taxon.scientificName
+      }];
+      this.overlayRef.instance.showImage(0);
+
+    } else if (this.taxon.children?.length > 0) {
+      const [filteredIndex, filteredChildren] = indexAndArrAfterFilter(
+        index, this.taxon.children,
+        taxonomy => taxonomy.multimedia && taxonomy.multimedia.length > 0
+      );
+      this.overlayRef.instance.modalImages = filteredChildren.map(taxonomy => <Image>{
+          ...taxonomy.multimedia[0],
+          taxonId: taxonomy.id,
+          vernacularName: taxonomy.vernacularName,
+          scientificName: taxonomy.scientificName
+        });
+      this.overlayRef.instance.showImage(filteredIndex);
+    }
+
     if (this.showModalSub) { this.showModalSub.unsubscribe(); }
     this.showModalSub = this.overlayRef.instance.showModal.subscribe(state => {
       if (state === false) { this.closeImage(); }

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/identification-list/identification-list.component.ts
@@ -96,18 +96,16 @@ export class IdentificationListComponent implements OnDestroy {
     this.overlayRef = this.overlayLoader._componentRef;
 
     if (this?.taxon?.species) {
-      const modalImages = [];
-      this.taxon.multimedia.forEach((media, i) => {
-        modalImages.push(<Image>{
+      this.overlayRef.instance.modalImages = this.taxon.multimedia.map((media, i) => {
+        const image = <Image>{
           ...this.taxon.multimedia[i],
           taxonId: this.taxon.id,
           vernacularName: this.taxon.vernacularName,
           scientificName: this.taxon.scientificName
-        });
+        };
+        return image;
       });
-      this.overlayRef.instance.modalImages = modalImages;
       this.overlayRef.instance.showImage(index);
-
     } else if (this.taxon.children?.length === 0) {
       this.overlayRef.instance.modalImages = [<Image>{
         ...this.taxon.multimedia[0],
@@ -116,7 +114,6 @@ export class IdentificationListComponent implements OnDestroy {
         scientificName: this.taxon.scientificName
       }];
       this.overlayRef.instance.showImage(0);
-
     } else if (this.taxon.children?.length > 0) {
       const [filteredIndex, filteredChildren] = indexAndArrAfterFilter(
         index, this.taxon.children,

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.html
@@ -1,8 +1,5 @@
 <div *ngIf="taxon.species; else parent" class="lu-text-content">
-  <div *ngFor="let media of taxon.multimedia">
-    <img lajiLazyImage [src]="media.largeURL">
-    <ng-container *ngTemplateOutlet="imageCopyright; context:{ $implicit: media }"></ng-container>
-  </div>
+  <laji-identification-list [taxon]="taxon"></laji-identification-list>
 </div>
 
 <ng-template #parent>
@@ -39,7 +36,6 @@
       <div class="child-container" *ngIf="child.children?.length === 0; else noDescriptions">
         <div class="image-container">
           <laji-identification-list [taxon]="child"></laji-identification-list>
-          <ng-container *ngTemplateOutlet="imageCopyright; context:{ $implicit: child.taxonMultimedia }"></ng-container>
         </div>
         <div class="description-container">
           <div class="description-items" *ngFor="let taxonDescription of child.taxonDescriptions | keyvalue">
@@ -73,24 +69,4 @@
       <laji-license type="MZ.intellectualRightsCC-BY-4.0"></laji-license>
     </ng-container>
   </laji-spinner>
-</ng-template>
-
-<ng-template #imageCopyright let-multimedia>
-  <div class="image-copyright" *ngIf="multimedia">
-    <div *ngIf="multimedia.copyrightOwner">
-      <b>{{ 'taxonomy.multimedia.copyrightOwner' | translate }}:</b>
-      {{ multimedia.copyrightOwner }}
-    </div>
-    <div *ngIf="multimedia.licenseAbbreviation">
-      <b>{{ 'taxonomy.multimedia.licenseAbbreviation' | translate }}:</b>
-      {{ multimedia.licenseAbbreviation }}
-    </div>
-    <div *ngIf="multimedia.taxonDescriptionCaption">
-      <b>{{ 'taxonomy.multimedia.taxonDescriptionCaption' | translate }}:</b>
-      {{ multimedia.taxonDescriptionCaption | multiLang }}
-    </div>
-    <ng-container *ngIf="multimedia.licenseId">
-      <laji-license type={{multimedia.licenseId}}></laji-license>
-    </ng-container>
-  </div>
 </ng-template>

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.scss
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.scss
@@ -76,8 +76,3 @@ li {
   padding-right: $sp-6;
   max-width: 800px;
 }
-
-.image-copyright {
-  margin-top: $sp-4;
-  margin-bottom: $sp-6;
-}

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
@@ -44,13 +44,12 @@ const requestedDescriptionVariables = {
   ],
 };
 
-interface TaxonomyWithDescriptionsAndMultimedia extends Taxonomy {
+interface TaxonomyWithDescriptions extends Taxonomy {
   taxonDescriptions: Record<string, any>;
-  taxonMultimedia: Record<string, any>;
 }
 
 interface Data {
-  children: TaxonomyWithDescriptionsAndMultimedia[];
+  children: TaxonomyWithDescriptions[];
   descriptionSources: Array<string>;
   speciesCardAuthors: Array<string>;
   speciesCardAuthorsTitle: string | undefined;
@@ -127,8 +126,7 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
       this.children$.subscribe((t) => {
         this.data.children = t.map(child => {
           const taxonDescriptions = this.parseTaxonDescriptions(child);
-          const taxonMultimedia = this.parseTaxonMultimedia(child);
-          return { ...child, taxonDescriptions, taxonMultimedia };
+          return { ...child, taxonDescriptions };
         });
         this.cdr.markForCheck();
         this.totalChildren$.pipe(take(1)).subscribe(total => {
@@ -196,18 +194,4 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
 
     return taxonDescriptions;
   }
-
-  private parseTaxonMultimedia(taxon: Taxonomy): any {
-    if (!taxon.multimedia || taxon.multimedia.length < 0) { return undefined; }
-
-    const mainImage = taxon.multimedia[0];
-    const taxonMultimedia = {};
-
-    if (mainImage.copyrightOwner) { taxonMultimedia['copyrightOwner'] = mainImage.copyrightOwner; }
-    if (mainImage.licenseAbbreviation) { taxonMultimedia['licenseAbbreviation'] = mainImage.licenseAbbreviation; }
-    if (mainImage.licenseId) { taxonMultimedia['licenseId'] = mainImage.licenseId; }
-    if (mainImage.taxonDescriptionCaption) { taxonMultimedia['taxonDescriptionCaption'] = mainImage.taxonDescriptionCaption; }
-
-    return taxonMultimedia;
-  };
 }

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.html
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal-overlay.component.html
@@ -26,6 +26,10 @@
         <span [innerHTML]="img.caption | multiLang"></span>
         <br>
       </ng-container>
+      <ng-container *ngIf="img.taxonDescriptionCaption">
+        <span [innerHTML]="img.taxonDescriptionCaption | multiLang"></span>
+        <br>
+      </ng-container>
       <span *ngIf="img.author">{{ img.author }}, </span>
       <span *ngIf="img.copyrightOwner && (!img.author || img.author.indexOf(img.copyrightOwner) === -1)">
         {{ img.copyrightOwner }},


### PR DESCRIPTION
This pull request contains two stories.

---

https://183720157.dev.laji.fi/taxon/MX.39248/identification
https://www.pivotaltracker.com/n/projects/2346653/stories/183720157

Clicking any image (except for the no-image icon) opens the image into a modal. Also, refactored the image copyright rendering into the same component with the image rendering.

---

https://183720157.dev.laji.fi/taxon/MX.204722/images
https://www.pivotaltracker.com/n/projects/2346653/stories/183749970

The image modal displays all captions. Previously it only has shown "caption" field content, now it also shows "taxonDescriptionCaption" field content.