### PR TITLE
Refactor laji-datepicker [#183827818]

### DIFF
--- a/projects/laji/e2e/src/+observation/observation.e2e-spec.ts
+++ b/projects/laji/e2e/src/+observation/observation.e2e-spec.ts
@@ -103,4 +103,89 @@ describe('Observation list', () => {
       });
     });
   });
+
+  describe('date search', () => {
+    beforeAll(async (done) => {
+      await page.timePanel.open();
+      done();
+    });
+
+    const dateAsISO8601 = (date: Date) => date.toISOString().match(/^[^T]+/)[0];
+
+    it('time start accepts date without zeros and updates query', async (done) => {
+      await page.dateBegin.type('1.1.2022');
+      expect(await page.getTimeStart()).toBe('2022-01-01');
+      expect(await page.getTimeEnd()).toBe('');
+      done();
+    });
+
+    it('time start accepts date with zeros and updates query', async (done) => {
+      await page.dateBegin.type('01.01.2022');
+      expect(await page.getTimeStart()).toBe('2022-01-01');
+      expect(await page.getTimeEnd()).toBe('');
+      done();
+    });
+
+    it('time end updates query', async (done) => {
+      await page.dateEnd.type('1.1.2023');
+      expect(await page.getTimeStart()).toBe('2022-01-01');
+      expect(await page.getTimeEnd()).toBe('2023-01-01');
+      done();
+    });
+
+
+    describe('calendar', () => {
+      it('calendar shows when toggled', async (done) => {
+        await page.dateEnd.calendar.toggle();
+
+        expect(await isDisplayed(page.dateEnd.calendar.$getContainer())).toBe(true);
+        done();
+      });
+
+      it('calendar displays selected year', async (done) => {
+        expect(await page.dateEnd.calendar.getYear()).toBe('2023');
+        done();
+      });
+
+      it('calendar displays current year', async (done) => {
+        await page.dateEnd.clear();
+        await page.dateEnd.calendar.toggle();
+
+        expect(await page.dateEnd.calendar.getYear()).toBe('' + new Date().getFullYear());
+        done();
+      });
+
+      it('calendar clicking day selects it', async (done) => {
+        await page.dateEnd.calendar.selectToday();
+        expect(await page.getTimeEnd()).toBe(dateAsISO8601(new Date()));
+        done();
+      });
+    });
+
+    it('today btn clears old values and updates to only today', async (done) => {
+      await page.$today.click();
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      expect(await page.getTimeStart()).toBe(dateAsISO8601(yesterday));
+      expect(await page.getTimeEnd()).toBe('');
+      done();
+    });
+
+    describe('preselected value', () => {
+      beforeAll(async (done) => {
+        await page.navigateTo('list', {time: '2022-01-22/'});
+        done();
+      });
+
+      it('causes time panel to be open', async (done) => {
+        expect(await page.timePanel.isOpen()).toBe(true);
+        done();
+      });
+
+      it('shows value from input properties', async (done) => {
+        expect(await page.dateBegin.getInputValue()).toBe('22.1.2022');
+        done();
+      });
+    });
+  });
 });

--- a/projects/laji/src/app/+observation/form-sample/form-sample.component.html
+++ b/projects/laji/src/app/+observation/form-sample/form-sample.component.html
@@ -167,9 +167,6 @@
     </laji-info>
       <laji-datepicker
         [(ngModel)]="formQuery.timeStart"
-        [viewFormat]="'DD.MM.YYYY'"
-        [otherFormats]="['D.M.YYYY', 'YYYY']"
-        [format]="dateFormat"
         (dateSelect)="onFormQueryChange()"
         (change)="onFormQueryChange()"
         name="timeStart"></laji-datepicker>
@@ -179,10 +176,7 @@
     <div class="col-sm-12">
       <laji-datepicker
         [(ngModel)]="formQuery.timeEnd"
-        [viewFormat]="'DD.MM.YYYY'"
-        [otherFormats]="['D.M.YYYY', 'YYYY']"
         [toLastOfYear]="true"
-        [format]="dateFormat"
         (dateSelect)="onFormQueryChange()"
         (change)="onFormQueryChange()"
         name="timeEnd"></laji-datepicker>

--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.html
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.html
@@ -5,13 +5,11 @@
   </div>
   <laji-datepicker
     [(ngModel)]="datepickerTimeStart"
-    (dateSelect)="onFormQueryChange()"
     (change)="onFormQueryChange()"
     name="timeStart"></laji-datepicker>
   <laji-datepicker
     [(ngModel)]="datepickerTimeEnd"
     [toLastOfYear]="true"
-    (dateSelect)="onFormQueryChange()"
     (change)="onFormQueryChange()"
     name="timeEnd"></laji-datepicker>
   <div class="btn-group btn-group-xs mt-1">
@@ -42,13 +40,11 @@
     </div>
     <laji-datepicker
       [(ngModel)]="query.loadedSameOrAfter"
-      (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeStart"></laji-datepicker>
     <laji-datepicker
       [(ngModel)]="query.loadedSameOrBefore"
       [toLastOfYear]="true"
-      (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeEnd"></laji-datepicker>
     <div class="btn-group btn-group-xs mt-1">

--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.html
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.html
@@ -1,29 +1,23 @@
-<div class="mb-4">
+<div class="mb-4 observation-time-container">
   <div>
     <label>{{ 'observation.form.time' | translate }}</label>
     <laji-info>{{ 'observation.info.time' | translate }}</laji-info>
   </div>
   <laji-datepicker
     [(ngModel)]="datepickerTimeStart"
-    [viewFormat]="'DD.MM.YYYY'"
-    [otherFormats]="['D.M.YYYY', 'YYYY']"
-    [format]="dateFormat"
     (dateSelect)="onFormQueryChange()"
     (change)="onFormQueryChange()"
     name="timeStart"></laji-datepicker>
   <laji-datepicker
     [(ngModel)]="datepickerTimeEnd"
-    [viewFormat]="'DD.MM.YYYY'"
-    [otherFormats]="['D.M.YYYY', 'YYYY']"
     [toLastOfYear]="true"
-    [format]="dateFormat"
     (dateSelect)="onFormQueryChange()"
     (change)="onFormQueryChange()"
     name="timeEnd"></laji-datepicker>
   <div class="btn-group btn-group-xs mt-1">
-    <button type="button" class="btn btn-default" (click)="onUpdateTime(1)">{{ 'observations.form.1d' | translate }}</button>
-    <button type="button" class="btn btn-default" (click)="onUpdateTime(7)">{{ 'observations.form.7d' | translate }}</button>
-    <button type="button" class="btn btn-default" (click)="onUpdateTime(365)">
+    <button type="button" class="btn btn-default btn-today" (click)="onUpdateTime(1)">{{ 'observations.form.1d' | translate }}</button>
+    <button type="button" class="btn btn-default btn-week" (click)="onUpdateTime(7)">{{ 'observations.form.7d' | translate }}</button>
+    <button type="button" class="btn btn-default btn-year" (click)="onUpdateTime(365)">
       {{ 'observation.form.thisYear' | translate }}
     </button>
   </div>
@@ -48,18 +42,12 @@
     </div>
     <laji-datepicker
       [(ngModel)]="query.loadedSameOrAfter"
-      [viewFormat]="'DD.MM.YYYY'"
-      [otherFormats]="['D.M.YYYY', 'YYYY']"
-      [format]="dateFormat"
       (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeStart"></laji-datepicker>
     <laji-datepicker
       [(ngModel)]="query.loadedSameOrBefore"
-      [viewFormat]="'DD.MM.YYYY'"
-      [otherFormats]="['D.M.YYYY', 'YYYY']"
       [toLastOfYear]="true"
-      [format]="dateFormat"
       (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeEnd"></laji-datepicker>
@@ -79,19 +67,13 @@
     </div>
     <laji-datepicker
       [(ngModel)]="query.firstLoadedSameOrAfter"
-      [viewFormat]="'DD.MM.YYYY'"
-      [otherFormats]="['D.M.YYYY', 'YYYY']"
-      [format]="dateFormat"
       (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeStart"></laji-datepicker>
 
     <laji-datepicker
       [(ngModel)]="query.firstLoadedSameOrBefore"
-      [viewFormat]="'DD.MM.YYYY'"
-      [otherFormats]="['D.M.YYYY', 'YYYY']"
       [toLastOfYear]="true"
-      [format]="dateFormat"
       (dateSelect)="onQueryChange()"
       (change)="onQueryChange()"
       name="timeEnd"></laji-datepicker>

--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.ts
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.ts
@@ -19,53 +19,35 @@ export class DateFormComponent implements OnDestroy {
 
   @Input() query;
   @Input() formQuery: ObservationFormQuery;
-  @Input() dateFormat = 'YYYY-MM-DD';
 
   @Output() formQueryChange = new EventEmitter<void>();
   @Output() queryChange = new EventEmitter<void>();
   @Output() searchQueryChange = new EventEmitter<any>();
   @Output() updateTime = new EventEmitter<any>();
 
-  // Datepicker component emits a value change event every time it receives an update
-  // with this hack we ignore value change events that were initiated by xDaysAgo
-  private ignoreStartDatepickerEvent = false;
-  private ignoreEndDatepickerEvent = false;
-
   get datepickerTimeStart() {
     return isRelativeDate(this.formQuery.timeStart) ? undefined : this.formQuery.timeStart;
   }
   set datepickerTimeStart(time) {
-    if (this.ignoreStartDatepickerEvent) {
-      this.ignoreStartDatepickerEvent = false;
-      return;
-    }
     this.formQuery.timeStart = time;
+    this.onFormQueryChange();
   }
 
   get datepickerTimeEnd() {
     return (!isRelativeDate(this.formQuery.timeStart) || !this.formQuery.timeStart) ? this.formQuery.timeEnd : undefined;
   }
   set datepickerTimeEnd(time) {
-    if (this.ignoreEndDatepickerEvent) {
-      this.ignoreEndDatepickerEvent = false;
-      return;
-    }
     if (isRelativeDate(this.formQuery.timeStart)) {
       this.formQuery.timeStart = undefined;
     }
     this.formQuery.timeEnd = time;
+    this.onFormQueryChange();
   }
 
   get xDaysAgo() {
     return isRelativeDate(this.formQuery.timeStart) ? Math.abs(parseInt(this.formQuery.timeStart, 10)) : undefined;
   }
   set xDaysAgo(days: number) {
-    if (this.formQuery.timeStart) {
-      this.ignoreStartDatepickerEvent = true;
-    }
-    if (this.formQuery.timeEnd) {
-      this.ignoreEndDatepickerEvent = true;
-    }
     this.formQuery.timeStart = typeof days === 'number'
       ? (-1) * Math.abs(days) + '/0'
       : undefined;

--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -130,10 +130,9 @@
 </section>
 
 <!-- DATE -->
-<section class="laji-panel" laji-panel [title]="'observation.form.date' | translate" [autoToggle]="true"  [open]="visible['time']">
+<section class="laji-panel laji-panel-time" laji-panel [title]="'observation.form.date' | translate" [autoToggle]="true"  [open]="visible['time']">
   <laji-date-form [query]="query"
                   [formQuery]="formQuery"
-                  [dateFormat]="dateFormat"
                   (formQueryChange)="onFormQueryChange()"
                   (queryChange)="onQueryChange()"
                   (searchQueryChange)="updateSearchQuery($event[0], $event[1])"

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -11,6 +11,8 @@ import { isRelativeDate } from './date-form/date-form.component';
 import { TaxonAutocompleteService } from '../../shared/service/taxon-autocomplete.service';
 import { BrowserService } from 'projects/laji/src/app/shared/service/browser.service';
 
+const DATE_FORMAT = 'YYYY-MM-DD';
+
 interface ISections {
   taxon?: Array<keyof WarehouseQueryInterface>;
   own?: Array<keyof WarehouseQueryInterface>;
@@ -41,7 +43,6 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
 
   @Input() skipActiveFilters: string[] = [];
   @Input() invasiveStatuses: string[] = [];
-  @Input() dateFormat = 'YYYY-MM-DD';
 
   @Output() queryChange = new EventEmitter<WarehouseQueryInterface>();
   @Output() mapDraw = new EventEmitter<string>();
@@ -499,7 +500,7 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
   }
 
   private getValidDate(date) {
-    if (date && (moment(date, this.dateFormat, true).isValid() || isRelativeDate(date))) {
+    if (date && (moment(date, DATE_FORMAT, true).isValid() || isRelativeDate(date))) {
       return date;
     }
     return '';
@@ -607,8 +608,8 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
       return '';
     }
     if (
-      (start && !moment(start, this.dateFormat, true).isValid()) ||
-      (end && !moment(end, this.dateFormat, true).isValid())
+      (start && !moment(start, DATE_FORMAT, true).isValid()) ||
+      (end && !moment(end, DATE_FORMAT, true).isValid())
     ) {
       return '';
     }

--- a/projects/laji/src/app/+observation/view/observation-view.component.html
+++ b/projects/laji/src/app/+observation/view/observation-view.component.html
@@ -36,7 +36,6 @@
         [query]="vm.query"
         [skipActiveFilters]="skipUrlParameters"
         [invasiveStatuses]="invasiveStatuses"
-        [dateFormat]="dateFormat"
         (queryChange)="onQueryChange($event)"
         (mapDraw)="draw($event)"
       ></laji-form-sample>
@@ -44,7 +43,6 @@
         *ngSwitchDefault
         [query]="vm.query"
         [invasiveStatuses]="invasiveStatuses"
-        [dateFormat]="dateFormat"
         (queryChange)="onQueryChange($event)"
         (mapDraw)="draw($event)"
       ></laji-observation-form>

--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -72,7 +72,6 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
   subscription: any;
 
   showFilter = true;
-  dateFormat = 'YYYY-MM-DD';
   statusFilterMobile = false;
 
   invasiveStatuses: string[] = [

--- a/projects/laji/src/app/+theme/quality/quality-filters/quality-filters.component.html
+++ b/projects/laji/src/app/+theme/quality/quality-filters/quality-filters.component.html
@@ -14,19 +14,13 @@
     <div class="form-inline">
       <laji-datepicker
         [(ngModel)]="filters.timeStart"
-        [viewFormat]="'DD.MM.YYYY'"
-        [otherFormats]="['D.M.YYYY', 'YYYY']"
-        [format]="'YYYY-MM-DD'"
         [addonText]="'quality.timeStart' | translate"
         (dateSelect)="onSelectChange()"
         (change)="onSelectChange()"
         name="timeStart"></laji-datepicker>
       <laji-datepicker
         [(ngModel)]="filters.timeEnd"
-        [viewFormat]="'DD.MM.YYYY'"
-        [otherFormats]="['D.M.YYYY', 'YYYY']"
         [toLastOfYear]="true"
-        [format]="'YYYY-MM-DD'"
         [addonText]="'quality.timeEnd' | translate"
         (dateSelect)="onSelectChange()"
         (change)="onSelectChange()"

--- a/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
+++ b/projects/laji/src/app/shared-modules/own-submissions/own-datatable/own-datatable.component.html
@@ -41,9 +41,6 @@
         <label>{{ 'observations.label.detAfter' | translate }}&nbsp;</label>
         <div class="date-picker-wrapper"><laji-datepicker
         [(ngModel)]="labelFilter.detLaterThan"
-        [viewFormat]="'DD.MM.YYYY'"
-        [otherFormats]="['D.M.YYYY', 'YYYY']"
-        [format]="'YYYY-MM-DD'"
         [popoverAlign]="'left'"
         (dateSelect)="updateLabelFilter('detLaterThan', labelFilter.detLaterThan)"
         (change)="updateLabelFilter('detLaterThan', labelFilter.detLaterThan)"></laji-datepicker></div></div>

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.css
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.css
@@ -145,15 +145,19 @@
   pointer-events: none;
 }
 
-.ng-datepicker > .calendar > span > span.day:hover {
-  background: rgba(0, 0, 0, 0.4);
-  color: #fff;
-}
-
 .ng-datepicker > .calendar > span > span.day.selected {
   background: rgba(0, 0, 0, 0.8);
   cursor: default;
   pointer-events: none;
+  color: #fff;
+}
+
+.ng-datepicker > .calendar > span > span.day.today {
+  background: #e3e3e3;
+}
+
+.ng-datepicker > .calendar > span > span.day:hover {
+  background: rgba(0, 0, 0, 0.4);
   color: #fff;
 }
 

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.html
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.html
@@ -2,11 +2,11 @@
   <span *ngIf="addonText" class="input-group-addon">{{ addonText }}</span>
   <input type="text"
          class="ng-datepicker-input form-control input-sm"
-         [value]="viewDate"
-         (blur)="updateValue(dateInput.value)"
+         [value]="viewValue"
+         (blur)="onInputValueChange(dateInput.value)"
          #dateInput>
-  <span *ngIf="viewDate !== ''" class="input-group-addon link clear" (click)="clear()">x</span>
-  <span class="input-group-addon link" (click)="toggle()"><i class="glyphicon glyphicon-calendar"></i></span>
+  <span *ngIf="viewValue !== ''" class="input-group-addon link clear" (click)="onInputValueChange('')">x</span>
+  <span class="input-group-addon link calendar-toggle" (click)="toggle()"><i class="glyphicon glyphicon-calendar"></i></span>
 </div>
 
 <div *ngIf="opened">
@@ -18,7 +18,7 @@
         <i class="glyphicon glyphicon-chevron-left" (click)="prevMonth()"></i>
       </div>
       <span class="date">
-        {{ ('m-' + date.format('MM')) | translate }} {{ date.format('YYYY') }}
+        {{ ('m-' + moment(calendarUIValue).format('MM')) | translate }} {{ moment(calendarUIValue).format('YYYY') }}
       </span>
       <div class="right">
         <i class="glyphicon glyphicon-chevron-right" (click)="nextMonth()"></i>
@@ -37,7 +37,7 @@
     </div>
     <div class="calendar">
         <span *ngFor="let d of days; let i = index">
-          <span class="day" [ngClass]="{'disabled': !d.enabled, 'selected': d.selected && d.enabled}"h
+          <span class="day" [ngClass]="{'selected': d.selected, 'today': d.today}"h
                 (click)="selectDate($event, i)">
             {{ d.day }}
           </span>

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.ts
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.ts
@@ -1,4 +1,3 @@
-import { distinctUntilChanged } from 'rxjs/operators';
 /**
  * Originally from here: https://github.com/jkuri/ng2-datepicker
  *
@@ -28,26 +27,24 @@ import { distinctUntilChanged } from 'rxjs/operators';
  */
 import {
   ChangeDetectionStrategy,
-  ChangeDetectorRef,
   Component,
+  ElementRef,
   EventEmitter,
   forwardRef,
   Input,
-  OnDestroy,
   OnInit,
   Output,
+  ViewChild,
   ViewContainerRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { BehaviorSubject, Subscription } from 'rxjs';
 import * as moment from 'moment';
 import { PlatformService } from '../../root/platform.service';
 
 export interface CalendarDate {
-  day: number;
-  month: number;
-  year: number;
-  enabled: boolean;
+  day: string;
+  month: string;
+  year: string;
   today: boolean;
   selected: boolean;
 }
@@ -58,6 +55,9 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
   multi: true
 };
 
+const FORMAT = 'YYYY-MM-DD'; // ISO-8601 format.
+const VIEW_FORMAT = 'D.M.YYYY'; // Allows e.g. '01.9.2022" and "1.09.2022".
+
 @Component({
   selector: 'laji-datepicker',
   templateUrl: './datepicker.component.html',
@@ -65,106 +65,87 @@ export const CALENDAR_VALUE_ACCESSOR: any = {
   providers: [CALENDAR_VALUE_ACCESSOR],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DatePickerComponent implements ControlValueAccessor, OnInit, OnDestroy {
-  @Input() classAttr: string;
-  @Input() expanded: boolean;
-  @Input() opened: boolean;
-  @Input() format: string;
-  @Input() otherFormats: string[] = [];
-  @Input() viewFormat: string;
-  @Input() firstWeekdaySunday: boolean;
+export class DatePickerComponent implements ControlValueAccessor, OnInit {
   @Input() toLastOfYear = false;
   @Input() addonText: string;
   @Input() popoverAlign: 'right' | 'left' = 'right';
   @Output() dateSelect = new EventEmitter();
 
+  @ViewChild('dateInput') dateInput: ElementRef;
+
+  public moment = moment;
   public validDate = true;
-  public viewDate: string = null;
+  public viewValue= '';
+  public calendarUIValue = ''; // The active calendar date in ISO-8601 format.
   public date: moment.Moment;
   public days: CalendarDate[] = [];
-  private readonly el: Element;
-  private currentValue;
+  public opened = false;
 
-  private valueSource = new BehaviorSubject<string>('');
-  private value$: Subscription;
+  private value: string | undefined;
+  private readonly el: Element;
+  private onTouchedCallback: () => void;
+  private onChangeCallback: (_: any) => void;
 
   constructor(
-    private viewContainerRef: ViewContainerRef,
-    private cd: ChangeDetectorRef,
+    viewContainerRef: ViewContainerRef,
     private platformService: PlatformService
   ) {
     this.el = viewContainerRef.element.nativeElement;
-    this.date = moment();
-  }
-
-  get value(): any {
-    return this.currentValue;
-  }
-
-  set value(value: any) {
-    if (typeof value === 'string') {
-      value = value.trim();
-    }
-    let date: any = (value instanceof moment) ? value : moment(value, this.format, true);
-    if (date.isValid && !date.isValid()) {
-      this.validDate = false;
-      for (const format of [this.format, ...this.otherFormats]) {
-        date = moment(value, format, true);
-        if (date.isValid()) {
-          if (format.length <= 4 && this.toLastOfYear) {
-            date = moment(value, format, true).endOf('year');
-          }
-          this.value = date.format(this.format);
-          return;
-        }
-      }
-    }
-    value = value || undefined;
-    if (date.isValid && date.isValid()) {
-      this.validDate = true;
-      this.viewDate = date.format(this.viewFormat);
-      this.date = date;
-      if (this.currentValue !== value) {
-        this.onTouchedCallback();
-      }
-    } else if (value === undefined) {
-      this.validDate = true;
-      this.viewDate = '';
-    } else {
-      this.validDate = false;
-      this.viewDate = value || '';
-    }
-    if (this.currentValue !== value) {
-      this.sendNewValue(value);
-      this.currentValue = value;
-    }
-  }
-
-  private sendNewValue(value) {
-    this.onChangeCallback(value);
-    this.dateSelect.emit(value);
-    this.valueSource.next(value || '');
-    this.cd.markForCheck();
   }
 
   ngOnInit() {
-    this.classAttr = `ui-kit-calendar-container ${this.classAttr}`;
-    this.opened = this.opened || false;
-    this.format = this.format || 'YYYY-MM-DD';
-    this.viewFormat = this.viewFormat || 'D.M.YYYY';
-    this.firstWeekdaySunday = this.firstWeekdaySunday || false;
     if (this.platformService.isServer) {
       return;
     }
-    this.value$ = this.valueSource.pipe(
-      distinctUntilChanged(),
-    ).subscribe((val) => this.value = val);
   }
 
-  ngOnDestroy() {
-    if (this.value$) {
-      this.value$.unsubscribe();
+  onInputValueChange(viewFormatValue: string) {
+    const viewFormMoment = moment(viewFormatValue, VIEW_FORMAT, true);
+
+    if (this.validDate && viewFormatValue && !viewFormMoment.isValid()) {
+      this.validDate = false;
+      return this.onInputValueChange(this.viewValue); // Restore prev value that is valid.
+    } else {
+      this.validDate = true;
     }
+
+
+    // First try formatting with default view format.
+    if (viewFormMoment.isValid()) {
+      return this.updateValue(viewFormMoment.format(FORMAT));
+    }
+
+    // Try formatting a value that is just a year.
+    const yearMoment = moment(viewFormatValue, 'YYYY', true);
+    if (yearMoment.isValid()) {
+      const momentValue = this.toLastOfYear ? yearMoment.endOf('year') : yearMoment.startOf('year');
+      return this.updateValue(momentValue.format(FORMAT));
+    }
+
+    this.updateValue('');
+  }
+
+  updateValue(value?: string) { // Expects ISO-8601 formatted value.
+    if (value && !moment(value, FORMAT, true).isValid()) {
+      throw new Error(`Invalid date for laji-datepicker$ (${value}). only ISO-8601 dates are accepted.`);
+    }
+    if (!value) {
+      value = undefined;
+    }
+    this.value = value;
+    this.viewValue = value
+      ? moment(value, FORMAT).format(VIEW_FORMAT)
+      : '';
+
+    // Update input elem value manually, as updating the input value attribute doesn't work.
+    if ( this.dateInput) {
+      this.dateInput.nativeElement.value = this.viewValue;
+    }
+
+    this.calendarUIValue = value;
+    this.dateSelect.next(this.value);
+    this.onChangeCallback?.(this.value);
+    this.generateCalendar();
   }
 
   closeEvent(e) {
@@ -177,42 +158,24 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit, OnDest
   }
 
   generateCalendar() {
-    const date = moment(this.date);
-    const month = date.month();
-    const year = date.year();
-    let n = 1;
-    const firstWeekDay: number = (this.firstWeekdaySunday) ? date.date(2).day() : date.date(1).day();
-
-    if (firstWeekDay !== 1) {
-      n -= (firstWeekDay + 6) % 7;
-    }
+    const date = moment(this.calendarUIValue);
+    const month = date.month() + 1; // Moment month is zero indexed.
+    const year = date.format('YYYY');
 
     this.days = [];
-    const selectedDate = moment(this.value, this.format);
-    for (let i = n; i <= date.endOf('month').date(); i += 1) {
-      const iteratedDate = moment(`${year}-${month + 1}-${i}`, 'YYYY-MM-DD');
-      const today = moment().isSame(iteratedDate, 'day') && moment().isSame(iteratedDate, 'month');
+    const selectedDate = moment(this.value, FORMAT);
+    for (let i = 1; i <= date.endOf('month').date(); i += 1) {
+      const iteratedDate = moment(`${year}-${month}-${i}`, 'YYYY-M-D');
+      const today = moment().isSame(iteratedDate.format(), 'day');
       const selected = selectedDate.isSame(iteratedDate, 'day');
 
-      if (i > 0) {
-        this.days.push({
-          day: i,
-          month: month + 1,
-          year,
-          enabled: true,
-          today,
-          selected
-        });
-      } else {
-        this.days.push({
-          day: null,
-          month: null,
-          year: null,
-          enabled: false,
-          today: false,
-          selected
-        });
-      }
+      this.days.push({
+        day: '' + iteratedDate.format('DD'),
+        month: '' + iteratedDate.format('MM'),
+        year,
+        today,
+        selected
+      });
     }
   }
 
@@ -220,42 +183,33 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit, OnDest
     e.preventDefault();
 
     const date: CalendarDate = this.days[i];
-    const selectedDate = moment(`${date.day}.${date.month}.${date.year}`, 'DD.MM.YYYY');
-    this.value = selectedDate.format(this.format);
-    this.viewDate = selectedDate.format(this.viewFormat);
+    this.updateValue(`${date.year}-${date.month}-${date.day}`);
     this.close();
     this.generateCalendar();
   }
 
   public prevYear(): void {
-    this.date = this.date.subtract(1, 'year');
+    this.calendarUIValue = moment(this.calendarUIValue).subtract(1, 'year').format();
     this.generateCalendar();
   }
 
   public nextYear(): void {
-    this.date = this.date.add(1, 'year');
+    this.calendarUIValue = moment(this.calendarUIValue).add(1, 'year').format();
     this.generateCalendar();
   }
 
   prevMonth() {
-    this.date = this.date.subtract(1, 'month');
+    this.calendarUIValue = moment(this.calendarUIValue).subtract(1, 'month').format();
     this.generateCalendar();
   }
 
   nextMonth() {
-    this.date = this.date.add(1, 'month');
+    this.calendarUIValue = moment(this.calendarUIValue).add(1, 'month').format();
     this.generateCalendar();
   }
 
-  updateValue(viewFormatValue: string) {
-    this.valueSource.next(viewFormatValue.length
-      ? moment(viewFormatValue, this.viewFormat, true).format(this.format)
-      : ''
-    );
-  }
-
-  writeValue(value: any) {
-    this.value = value;
+  writeValue(value: string) {
+    this.updateValue(value);
   }
 
   registerOnChange(fn: any) {
@@ -267,11 +221,6 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit, OnDest
   }
 
   toggle() {
-    if (!this.viewDate) {
-      const value = moment().format(this.format);
-      this.value = value;
-      this.onChangeCallback(value);
-    }
     if (!this.opened) {
       this.generateCalendar();
     }
@@ -285,14 +234,4 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit, OnDest
   close() {
     this.opened = false;
   }
-
-  clear() {
-    this.value = '';
-    this.dateSelect.emit(undefined);
-  }
-
-  private onTouchedCallback: () => void = () => {
-  };
-  private onChangeCallback: (_: any) => void = () => {
-  };
 }

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.ts
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.ts
@@ -32,14 +32,12 @@ import {
   EventEmitter,
   forwardRef,
   Input,
-  OnInit,
   Output,
   ViewChild,
   ViewContainerRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import * as moment from 'moment';
-import { PlatformService } from '../../root/platform.service';
 
 export interface CalendarDate {
   day: string;
@@ -65,7 +63,7 @@ const VIEW_FORMAT = 'D.M.YYYY'; // Allows e.g. '01.9.2022" and "1.09.2022".
   providers: [CALENDAR_VALUE_ACCESSOR],
   changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class DatePickerComponent implements ControlValueAccessor, OnInit {
+export class DatePickerComponent implements ControlValueAccessor {
   @Input() toLastOfYear = false;
   @Input() addonText: string;
   @Input() popoverAlign: 'right' | 'left' = 'right';
@@ -87,16 +85,9 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit {
   private onChangeCallback: (_: any) => void;
 
   constructor(
-    viewContainerRef: ViewContainerRef,
-    private platformService: PlatformService
+    viewContainerRef: ViewContainerRef
   ) {
     this.el = viewContainerRef.element.nativeElement;
-  }
-
-  ngOnInit() {
-    if (this.platformService.isServer) {
-      return;
-    }
   }
 
   onInputValueChange(viewFormatValue: string) {
@@ -132,6 +123,7 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit {
     if (!value) {
       value = undefined;
     }
+    const prevValue = this.value;
     this.value = value;
     this.viewValue = value
       ? moment(value, FORMAT).format(VIEW_FORMAT)
@@ -144,7 +136,10 @@ export class DatePickerComponent implements ControlValueAccessor, OnInit {
 
     this.calendarUIValue = value;
     this.dateSelect.next(this.value);
-    this.onChangeCallback?.(this.value);
+    if (prevValue !== this.value) {
+      this.onChangeCallback?.(this.value);
+      this.onTouchedCallback?.();
+    }
     this.generateCalendar();
   }
 

--- a/projects/laji/src/app/shared/panel/panel.component.html
+++ b/projects/laji/src/app/shared/panel/panel.component.html
@@ -1,4 +1,4 @@
-<div class="panel-heading" [ngClass]="{link: headerLink}" aria-expanded="true" role="tab" (click)="activateCurrent()" tabindex="0" luKeyboardClickable>
+<div class="panel-heading" [ngClass]="{link: headerLink, 'is-open': open}" aria-expanded="true" role="tab" (click)="activateCurrent()" tabindex="0" luKeyboardClickable>
   <ng-container *ngIf="headingTemplate else defaultHeading">
     <ng-template [ngTemplateOutlet]="headingTemplate"></ng-template>
   </ng-container>


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/183827818
Demo https://183827818.dev.laji.fi/observation/list

* removes all input variables from the datepicker that aren't either used, or have always the same value in every instance where the component is used
  * I'd like to note that we shouldn't have input variables "just in case" - that adds complexity without necessarily adding any value
* date format for the actual value is strictly always `ISO-8601`
* date view format is always in Finnish format (e.g. "1.2.2022")
* handle the state with minimal amount of variables:
  * actual value is a simple `string` - could've been a `Moment` value but I prefer simple `string`s since they can be guaranteed to be immutable
  * the calendar UI value is a `Moment` instance because it needs more fine-grained manipulation 
* remove hack from `laji-date-form` that was a result of the buggy `laji-datepicker`. Also, properly trigger `onFormQueryChange()` when it is changed