### PR TITLE
Collection filter removed from the observation search [#183899007]

### DIFF
--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -580,14 +580,6 @@
     <label><laji-checkbox [value]="query.typeSpecimen" (valueChange)="onCheckBoxToggle('typeSpecimen')"></laji-checkbox>{{ 'observation.form.typeSpecimen' | translate }}</label>
     <laji-info [html]="'observation.info.typeSpecimen' | translate"></laji-info>
   </div>
-  <laji-metadata-select
-    [(ngModel)]="query.collectionId"
-    (ngModelChange)="onQueryChange()"
-    [multiple]="true"
-    [field]="'MY.collectionID'"
-    [placeholder]="'MY.collectionID' | label"
-    [mapToWarehouse]="false"
-    name="collectionID"></laji-metadata-select>
 </section>
 
 <!-- IDs, keywords -->


### PR DESCRIPTION
https://183899007.dev.laji.fi/en/observation/list
https://www.pivotaltracker.com/n/projects/2346653/stories/183899007

Fixes 2022. "Scientific collections -> Collection" -filter was no longer needed in observation search, so it is removed in this pull request.