### PR TITLE
Fix GIS download selection resetting

### DIFF
--- a/projects/laji-ui/src/lib/button/button.component.html
+++ b/projects/laji-ui/src/lib/button/button.component.html
@@ -5,7 +5,7 @@
   [ngClass]="classes"
   [class.pressed]="pressed"
   [class.lu-loading]="loading"
-  [disabled]="disabled || loading"
+  [disabled]="disabled || loading || isServer"
   (click)="onClick($event)"
   (mousedown)="onMouseDown()"
   (mouseup)="onMouseUp($event)">

--- a/projects/laji-ui/src/lib/button/button.component.ts
+++ b/projects/laji-ui/src/lib/button/button.component.ts
@@ -5,8 +5,9 @@ import {
   Output,
   EventEmitter,
   HostListener,
-  OnChanges, SimpleChanges, OnInit
+  OnChanges, SimpleChanges, OnInit, Inject, PLATFORM_ID
 } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
 
 export type ButtonRole = 'primary' | 'secondary' | 'neutral' | 'success' | 'warning' | 'danger' | 'other' | 'edit' ;
 
@@ -38,9 +39,17 @@ export class ButtonComponent implements OnChanges, OnInit {
   pressed = false;
   classes = {};
 
+  isServer = false;
+
   @Input() set anchor(url: string|string[]) {
     this.routerLink = url;
     this.useHref = typeof url === 'string' && (url.startsWith('http') || url.includes('?'));
+  }
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: any
+  ) {
+    this.isServer = isPlatformServer(this.platformId);
   }
 
   @HostListener('click', ['$event'])

--- a/projects/laji/src/app/shared/directive/ssr-disable.directive.ts
+++ b/projects/laji/src/app/shared/directive/ssr-disable.directive.ts
@@ -7,7 +7,7 @@ import { PlatformService } from '../../root/platform.service';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'input[type=text], input[type=checkbox], button'
+  selector: 'input[type=text], input[type=checkbox], input[type=radio], button'
 })
 export class SsrDisableDirective implements OnInit {
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183838261

If the user filled the GIS download form before the page had fully loaded, it reset. This was fixed by disabling radio buttons and lu-buttons when server side rendering.