### PR TITLE
fix grc sample aggregate query failing

### DIFF
--- a/projects/laji/e2e/protractor.conf.js
+++ b/projects/laji/e2e/protractor.conf.js
@@ -46,6 +46,7 @@ exports.config = {
     map: './src/+map/**/*.e2e-spec.ts',
     vihko: './src/+vihko/**/*.e2e-spec.ts',
     projectForm: './src/+project-form/**/*.e2e-spec.ts',
+    geneticResource: './src/+theme/genetic-resource/*.e2e-spec.ts'
   },
   baseUrl: 'http://localhost:3000/',
   framework: 'jasmine',

--- a/projects/laji/e2e/src/+theme/genetic-resource/genetic-resource.e2e-spec.ts
+++ b/projects/laji/e2e/src/+theme/genetic-resource/genetic-resource.e2e-spec.ts
@@ -1,0 +1,24 @@
+import { ErrorPage } from '../../+error/error.page';
+import { GeneticResourcePage } from './genetic-resource.po';
+
+describe('Genetic Resource page', () => {
+  let page: GeneticResourcePage;
+  let error: ErrorPage;
+
+  beforeEach(() => {
+    page = new GeneticResourcePage();
+    error = new ErrorPage();
+  });
+
+  afterEach(async (done) => {
+    expect(await error.isPresentErrorDialog()).toBe(false, 'Error dialog was visible when it should not be');
+    done();
+  });
+
+  it('should not have non-graphql api errors', async (done) => {
+    await page.navigateToMollusca();
+    await page.waitUntilLoaded();
+    expect(await page.hasNonGQLApiErrors()).toBe(false);
+    done();
+  });
+});

--- a/projects/laji/e2e/src/+theme/genetic-resource/genetic-resource.po.ts
+++ b/projects/laji/e2e/src/+theme/genetic-resource/genetic-resource.po.ts
@@ -1,0 +1,23 @@
+import { $, browser } from 'protractor';
+import { waitForInvisibility } from '../../../helper';
+
+export class GeneticResourcePage {
+  private spinners$ = $('laji-observation-result').$$('.spinner');
+
+  async navigateToMollusca() {
+    await browser.get(`theme/luomusgrc/search/list?keyword=http:%2F%2Ftun.fi%2FGX.8057`);
+  }
+  async hasNonGQLApiErrors() {
+    const browserLog = await browser.manage().logs().get('browser');
+    const badRequests = browserLog.filter(entry =>
+      // matches any string that includes api/ followed by 400/404/500, but does not include graphql
+      entry.message.match(/.*api\/(?!graphql).*(?:40[04]|500)/)
+    );
+    return badRequests.length > 0;
+  }
+  async waitUntilLoaded() {
+    for (const spinner$ of await this.spinners$) {
+      await waitForInvisibility(spinner$);
+    }
+  }
+}

--- a/projects/laji/src/app/+theme/genetic-resource/genetic-resource.component.ts
+++ b/projects/laji/src/app/+theme/genetic-resource/genetic-resource.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component, OnDestroy, OnInit } from '@angular/
 import { ActivatedRoute } from '@angular/router';
 import { AbstractObservation } from '../../+observation/abstract-observation';
 import { ObservationFacade } from '../../+observation/observation.facade';
-import { WarehouseApi } from '../../shared/api/WarehouseApi';
+import { WarehouseApi, WarehouseSubPath } from '../../shared/api/WarehouseApi';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
 import { Util } from '../../shared/service/util.service';
 import { TableColumnService } from '../../shared-modules/datatable/service/table-column.service';
@@ -40,7 +40,7 @@ export class GeneticResourceComponent extends AbstractObservation implements OnI
   ) {
     super();
     this.observationListService.idFields = ['sample.sampleId', 'unit.unitId', 'document.documentId'];
-    this.warehouseApi.subPath = '/warehouse/query/sample/';
+    this.warehouseApi.subPath = WarehouseSubPath.sample;
     this.observationFacade.emptyQuery = {
       sampleCollectionId: ['HR.77', 'HR.2831'],
       sampleType: ['MF.preparationTypeDNAExtract', 'MF.preparationTypeTissue']

--- a/projects/laji/src/app/shared/api/WarehouseApi.ts
+++ b/projects/laji/src/app/shared/api/WarehouseApi.ts
@@ -39,12 +39,15 @@ import { geoJSONToWKT } from 'laji-map/lib/utils';
 
 'use strict';
 
+export enum WarehouseSubPath {
+  default = '/warehouse/query/',
+  sample = '/warehouse/query/sample/'
+}
+
 @Injectable({providedIn: 'root'})
 export class WarehouseApi {
   public static readonly longTimeout = 10000;
-  public subPath:
-    '/warehouse/query/sample/' |
-    '/warehouse/query/' = '/warehouse/query/';
+  public subPath: WarehouseSubPath = WarehouseSubPath.default;
   protected basePath = environment.apiBase;
 
   constructor(
@@ -187,7 +190,8 @@ export class WarehouseApi {
    * @param onlyCount return only count in result items (default true).
    */
   public warehouseQueryAggregateGet(query: WarehouseQueryInterface, aggregateBy?: Array<string>, orderBy?: Array<string>, pageSize?: number, page?: number, geoJSON?: boolean, onlyCount?: boolean): Observable<PagedResult<any>|any> {
-    return this.warehouseQueryGet('unit/aggregate', query, aggregateBy, orderBy, pageSize, page, geoJSON, onlyCount);
+    const target = this.subPath === WarehouseSubPath.sample ? 'aggregate' : 'unit/aggregate';
+    return this.warehouseQueryGet(target, query, aggregateBy, orderBy, pageSize, page, geoJSON, onlyCount);
   }
 
   /**


### PR DESCRIPTION
The regular warehouse queries no longer fail (however graphql queries do fail, that needs to be fixed in graphql-backend). The issue was that the query was targeting `/api/warehouse/query/sample/unit/aggregate` instead of `/api/warehouse/query/sample/aggregate`. I fixed it, but could not locate when/why this was changed (seeing as grc must have worked at some point)

https://www.pivotaltracker.com/story/show/184114619
https://184114619.dev.laji.fi/