### PR TITLE
fix obs search filters date change management [fixes #184323833]

### DIFF
--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.html
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.html
@@ -3,15 +3,8 @@
     <label>{{ 'observation.form.time' | translate }}</label>
     <laji-info>{{ 'observation.info.time' | translate }}</laji-info>
   </div>
-  <laji-datepicker
-    [(ngModel)]="datepickerTimeStart"
-    (change)="onFormQueryChange()"
-    name="timeStart"></laji-datepicker>
-  <laji-datepicker
-    [(ngModel)]="datepickerTimeEnd"
-    [toLastOfYear]="true"
-    (change)="onFormQueryChange()"
-    name="timeEnd"></laji-datepicker>
+  <laji-datepicker [(ngModel)]="datepickerTimeStart" ></laji-datepicker>
+  <laji-datepicker [(ngModel)]="datepickerTimeEnd" [toLastOfYear]="true"></laji-datepicker>
   <div class="btn-group btn-group-xs mt-1">
     <button type="button" class="btn btn-default btn-today" (click)="onUpdateTime(1)">{{ 'observations.form.1d' | translate }}</button>
     <button type="button" class="btn btn-default btn-week" (click)="onUpdateTime(7)">{{ 'observations.form.7d' | translate }}</button>
@@ -38,15 +31,8 @@
       <label>{{ 'observation.form.loaded' | translate }}</label>
       <laji-info>{{ 'observation.info.loaded' | translate }}</laji-info>
     </div>
-    <laji-datepicker
-      [(ngModel)]="query.loadedSameOrAfter"
-      (change)="onQueryChange()"
-      name="timeStart"></laji-datepicker>
-    <laji-datepicker
-      [(ngModel)]="query.loadedSameOrBefore"
-      [toLastOfYear]="true"
-      (change)="onQueryChange()"
-      name="timeEnd"></laji-datepicker>
+    <laji-datepicker [(ngModel)]="loadedSameOrAfter"></laji-datepicker>
+    <laji-datepicker [(ngModel)]="loadedSameOrBefore" [toLastOfYear]="true"></laji-datepicker>
     <div class="btn-group btn-group-xs mt-1">
       <button type="button" class="btn btn-default" (click)="onUpdateTime(1, 'loadedSameOrAfter', 'loadedSameOrBefore')">{{ 'observations.form.1d' | translate }}</button>
       <button type="button" class="btn btn-default" (click)="onUpdateTime(7, 'loadedSameOrAfter', 'loadedSameOrBefore')">{{ 'observations.form.7d' | translate }}</button>
@@ -61,18 +47,9 @@
       <label>{{ 'observation.form.firstLoaded' | translate }}</label>
       <laji-info>{{ 'observation.info.firstLoaded' | translate }}</laji-info>
     </div>
-    <laji-datepicker
-      [(ngModel)]="query.firstLoadedSameOrAfter"
-      (dateSelect)="onQueryChange()"
-      (change)="onQueryChange()"
-      name="timeStart"></laji-datepicker>
+    <laji-datepicker [(ngModel)]="firstLoadedSameOrAfter"></laji-datepicker>
 
-    <laji-datepicker
-      [(ngModel)]="query.firstLoadedSameOrBefore"
-      [toLastOfYear]="true"
-      (dateSelect)="onQueryChange()"
-      (change)="onQueryChange()"
-      name="timeEnd"></laji-datepicker>
+    <laji-datepicker [(ngModel)]="firstLoadedSameOrBefore"></laji-datepicker>
 
     <div class="btn-group btn-group-xs mt-1">
       <button type="button" class="btn btn-default" (click)="onUpdateTime(1, 'firstLoadedSameOrAfter', 'firstLoadedSameOrBefore')">{{ 'observations.form.1d' | translate }}</button>

--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.ts
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.ts
@@ -44,6 +44,38 @@ export class DateFormComponent implements OnDestroy {
     this.onFormQueryChange();
   }
 
+  get loadedSameOrAfter() {
+    return this.query.loadedSameOrAfter;
+  }
+  set loadedSameOrAfter(v: string | undefined) {
+    this.query.loadedSameOrAfter = v;
+    this.queryChange.emit();
+  }
+
+  get loadedSameOrBefore() {
+    return this.query.loadedSameOrBefore;
+  }
+  set loadedSameOrBefore(v: string | undefined) {
+    this.query.loadedSameOrBefore = v;
+    this.queryChange.emit();
+  }
+
+  get firstLoadedSameOrAfter() {
+    return this.query.firstLoadedSameOrAfter;
+  }
+  set firstLoadedSameOrAfter(v: string | undefined) {
+    this.query.firstLoadedSameOrAfter = v;
+    this.queryChange.emit();
+  }
+
+  get firstLoadedSameOrBefore() {
+    return this.query.firstLoadedSameOrBefore;
+  }
+  set firstLoadedSameOrBefore(v: string | undefined) {
+    this.query.firstLoadedSameOrBefore = v;
+    this.queryChange.emit();
+  }
+
   get xDaysAgo() {
     return isRelativeDate(this.formQuery.timeStart) ? Math.abs(parseInt(this.formQuery.timeStart, 10)) : undefined;
   }
@@ -57,10 +89,6 @@ export class DateFormComponent implements OnDestroy {
 
   onFormQueryChange() {
     this.formQueryChange.emit();
-  }
-
-  onQueryChange() {
-    this.queryChange.emit();
   }
 
   updateSearchQuery(field, value) {

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.ts
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.ts
@@ -137,6 +137,7 @@ export class DatePickerComponent implements ControlValueAccessor {
     this.calendarUIValue = value;
     this.dateSelect.next(this.value);
     if (prevValue !== this.value) {
+      console.log('change', this.value, !!this.onChangeCallback);
       this.onChangeCallback?.(this.value);
       this.onTouchedCallback?.();
     }

--- a/projects/laji/src/app/shared/datepicker/datepicker.component.ts
+++ b/projects/laji/src/app/shared/datepicker/datepicker.component.ts
@@ -137,7 +137,6 @@ export class DatePickerComponent implements ControlValueAccessor {
     this.calendarUIValue = value;
     this.dateSelect.next(this.value);
     if (prevValue !== this.value) {
-      console.log('change', this.value, !!this.onChangeCallback);
       this.onChangeCallback?.(this.value);
       this.onTouchedCallback?.();
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184323833
https://184323833.dev.laji.fi/observation/statistics?countryId=ML.206&qualityIssues=BOTH&firstLoadedSameOrAfter=2023-01-20&observerPersonToken=true

The laji-datepicker was used with two-way binded ng model (`[(banana in a box syntax)]`), and it also had a change event listener. That didn't make sense, so it made it use only the two-way binded ng model. It had broken after the datepicker refactoring which made the datepicker implement ngModel value accessor interface better. 