### PR TITLE
Fix front page obs map [#184370599]

### DIFF
--- a/projects/laji/src/app/+home/home.component.html
+++ b/projects/laji/src/app/+home/home.component.html
@@ -72,19 +72,20 @@
       </a>
     </div>
     <div class="map-container">
-      <laji-observation-map
-        [routerLink]="['/observation/map'] | localize"
-        [settingsKey]="'frontMap'"
-        [height]="438"
-        [showControls]="false"
-        [initWithWorldMap]="false"
-        [clickBeforeZoomAndPan]="false"
-        [viewLocked]="true"
-        [noClick]="true"
-        [draw]="false"
-        [query]="{firstLoadedSameOrAfter: mapStartDate, countryId: 'ML.206', cache: true}"
-        [hideLegend]="true"
-      ></laji-observation-map>
+      <a [routerLink]="['/observation/map'] | localize" [queryParams]="mapQueryParams">
+        <laji-observation-map
+          [settingsKey]="'frontMap'"
+          [height]="438"
+          [showControls]="false"
+          [initWithWorldMap]="false"
+          [clickBeforeZoomAndPan]="false"
+          [viewLocked]="true"
+          [noClick]="true"
+          [draw]="false"
+          [query]="{firstLoadedSameOrAfter: mapStartDate, countryId: 'ML.206', cache: true}"
+          [hideLegend]="true"
+        ></laji-observation-map>
+      </a>
       <div>
         <div>
           <strong><laji-observation-count [lightLoader]="true" [value]="(homeData$ | async)?.today?.total"></laji-observation-count></strong>
@@ -92,7 +93,7 @@
           <strong><laji-observation-count [lightLoader]="true" [value]="(homeData$ | async)?.speciesToday?.total" ></laji-observation-count></strong>
           {{ 'observation.results.species' | translate }}
         </div>
-        <a [routerLink]="['/observation/map'] | localize" [queryParams]="{firstLoadedSameOrAfter: mapStartDate, countryId: 'ML.206'}">
+        <a [routerLink]="['/observation/map'] | localize" [queryParams]="mapQueryParams">
           {{ 'home.map.latest' | translate }}
         </a>
       </div>

--- a/projects/laji/src/app/+home/home.component.html
+++ b/projects/laji/src/app/+home/home.component.html
@@ -73,11 +73,14 @@
     </div>
     <div class="map-container">
       <laji-observation-map
+        [routerLink]="['/observation/map'] | localize"
         [settingsKey]="'frontMap'"
         [height]="438"
         [showControls]="false"
         [initWithWorldMap]="false"
-        [clickBeforeZoomAndPan]="true"
+        [clickBeforeZoomAndPan]="false"
+        [viewLocked]="true"
+        [noClick]="true"
         [draw]="false"
         [query]="{firstLoadedSameOrAfter: mapStartDate, countryId: 'ML.206', cache: true}"
         [hideLegend]="true"

--- a/projects/laji/src/app/+home/home.components.ts
+++ b/projects/laji/src/app/+home/home.components.ts
@@ -20,12 +20,14 @@ import { NewsFacade } from '../+news/news.facade';
 })
 export class HomeComponent implements OnInit {
 
-  mapStartDate;
+  mapStartDate: string;
+  mapQueryParams: Record<string, string>;
   images$: Observable<Image[]>;
   homeData$: Observable<IHomeData>;
   publications$: Observable<Information>;
 
   formId = Global.forms.whichSpecies;
+
 
   constructor(
     private sourceService: SourceService,
@@ -40,6 +42,7 @@ export class HomeComponent implements OnInit {
   ngOnInit() {
     this.newsFacade.loadPage(1);
     this.mapStartDate = HomeDataService.getRecentDate();
+    this.mapQueryParams = {firstLoadedSameOrAfter: this.mapStartDate, countryId: 'ML.206'};
     this.homeData$ = this.homeDataService.getHomeData();
     this.images$ = this.homeData$.pipe(
       map(data => data.identify && data.identify.results || []),

--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
@@ -132,6 +132,9 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
   @Input() set clickBeforeZoomAndPan(clickBeforeZoomAndPan: boolean) {
     this.mapOptions = {...this.mapOptions, clickBeforeZoomAndPan};
   }
+  @Input() set viewLocked(viewLocked: boolean) {
+    this.mapOptions = {...this.mapOptions, viewLocked};
+  }
   @Input() ready = true;
   /**
    * height < 0: fill remaining height in window
@@ -154,6 +157,7 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
     'document.linkings.collectionQuality',
     'gathering.interpretations.coordinateAccuracy'
   ];
+  @Input() noClick = false;
 
   @Output() create = new EventEmitter();
 
@@ -551,6 +555,9 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private onFeatureClick(e: any, d: any) {
+    if (this.noClick) {
+      return;
+    }
     if (d.feature.geometry.type === 'Point') {
       this.onDataClick({
         type: 'wgs84',


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184370599
https://184370599.dev.laji.fi

The obs map on the front page redirects to /observation/map on click. The map view is also locked (can't be panned/zoomed).