### PR TITLE
Fix biology tab descriptions & Refactor CheckLangService [#184388410]

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
@@ -29,7 +29,7 @@
         <div class="panel-group" role="tablist" aria-multiselectable="true">
           <div *ngFor="let group of taxonDescription[activeDescription]?.groups; let i = index">
             <div class="panel panel-default"
-               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && groupTranslationChecklist[activeDescription]"
+               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && (groupTranslationChecklist[activeDescription] && !(groupTranslationChecklist[activeDescription].groups[i].values.indexOf(false) == -1))"
                [title]="group.title | multiLang"
                [open]="true"
                [autoToggle]="true"

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
@@ -29,7 +29,7 @@
         <div class="panel-group" role="tablist" aria-multiselectable="true">
           <div *ngFor="let group of taxonDescription[activeDescription]?.groups; let i = index">
             <div class="panel panel-default"
-               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && ((groupHasTranslation[activeDescription] && groupHasTranslation[activeDescription].groups[i].values.indexOf(true) == -1) || (groupHasTranslation[activeDescription] && groupHasTranslation[activeDescription].groups[i].checkYlesta))"
+               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && groupTranslationChecklist[activeDescription]"
                [title]="group.title | multiLang"
                [open]="true"
                [autoToggle]="true"
@@ -37,11 +37,11 @@
                laji-panel>
                 <div *ngFor="let variable of group.variables; let y = index">
                   <div style="float:left; width: 100%">
-                    <h4 *ngIf="variable.variable !== 'MX.ingressText' && !groupHasTranslation[activeDescription].groups[i].values[y]">
+                    <h4 *ngIf="variable.variable !== 'MX.ingressText' && !groupTranslationChecklist[activeDescription].groups[i].values[y]">
                       {{ variable.title | multiLang }}
                     </h4>
-                    <strong *ngIf="variable.variable === 'MX.ingressText' && !groupHasTranslation[activeDescription].groups[i].values[y]" [innerHTML]="variable.content | multiLang"></strong>
-                    <span *ngIf="variable.variable !== 'MX.ingressText' && !groupHasTranslation[activeDescription].groups[i].values[y]" [innerHTML]="variable.content | multiLang"></span>
+                    <strong *ngIf="variable.variable === 'MX.ingressText' && !groupTranslationChecklist[activeDescription].groups[i].values[y]" [innerHTML]="variable.content | multiLang"></strong>
+                    <span *ngIf="variable.variable !== 'MX.ingressText' && !groupTranslationChecklist[activeDescription].groups[i].values[y]" [innerHTML]="variable.content | multiLang"></span>
                     <div *ngIf="group.group === 'MX.SDVG5' && variable.variable === 'MX.habitat'">
                       <div class="col-lg-6 col-md-6 col-xs-10">
                         <span *ngIf="!variable.variable"><h4>{{ 'iucn.filter.habitat' | translate }}</h4></span>

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.html
@@ -29,7 +29,7 @@
         <div class="panel-group" role="tablist" aria-multiselectable="true">
           <div *ngFor="let group of taxonDescription[activeDescription]?.groups; let i = index">
             <div class="panel panel-default"
-               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && (groupTranslationChecklist[activeDescription] && !(groupTranslationChecklist[activeDescription].groups[i].values.indexOf(false) == -1))"
+               *ngIf="(group.group !== 'MX.SDVG14') && (group.group !== 'MX.SDVG8') && (groupTranslationChecklist[activeDescription] && groupTranslationChecklist[activeDescription].groups[i].hasTranslatedContent)"
                [title]="group.title | multiLang"
                [open]="true"
                [autoToggle]="true"

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-biology/taxon-biology.component.ts
@@ -17,7 +17,7 @@ export class TaxonBiologyComponent implements OnChanges {
   translationKo: any;
   ylesta: any;
   ylestaTitle: any;
-  groupHasTranslation: any[];
+  groupTranslationChecklist: any[];
   ylestaHasTranslation: any;
 
   hasAuthorData = true;
@@ -32,14 +32,14 @@ export class TaxonBiologyComponent implements OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     this.ylesta = [{text: undefined, visible: undefined}];
     this.ylestaTitle = undefined;
-    this.groupHasTranslation = [];
+    this.groupTranslationChecklist = [];
     this.ylestaHasTranslation = [];
     this.activeDescriptionContent = {};
     this.currentLang = this.translation.currentLang;
     if (changes.taxonDescription || changes.context) {
       this.activeDescription = 0;
       if (this.taxonDescription && this.context) {
-        this.groupHasTranslation = this.checklang.checkValue(this.taxonDescription);
+        this.groupTranslationChecklist = this.checklang.createTranslationChecklist(this.taxonDescription);
         this.taxonDescription.forEach((description, idx) => {
           if (description.id === this.context) {
             this.activeDescription = idx;
@@ -50,7 +50,7 @@ export class TaxonBiologyComponent implements OnChanges {
               this.ylestaTitle = gruppo.title;
               this.ylesta[0].text = gruppo.variables;
 
-              this.ylestaHasTranslation = this.groupHasTranslation[idx].groups.filter(el =>
+              this.ylestaHasTranslation = this.groupTranslationChecklist[idx].groups.filter(el =>
                 el.id === 'MX.SDVG8'
               );
               this.ylesta[0].visible = this.ylestaHasTranslation.length > 0 ? this.ylestaHasTranslation[0].values : [];

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.ts
@@ -29,7 +29,7 @@ export class TaxonOverviewComponent implements OnChanges, OnDestroy {
   ylestaTitle: any;
   ylestaSpeciesCardAuthors: any;
   _taxonDescription: TaxonomyDescription[];
-  groupHasTranslation: any[];
+  groupTranslationChecklist: any[];
   ylestaHasTranslation: any[];
   isChildrenOnlySpecie = false;
   totalObservations = 0;
@@ -51,11 +51,11 @@ export class TaxonOverviewComponent implements OnChanges, OnDestroy {
     this.ylesta = [{text: undefined, visible: undefined}];
     this.ylestaTitle = undefined;
     this.ylestaSpeciesCardAuthors = undefined;
-    this.groupHasTranslation = [];
+    this.groupTranslationChecklist = [];
     this.ylestaHasTranslation = [];
     this._taxonDescription = taxonDescription && taxonDescription.length > 0 ? taxonDescription : undefined;
     if (this._taxonDescription && this._taxonDescription.length > 0) {
-      this.groupHasTranslation = this.checklang.checkValue(this._taxonDescription);
+      this.groupTranslationChecklist = this.checklang.createTranslationChecklist(this._taxonDescription);
       this._taxonDescription.forEach((item, idx) => {
         (item.groups || []).forEach(gruppo => {
           if (gruppo.group === 'MX.SDVG1' && this.description === undefined && this.ingress === undefined) {
@@ -72,7 +72,7 @@ export class TaxonOverviewComponent implements OnChanges, OnDestroy {
             this.ylestaSpeciesCardAuthors = item.speciesCardAuthors ? item.speciesCardAuthors : null;
             this.ylesta[0].text = gruppo.variables;
 
-            this.ylestaHasTranslation = this.groupHasTranslation[idx].groups.filter(el =>
+            this.ylestaHasTranslation = this.groupTranslationChecklist[idx].groups.filter(el =>
               el.id === 'MX.SDVG8'
             );
             this.ylesta[0].visible = this.ylestaHasTranslation.length > 0 ? this.ylestaHasTranslation[0].values : [];

--- a/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
@@ -37,6 +37,8 @@ export class CheckLangService {
       }
     });
 
-    this.translationChecklist[index].groups.push({ id, values: tmpArray });
+    const hasTranslatedContent = !(tmpArray.indexOf(false) === -1);
+
+    this.translationChecklist[index].groups.push({ id, values: tmpArray, hasTranslatedContent });
   }
 }

--- a/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
@@ -28,16 +28,16 @@ export class CheckLangService {
   checkVariableTranslations(item: any, id: string, index: number): void {
     this.currentLang = this.translate.currentLang;
     const tmpArray = [];
+    let hasTranslatedContent = false;
 
     item.variables.forEach(text => {
       if (!text.content[this.currentLang]) {
         tmpArray.push(true); // true, i.e. no content in the currently used language
       } else {
         tmpArray.push(false); // false, i.e. has content in the currently used language
+        if (!hasTranslatedContent) { hasTranslatedContent = true; }
       }
     });
-
-    const hasTranslatedContent = !(tmpArray.indexOf(false) === -1);
 
     this.translationChecklist[index].groups.push({ id, values: tmpArray, hasTranslatedContent });
   }

--- a/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/service/check-lang.service.ts
@@ -1,77 +1,42 @@
 import { Injectable } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
+import { TaxonomyDescription } from '../../../shared/model/Taxonomy';
 
 @Injectable()
 export class CheckLangService {
 
   static readonly lang = ['en', 'fi', 'sv'];
   public currentLang: any;
-  public value: any;
-  public count: number;
-  public checktranslation: any[];
-  public ylestaIndex: number;
-  public infoIndex: number;
+  public translationChecklist: any[];
 
-  constructor(private translate: TranslateService) {}
+  constructor(private translate: TranslateService) { }
 
- public checkValue(info: any): any {
-  this.checktranslation = [];
-    info.forEach((item, index) => {
-      this.checktranslation.push({id: item.id, groups: [], totalVisible: undefined});
+  // creates a list of groups, where each variable is given a value depending on whether it has content in the used language
+  // true value means that the variable doesn't have content in the currently used language
+  public createTranslationChecklist(taxonDescription: TaxonomyDescription[]): any {
+    this.translationChecklist = [];
+    taxonDescription.forEach((item, index) => {
+      this.translationChecklist.push({ id: item.id, groups: [] });
       (item.groups || []).forEach(group => {
-        this.translationExist(group, group.group, index);
+        this.checkVariableTranslations(group, group.group, index);
       });
     });
 
-    this.checkGeneralGroup(this.checktranslation);
-
-    return this.checktranslation;
+    return this.translationChecklist;
   }
 
-  translationExist(item: any, id: string, index: number): boolean {
+  checkVariableTranslations(item: any, id: string, index: number): void {
     this.currentLang = this.translate.currentLang;
     const tmpArray = [];
 
     item.variables.forEach(text => {
       if (!text.content[this.currentLang]) {
-        tmpArray.push(true);
+        tmpArray.push(true); // true, i.e. no content in the currently used language
       } else {
-        tmpArray.push(false);
+        tmpArray.push(false); // false, i.e. has content in the currently used language
       }
     });
 
-    this.checktranslation[index].groups.push({id, values: tmpArray, checkYlesta: false});
-
-    if (tmpArray.filter(x => x === false).length > 0) {
-      return this.checktranslation[index].totalVisible = true;
-    } else {
-      return this.checktranslation[index].totalVisible = false;
-    }
-
+    this.translationChecklist[index].groups.push({ id, values: tmpArray });
   }
-
-  checkGeneralGroup(data: any): any {
-
-    data.forEach((item, i) => {
-      this.ylestaIndex = undefined;
-      this.infoIndex = undefined;
-      item.groups.forEach((element, index) => {
-        if (element.id === 'MX.SDVG8') {
-          this.ylestaIndex = index;
-        }
-        if (element.id === 'MX.SDVG1') {
-          this.infoIndex = index;
-        }
-      });
-
-      if (this.ylestaIndex >= 0 && this.infoIndex >= 0) {
-        if (data[i].groups[this.ylestaIndex].values.includes(false) && data[i].groups[this.infoIndex].values.includes(true)) {
-          data[i].groups[this.infoIndex].checkYlesta = true;
-        }
-      }
-    });
-
-  }
-
-
 }


### PR DESCRIPTION
https://184388410.dev.laji.fi/taxon/MX.205601/biology
https://www.pivotaltracker.com/n/projects/2346653/stories/184388410

In some cases, some descriptions were not rendered on taxon card's biology tab. Turned out that the reason was a condition that prevented showing the whole description group if any number of its variables were not translated into the used language (line 32 of taxon-biology-component.html). Now the condition for showing the group passes, if at least one variable has translations in the used language. Each variable has their own check now, and is shown if there's content in the used language.

On top that, this PR includes a refactor of CheckLangService, which seemed to have a lot of unused variables and functionalities, so I deleted those and renamed variables and functions to be more readable. CheckLangService is used to create a translationChecklist, which is used to check which variables have translations in the used language, while rendering variables in the template.