### PR TITLE
Technical news alert to PAP home page [#183451212]

### DIFF
--- a/projects/vir/src/app/+home/home.component.html
+++ b/projects/vir/src/app/+home/home.component.html
@@ -1,5 +1,6 @@
 <div class="container laji-page mt-6">
   <h1>{{ 'home.authority.title' | translate }}</h1>
+  <laji-technical-news></laji-technical-news>
   <div class="species-banner">
     <div class="img-1"></div>
     <div class="img-2"></div>

--- a/projects/vir/src/app/+home/home.module.ts
+++ b/projects/vir/src/app/+home/home.module.ts
@@ -7,6 +7,7 @@ import { HomeRoutingModule } from './home-routing.module';
 import { TranslateModule } from '@ngx-translate/core';
 import { SharedModule } from '../../../../laji/src/app/shared/shared.module';
 import { NavigationThumbnailModule } from '../../../../laji/src/app/shared-modules/navigation-thumbnail/navigation-thumbnail.module';
+import { TechnicalNewsModule } from 'projects/laji/src/app/shared-modules/technical-news/technical-news.module';
 
 
 @NgModule({
@@ -17,7 +18,8 @@ import { NavigationThumbnailModule } from '../../../../laji/src/app/shared-modul
     LajiUiModule,
     TranslateModule,
     NavigationThumbnailModule,
-    SharedModule
+    SharedModule,
+    TechnicalNewsModule
   ]
 })
 export class HomeModule { }


### PR DESCRIPTION
https://183451212.viranomaiset-dev.laji.fi/
https://www.pivotaltracker.com/n/projects/2346653/stories/183451212

PAP home page did not show alert of technical news, this is fixed now. Probably hard to test with the feature branch page, but there's a screenshot in Pivotal Tracker.