### PR TITLE
Disable all inputs when server side rendering

### DIFF
--- a/projects/laji/src/app/shared/directive/ssr-disable.directive.ts
+++ b/projects/laji/src/app/shared/directive/ssr-disable.directive.ts
@@ -7,7 +7,7 @@ import { PlatformService } from '../../root/platform.service';
 
 @Directive({
   // eslint-disable-next-line @angular-eslint/directive-selector
-  selector: 'input[type=text], input[type=checkbox], input[type=radio], button'
+  selector: 'input, button'
 })
 export class SsrDisableDirective implements OnInit {
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/184205197

This can only be tested in beta or with local SSR (and the throttling needs to be on to see it). I changed the SSR disable directive to disable all inputs and not just those with certain types. If the user changes an input value when the page is not fully loaded, it will reset when the page finishes loading so it's better to disable the inputs before that.