### PR TITLE
Fix collection filter 184003345

### DIFF
--- a/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
+++ b/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
@@ -5,7 +5,7 @@
       [includedOptions]="includedOptions"
       [excludedOptions]="excludedOptions"
       [optionsTree$]="collectionsTree$"
-      [options$]="collections$"
+      [options]="collections$ | async"
       [modalButtonLabel]="modalButtonLabel"
       [modalTitle]="modalTitle"
       [browseTitle]="browseTitle"

--- a/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
+++ b/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
@@ -2,8 +2,8 @@
   <strong *ngIf="title !== undefined && title !== ''" class="lj-title link" (click)="toggle($event)">{{ title }}<laji-info *ngIf="info" [html]="info"></laji-info></strong>
   <div *ngIf="open">
     <laji-tree-select
-      [includedOptions]="includedOptions"
-      [excludedOptions]="excludedOptions"
+      [includedOptions]="(selectedOptions$ | async).includedOptions"
+      [excludedOptions]="(selectedOptions$ | async).excludedOptions"
       [optionsTree$]="collectionsTree$"
       [options]="collections$ | async"
       [modalButtonLabel]="modalButtonLabel"

--- a/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
+++ b/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
@@ -1,7 +1,7 @@
 <div>
   <laji-tree-select
-    [includedOptions]="includedOptions"
-    [excludedOptions]="excludedOptions"
+    [includedOptions]="(selectedOptions$ | async).includedOptions"
+    [excludedOptions]="(selectedOptions$ | async).excludedOptions"
     [optionsTree$]="groupsTree$"
     [options]="groups$ | async"
     [modalButtonLabel]="modalButtonLabel"

--- a/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
+++ b/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
@@ -3,7 +3,7 @@
     [includedOptions]="includedOptions"
     [excludedOptions]="excludedOptions"
     [optionsTree$]="groupsTree$"
-    [options$]="groups$"
+    [options]="groups$ | async"
     [modalButtonLabel]="modalButtonLabel"
     [modalTitle]="modalTitle"
     [browseTitle]="browseTitle"

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select-modal/tree-select-modal.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select-modal/tree-select-modal.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, OnInit, ViewChild, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, ViewChild, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
 import { BsModalRef } from 'ngx-bootstrap/modal';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { TreeOptionsNode, SelectedOption } from '../tree-select.component';
 import { TreeSelectorComponent } from '../tree-selector/tree-selector.component';
 
@@ -12,7 +12,7 @@ import { TreeSelectorComponent } from '../tree-selector/tree-selector.component'
 })
 
 export class TreeSelectModalComponent {
-  @Input() selectedOptions$: SelectedOption[];
+  @Input() selectedOptions: SelectedOption[];
   @Input() optionsTree$: Observable<TreeOptionsNode[]>;
   @Input() modalTitle: string;
   @Input() browseTitle: string;
@@ -25,8 +25,6 @@ export class TreeSelectModalComponent {
   @Input() includeLink: boolean;
   @ViewChild('treeSelector') treeSelectorComponent: TreeSelectorComponent;
   @Output() emitConfirm = new EventEmitter<SelectedOption[]>();
-
-  selectedOptions: SelectedOption[];
 
   constructor(
     private modalRef: BsModalRef,

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.html
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.html
@@ -3,7 +3,7 @@
     {{modalButtonLabel}}
   </lu-button>
   <ng-container *ngIf='includedOptions?.length !== 0 || excludedOptions?.length !== 0'>
-    <ng-container *ngIf='options; else loading'>
+    <ng-container *ngIf='options?.length > 0; else loading'>
       <laji-selected-tree-nodes
         [selectedOptions]='options'
         [includedTitle]="includedTitle"

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, Input, EventEmitter, Output, OnInit, ChangeDetectorRef, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, ChangeDetectionStrategy, Input, EventEmitter, Output } from '@angular/core';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Observable } from 'rxjs';
 import { TreeSelectModalComponent } from './tree-select-modal/tree-select-modal.component';
@@ -30,11 +30,11 @@ export interface TreeOptionsChangeEvent {
   changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class TreeSelectComponent implements OnInit {
+export class TreeSelectComponent {
   @Input() includedOptions: string[] = [];
   @Input() excludedOptions: string[] = [];
   @Input() optionsTree$: Observable<TreeOptionsNode[]>;
-  @Input() options$: Observable<SelectedOption[]>;
+  @Input() options: SelectedOption[];
   @Input() modalButtonLabel: string;
   @Input() modalTitle: string;
   @Input() browseTitle: string;
@@ -49,20 +49,10 @@ export class TreeSelectComponent implements OnInit {
 
   lang: string;
   modalRef: BsModalRef;
-  options: SelectedOption[];
 
   constructor(
-    private modalService: BsModalService,
-    private cd: ChangeDetectorRef
+    private modalService: BsModalService
   ) {}
-
-  ngOnInit() {
-    this.options$.subscribe(data => {
-      this.options = data;
-
-      this.cd.markForCheck();
-    });
-  }
 
   openModal() {
     const initialState = {

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, Input, EventEmitter, Output } from 
 import { BsModalRef, BsModalService } from 'ngx-bootstrap/modal';
 import { Observable } from 'rxjs';
 import { TreeSelectModalComponent } from './tree-select-modal/tree-select-modal.component';
+import { Util } from '../../shared/service/util.service';
 
 
 export interface SelectedOption {
@@ -83,10 +84,12 @@ export class TreeSelectComponent {
         }
       });
 
-      this.selectedOptionsChange.emit({
-        selectedId: includeToReturn,
-        selectedIdNot: excludeToReturn,
-      });
+      if (!Util.equalsArray(this.includedOptions, includeToReturn) || !Util.equalsArray(this.excludedOptions, excludeToReturn)) {
+        this.selectedOptionsChange.emit({
+          selectedId: includeToReturn,
+          selectedIdNot: excludeToReturn,
+        });
+      }
     });
   }
 


### PR DESCRIPTION
https://184003345.dev.laji.fi/observation/statistics
https://www.pivotaltracker.com/story/show/184003345

The reason for this bug was that the `collections$` observable (in`projects/laji/src/app/shared-modules/collections-select/collections-select.component.ts`) was recreated when the query changed and the tree select component subscribed only the first observable. It's preferred that the observables are created only once so I changed that for both collection select and informal group select. I also added some caching.