### PR TITLE
Rm doc table from doc form [#184379680]

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.component.html
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.component.html
@@ -25,17 +25,6 @@
                               [form]="vm.form"
                               [description]="vm.form.description"
                               lajiFormOption="description logo title options.hideTES">
-    <laji-own-submissions *ngIf="vm.namedPlace && vm.form.options?.displayOwnSubmissions"
-           [actions]="vm.isAdmin ? ['edit', 'view', 'delete'] : ['edit', 'view']"
-           [columns]="['dateObserved', 'observer', 'dateEdited']"
-           [columnNameMapping]="vm.form.options?.namedPlaceOptions?.listColumnNameMapping"
-           [collectionID]="vm.form.collectionID"
-           [formID]="vm.form.id"
-           [namedPlace]="vm.namedPlace?.id"
-           [showDownloadAll]="false"
-           [header]="vm.form.options?.formOwnSubmissionsLabel || vm.namedPlace ? 'np.formOwnSubmissions' : (vm.isAdmin ? 'haseka.ownSubmissions.allTitle' : 'haseka.mobile.ownSubmissions')"
-           [forceLocalDocument]="vm.form.options?.documentsViewableForAll"
-           [admin]="vm.isAdmin"></laji-own-submissions>
     </laji-project-form-header>
     <laji-named-place-linker-button [documentID]="documentID"></laji-named-place-linker-button>
     <alert [type]="'danger'" *ngIf="vm.formData?.locked">

--- a/projects/laji/src/app/+project-form/form/form.module.ts
+++ b/projects/laji/src/app/+project-form/form/form.module.ts
@@ -14,7 +14,6 @@ import { NpEditFormModule } from './named-place/np-edit-form/np-edit-form.module
 import { NamedPlaceLinkerModule } from './named-place-linker/named-place-linker.module';
 import { InfoPageModule } from '../../shared-modules/info-page/info-page.module';
 import { NamedPlaceLinkerButtonModule } from './named-place-linker/named-place-linker-button/named-place-linker-button.module';
-import { OwnSubmissionsModule } from '../../shared-modules/own-submissions/own-submissions.module';
 import { ProjectFormHeaderModule } from '../header/project-form-header.module';
 import { LajiFormModule } from '@laji-form/laji-form.module';
 
@@ -35,7 +34,6 @@ import { LajiFormModule } from '@laji-form/laji-form.module';
     InfoPageModule,
     ProjectFormHeaderModule,
     NamedPlaceLinkerButtonModule,
-    OwnSubmissionsModule
   ],
   declarations: [
     FormComponent,


### PR DESCRIPTION
https://184379680.dev.laji.fi/project/MHL.45
https://www.pivotaltracker.com/story/show/184379680

Removes the document table from document form.

The difference to dev can be seen by navigating to some lolife document that has prior observations.
