### PR TITLE
Tree select fixes

### DIFF
--- a/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
+++ b/projects/laji/src/app/shared-modules/collections-select/collections-select.component.html
@@ -2,8 +2,8 @@
   <strong *ngIf="title !== undefined && title !== ''" class="lj-title link" (click)="toggle($event)">{{ title }}<laji-info *ngIf="info" [html]="info"></laji-info></strong>
   <div *ngIf="open">
     <laji-tree-select
-      [includedOptions]="(selectedOptions$ | async).includedOptions"
-      [excludedOptions]="(selectedOptions$ | async).excludedOptions"
+      [includedOptions]="includedOptions"
+      [excludedOptions]="excludedOptions"
       [optionsTree$]="collectionsTree$"
       [options]="collections$ | async"
       [modalButtonLabel]="modalButtonLabel"

--- a/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
+++ b/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.html
@@ -1,7 +1,7 @@
 <div>
   <laji-tree-select
-    [includedOptions]="(selectedOptions$ | async).includedOptions"
-    [excludedOptions]="(selectedOptions$ | async).excludedOptions"
+    [includedOptions]="includedOptions"
+    [excludedOptions]="excludedOptions"
     [optionsTree$]="groupsTree$"
     [options]="groups$ | async"
     [modalButtonLabel]="modalButtonLabel"

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.html
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.html
@@ -1,5 +1,5 @@
 <div>
-  <lu-button role='secondary' (click)='openModal()'>
+  <lu-button role='secondary' (click)='openModal()' [disabled]="(includedOptions?.length !== 0 || excludedOptions?.length !== 0) && !options?.length">
     {{modalButtonLabel}}
   </lu-button>
   <ng-container *ngIf='includedOptions?.length !== 0 || excludedOptions?.length !== 0'>

--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
@@ -57,7 +57,7 @@ export class TreeSelectComponent {
 
   openModal() {
     const initialState = {
-      selectedOptions: this.options,
+      selectedOptions: (this.options || []),
       optionsTree$: this.optionsTree$,
       modalTitle: this.modalTitle,
       browseTitle: this.browseTitle,

--- a/projects/laji/src/app/shared-modules/tree-select/tree-selector/tree-selector.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-selector/tree-selector.component.ts
@@ -289,5 +289,6 @@ export class TreeSelectorComponent implements OnInit {
       TREE_ACTIONS.DEACTIVATE(this.treeModel, node, null);
     });
     this.treeModel.collapseAll();
+    this.emitSelect.emit(this.selectedOptions);
   }
 }


### PR DESCRIPTION
https://184459097.dev.laji.fi/project/MHL.3/submissions
https://www.pivotaltracker.com/story/show/184001583

Fixes two bugs in tree select (informal group + collection select)
- selecting informal group before the component has loaded initial selection caused an error
- clear button didn't work
