### PR TITLE
Remove scrollable modal style from default styles

### DIFF
--- a/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
+++ b/projects/laji/src/app/shared-modules/tree-select/tree-select.component.ts
@@ -69,7 +69,7 @@ export class TreeSelectComponent {
       includeCount: this.includeCount,
       includeLink: this.includeLink,
     };
-    this.modalRef = this.modalService.show(TreeSelectModalComponent, { class: 'modal-lg', initialState });
+    this.modalRef = this.modalService.show(TreeSelectModalComponent, { class: 'modal-lg scrollable-modal', initialState });
     this.modalRef.content.emitConfirm.subscribe(result => {
       const includeToReturn = [];
       const excludeToReturn = [];

--- a/projects/laji/src/styles/laji.scss
+++ b/projects/laji/src/styles/laji.scss
@@ -751,7 +751,7 @@ body > .ui-select-bootstrap.open {
 }
 
 /** make modal body scrollable **/
-.modal-dialog {
+.scrollable-modal.modal-dialog {
   height: calc(100% - 20px);
 
   .modal-content {
@@ -790,6 +790,8 @@ body > .ui-select-bootstrap.open {
 @media only screen and (min-width : 768px) {
   .modal-dialog {
     margin: 60px auto 30px auto;
+  }
+  .scrollable-modal.modal-dialog {
     height: calc(100% - 90px);
   }
 }


### PR DESCRIPTION
https://183943758.dev.laji.fi/observation/list
https://www.pivotaltracker.com/story/show/183943758

Scrollable modal style didn't work for all modals (see example in the pivotal task) so I removed it from the default styles and added a class `scrollable-modal`
