### PR TITLE
Observation search alert

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.scss
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.scss
@@ -58,6 +58,7 @@ $mobileBreakpoint: 768px;
   display: flex;
   flex-flow: column;
   min-width: max-content;
+  width: 100%;
   &.static-width {
     min-width: unset;
   }

--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -180,22 +180,24 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
   }
 
   private toggleSearchButtonInfoToast(show: boolean) {
-    if (show) {
-      if (!searchButtonInfoDismissed && this.searchButtonInfoToast === undefined) {
-        this.searchButtonInfoToast = this.toastsService.showInfo(
-          this.translate.instant('observation.form.searchButtonInfo'),
-          undefined,
-          {
-            disableTimeOut: true,
-            closeButton: true,
-            positionClass: 'toast-center-center'
-          }
-        );
-        this.searchButtonInfoToastOnHiddenSub = this.searchButtonInfoToast.onHidden.subscribe(() => {
-          searchButtonInfoDismissed = true;
-        });
-      }
-    } else if (this.searchButtonInfoToast !== undefined) {
+    if (searchButtonInfoDismissed) {
+      return;
+    }
+
+    if (show && !this.searchButtonInfoToast) {
+      this.searchButtonInfoToast = this.toastsService.showInfo(
+        this.translate.instant('observation.form.searchButtonInfo'),
+        undefined,
+        {
+          disableTimeOut: true,
+          closeButton: true,
+          positionClass: 'toast-center-center'
+        }
+      );
+      this.searchButtonInfoToastOnHiddenSub = this.searchButtonInfoToast.onHidden.subscribe(() => {
+        searchButtonInfoDismissed = true;
+      });
+    } else if (!show && this.searchButtonInfoToast) {
       this.searchButtonInfoToastOnHiddenSub.unsubscribe();
       this.toastsService.clear(this.searchButtonInfoToast.toastId);
       this.searchButtonInfoToast = undefined;

--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -13,6 +13,7 @@ import { environment } from '../../../environments/environment';
 import { Global } from '../../../environments/global';
 import { ToastsService } from '../../shared/service/toasts.service';
 import { SidebarComponent } from 'projects/laji-ui/src/lib/sidebar/sidebar.component';
+import { ActiveToast } from 'ngx-toastr';
 
 export interface VisibleSections {
   finnish?: boolean;
@@ -32,6 +33,7 @@ export interface VisibleSections {
 
 // The info should be shown only once per browser session, so we initialize it here for the whole runtime.
 let coordinateFilterInfoShown = false;
+let searchButtonInfoDismissed = false;
 
 @Component({
   selector: 'laji-observation-view',
@@ -66,7 +68,6 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
   @ViewChild(SidebarComponent) sidebar: SidebarComponent;
   @ViewChild(ObservationResultComponent) results: ObservationResultComponent;
   showMobile: any;
-  subscription: any;
 
   showFilter = true;
   statusFilterMobile = false;
@@ -81,10 +82,12 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
     'otherInvasiveSpeciesList',
   ];
 
-  subQueryUpdate: Subscription;
-
   vm$: Observable<IObservationViewModel>;
   settingsList$: Observable<ISettingResultList>;
+
+  private searchButtonInfoToast?: ActiveToast<any>;
+  private searchButtonInfoToastOnHiddenSub?: Subscription;
+  private mainSubscription = new Subscription();
 
   constructor(
     public translate: TranslateService,
@@ -109,32 +112,37 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.vm$ = this.observationFacade.vm$;
     this.settingsList$ = this.userService.getUserSetting<ISettingResultList>(this.settingsKeyList);
-    this.subscription = this.browserService.lgScreen$.subscribe(data => this.showMobile = data);
-    this.subQueryUpdate = this.observationFacade.activeQuery$.pipe(
-      tap((query) => {
-        if (this.results) {
-          this.results.reloadTabs();
-        }
-        if ((query.coordinates) && !coordinateFilterInfoShown) {
-          coordinateFilterInfoShown = true;
-          this.toastsService.showInfo(
-            this.translate.instant('observation.form.coordinatesInfo'),
-            undefined,
-            {disableTimeOut: true, closeButton: true}
-          );
-        }
+
+    this.mainSubscription.add(
+      this.browserService.lgScreen$.subscribe(data => this.showMobile = data)
+    );
+    this.mainSubscription.add(
+      this.observationFacade.activeQuery$.pipe(
+        tap((query) => {
+          if (this.results) {
+            this.results.reloadTabs();
+          }
+          if ((query.coordinates) && !coordinateFilterInfoShown) {
+            coordinateFilterInfoShown = true;
+            this.toastsService.showInfo(
+              this.translate.instant('observation.form.coordinatesInfo'),
+              undefined,
+              {disableTimeOut: true, closeButton: true}
+            );
+          }
+        })
+      ).subscribe()
+    );
+    this.mainSubscription.add(
+      this.observationFacade.tmpQueryHasChanges$.subscribe(hasChanges => {
+        this.toggleSearchButtonInfoToast(hasChanges);
       })
-    ).subscribe();
+    );
   }
 
   ngOnDestroy() {
-    if (this.subQueryUpdate) {
-      this.subQueryUpdate.unsubscribe();
-    }
-
-    if (this.subscription) {
-      this.subscription.unsubscribe();
-    }
+    this.mainSubscription?.unsubscribe();
+    this.searchButtonInfoToastOnHiddenSub?.unsubscribe();
   }
 
   draw(type: string) {
@@ -148,15 +156,15 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
   }
 
   updateTmpQuery(query: WarehouseQueryInterface, showSidebarOnMobile = false) {
+    this.observationFacade.updateTmpQuery({...query});
     if (showSidebarOnMobile) {
       this.sidebar.showOnMobile();
     }
-    this.observationFacade.updateTmpQuery({...query});
   }
 
   updateActiveQuery(query: WarehouseQueryInterface) {
-    this.sidebar.hideOnMobile();
     this.observationFacade.updateActiveQuery$(query).subscribe();
+    this.sidebar.hideOnMobile();
   }
 
   filterVisible(event: boolean) {
@@ -169,5 +177,28 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
 
   toggleMobile() {
     this.statusFilterMobile = !this.statusFilterMobile;
+  }
+
+  private toggleSearchButtonInfoToast(show: boolean) {
+    if (show) {
+      if (!searchButtonInfoDismissed && this.searchButtonInfoToast === undefined) {
+        this.searchButtonInfoToast = this.toastsService.showInfo(
+          this.translate.instant('observation.form.searchButtonInfo'),
+          undefined,
+          {
+            disableTimeOut: true,
+            closeButton: true,
+            positionClass: 'toast-center-center'
+          }
+        );
+        this.searchButtonInfoToastOnHiddenSub = this.searchButtonInfoToast.onHidden.subscribe(() => {
+          searchButtonInfoDismissed = true;
+        });
+      }
+    } else if (this.searchButtonInfoToast !== undefined) {
+      this.searchButtonInfoToastOnHiddenSub.unsubscribe();
+      this.toastsService.clear(this.searchButtonInfoToast.toastId);
+      this.searchButtonInfoToast = undefined;
+    }
   }
 }

--- a/projects/laji/src/app/+taxonomy/taxon/taxon.component.scss
+++ b/projects/laji/src/app/+taxonomy/taxon/taxon.component.scss
@@ -32,7 +32,7 @@ laji-info-card {
   }
 }
 
-:host ::ng-deep lu-sidebar .sidebar-content-wrapper {
+:host ::ng-deep lu-sidebar .sidebar-content {
   padding: 15px;
 }
 

--- a/projects/laji/src/app/shared/service/toasts.service.ts
+++ b/projects/laji/src/app/shared/service/toasts.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ToastrService } from 'ngx-toastr';
+import { ActiveToast, ToastrService } from 'ngx-toastr';
 import { PlatformService } from '../../root/platform.service';
 import { IndividualConfig } from 'ngx-toastr/toastr/toastr-config';
 
@@ -11,35 +11,38 @@ export class ToastsService {
     private platformService: PlatformService
   ) {}
 
-  getToests() {
-    return this.toastr;
+  showSuccess(message: string, title?: string, options?: Partial<IndividualConfig>): ActiveToast<any> {
+    return this.toast('success', message, title, options);
   }
 
-  showSuccess(message: string, title?: string, options?: Partial<IndividualConfig>) {
-    this.toast('success', message, title, options);
+  showError(message: string, title?: string, options?: Partial<IndividualConfig>): ActiveToast<any> {
+    return this.toast('error', message, title, options);
   }
 
-  showError(message: string, title?: string, options?: Partial<IndividualConfig>) {
-    this.toast('error', message, title, options);
+  showWarning(message: string, title?: string, options?: Partial<IndividualConfig>): ActiveToast<any> {
+    return this.toast('warning', message, title, options);
   }
 
-  showWarning(message: string, title?: string, options?: Partial<IndividualConfig>) {
-    this.toast('warning', message, title, options);
+  showInfo(message: string, title?: string, options?: Partial<IndividualConfig>): ActiveToast<any> {
+    return this.toast('info', message, title, options);
   }
 
-  showInfo(message: string, title?: string, options?: Partial<IndividualConfig>) {
-    this.toast('info', message, title, options);
-  }
-
-  private toast(type: 'success' | 'error' | 'warning' | 'info', message: string, title?: string, options?: Partial<IndividualConfig>) {
+  clear(toastId?: number) {
     if (!this.platformService.isBrowser) {
       return;
+    }
+    this.toastr.clear(toastId);
+  }
+
+  private toast(type: 'success' | 'error' | 'warning' | 'info', message: string, title?: string, options?: Partial<IndividualConfig>): ActiveToast<any> {
+    if (!this.platformService.isBrowser) {
+      return undefined;
     }
     if (!options) {
       const time = 5000 + ((message + title).length * 100);
       options = {timeOut: time, closeButton: true};
     }
-    this.toastr[type](message, title, options);
+    return this.toastr[type](message, title, options);
   }
 
 }

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -1140,6 +1140,7 @@
   "observation.filters.collection": "Aineisto",
   "observation.filters.other": "Muut",
   "observation.filters.unit": "Näyte",
+  "observation.form.searchButtonInfo": "Paina Hae-nappia päivittääksesi rajaukset",
   "observation.form.active.sensitive": "Sensitiiviset lajit",
   "observation.form.administrativeStatus": "Hallinnollinen asema",
   "observation.form.alive.false": "Ei ole elossa",

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -1140,7 +1140,7 @@
   "observation.filters.collection": "Aineisto",
   "observation.filters.other": "Muut",
   "observation.filters.unit": "Näyte",
-  "observation.form.searchButtonInfo": "Paina Hae-nappia päivittääksesi rajaukset",
+  "observation.form.searchButtonInfo": "Hakutoiminto toimii uudella tavalla: paina Hae-nappia oikeassa ylänurkassa kun olet asettanut hakurajaukset.",
   "observation.form.active.sensitive": "Sensitiiviset lajit",
   "observation.form.administrativeStatus": "Hallinnollinen asema",
   "observation.form.alive.false": "Ei ole elossa",


### PR DESCRIPTION
https://184017766.dev.laji.fi/observation

The page shows an info toast about the new search button after the user touches the observation filters.

This also fixes the style of the sidebar in the species card (https://dev.laji.fi/taxon/MX.46587?showTree=true) that was broken by the observation search pull request.