### PR TITLE
Observation search alert fine-tuning

### DIFF
--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { Observable, Subscription } from 'rxjs';
+import { combineLatest, Observable, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { ObservationResultComponent } from '../result/observation-result.component';
 import { Router } from '@angular/router';
@@ -33,7 +33,6 @@ export interface VisibleSections {
 
 // The info should be shown only once per browser session, so we initialize it here for the whole runtime.
 let coordinateFilterInfoShown = false;
-let searchButtonInfoDismissed = false;
 
 @Component({
   selector: 'laji-observation-view',
@@ -134,8 +133,13 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
       ).subscribe()
     );
     this.mainSubscription.add(
-      this.observationFacade.tmpQueryHasChanges$.subscribe(hasChanges => {
-        this.toggleSearchButtonInfoToast(hasChanges);
+      combineLatest([
+        this.observationFacade.showSearchButtonInfo$,
+        this.observationFacade.tmpQueryHasChanges$]
+      ).subscribe(([show, hasChanges]) => {
+        if (show && hasChanges) {
+          this.showSearchButtonInfoToast();
+        }
       })
     );
   }
@@ -179,12 +183,8 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
     this.statusFilterMobile = !this.statusFilterMobile;
   }
 
-  private toggleSearchButtonInfoToast(show: boolean) {
-    if (searchButtonInfoDismissed) {
-      return;
-    }
-
-    if (show && !this.searchButtonInfoToast) {
+  private showSearchButtonInfoToast() {
+    if (!this.searchButtonInfoToast) {
       this.searchButtonInfoToast = this.toastsService.showInfo(
         this.translate.instant('observation.form.searchButtonInfo'),
         undefined,
@@ -195,12 +195,8 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
         }
       );
       this.searchButtonInfoToastOnHiddenSub = this.searchButtonInfoToast.onHidden.subscribe(() => {
-        searchButtonInfoDismissed = true;
+        this.observationFacade.hideSearchButtonInfo();
       });
-    } else if (!show && this.searchButtonInfoToast) {
-      this.searchButtonInfoToastOnHiddenSub.unsubscribe();
-      this.toastsService.clear(this.searchButtonInfoToast.toastId);
-      this.searchButtonInfoToast = undefined;
     }
   }
 }

--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -30,10 +30,6 @@ export interface VisibleSections {
   own?: boolean;
 }
 
-
-// The info should be shown only once per browser session, so we initialize it here for the whole runtime.
-let coordinateFilterInfoShown = false;
-
 @Component({
   selector: 'laji-observation-view',
   templateUrl: './observation-view.component.html',
@@ -120,14 +116,6 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
         tap((query) => {
           if (this.results) {
             this.results.reloadTabs();
-          }
-          if ((query.coordinates) && !coordinateFilterInfoShown) {
-            coordinateFilterInfoShown = true;
-            this.toastsService.showInfo(
-              this.translate.instant('observation.form.coordinatesInfo'),
-              undefined,
-              {disableTimeOut: true, closeButton: true}
-            );
           }
         })
       ).subscribe()

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -1164,7 +1164,6 @@
   "observation.form.conservation.or-info": "<b>Millä tahansa näistä (TAI/OR)</b>: Tämä valinta antaa tuloksen, johon otetaan mukaan kaikki havainnot, joiden laji kuuluu (1) vähintään yhteen valituista hallinnollisista asemista <b>TAI</b> (2) lajin uhanalaisuusluokka on jokin valituista.",
   "observation.form.coordinateAccuracyMax": "Havaintopaikan koordinaattien tarkkuus",
   "observation.form.coordinateIntersection": "Leikkausosuus",
-  "observation.form.coordinatesInfo": "Huomaa, että aluerajauksen tuloksena käytetään oletusarvoa ”Leikkaa edes vähän”. Näin myös paikkatiedolta ”karkeita” (esim. ilmoitettu tarkkuus on 10x10km) havaintoja tulee näkyviin. Valitse painike ”Kokonaan sisällä”, jos haluat vain alueen rajojen sisäpuolelle ilmoitetut havainnot.",
   "observation.form.count": "Yksilömäärä",
   "observation.form.countMax": "max",
   "observation.form.countMin": "min",


### PR DESCRIPTION
https://184017766.dev.laji.fi/observation

Changes the observation search info toast so that it is shown only once. I did that by bringing back the `persistentState` to `ObservationFacade`. This pull request also removes the coordinate info toast that was not needed anymore.