### PR TITLE
Observation front page fine-tuning

### DIFF
--- a/projects/laji/src/app/+observation/result-front/observation-result-front.component.html
+++ b/projects/laji/src/app/+observation/result-front/observation-result-front.component.html
@@ -1,7 +1,12 @@
 <div class="laji-page mb-4">
-  <laji-info-page *lajiIfWidthAboveBreakpoint="'sm' else mobileInstructions" [page]="{'fi': '7463', 'en': '7465', 'sv': '7467'} | multiLang"></laji-info-page>
+  <ng-container *lajiIfWidthAboveBreakpoint="'sm' else mobileInstructions; serverSide: loading">
+    <laji-info-page [page]="{'fi': '7463', 'en': '7465', 'sv': '7467'} | multiLang"></laji-info-page>
+  </ng-container>
   <ng-template #mobileInstructions>
     <laji-info-page [page]="{'fi': '7579', 'en': '7581', 'sv': '7583'} | multiLang"></laji-info-page>
+  </ng-template>
+  <ng-template #loading>
+    <laji-info-page-loading></laji-info-page-loading>
   </ng-template>
 
   <h4>{{ 'observation.front.sources' | translate }}</h4>

--- a/projects/laji/src/app/shared-modules/info-page/info-page-loading.component.ts
+++ b/projects/laji/src/app/shared-modules/info-page/info-page-loading.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, OnDestroy, Output } from '@angular/core';
+import { TranslateService } from '@ngx-translate/core';
+import { LajiApi, LajiApiService } from '../../shared/service/laji-api.service';
+import { map, tap } from 'rxjs/operators';
+import { InformationItem } from '../../shared/model/InformationItem';
+import { MultiLanguage } from '../../shared/model/MultiLanguage';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'laji-info-page-loading',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <lu-ghost-paragraph [length]="10"></lu-ghost-paragraph>
+    <lu-ghost-paragraph [length]="300"></lu-ghost-paragraph>
+    <lu-ghost-paragraph [length]="200"></lu-ghost-paragraph>
+`
+})
+export class InfoPageLoadingComponent {}

--- a/projects/laji/src/app/shared-modules/info-page/info-page.component.ts
+++ b/projects/laji/src/app/shared-modules/info-page/info-page.component.ts
@@ -12,9 +12,7 @@ import { Subscription } from 'rxjs';
   template: `
 <div *ngIf="!loadingContent else loading" [innerHtml]="content | safe:'html'" lajiRouteTransformer></div>
 <ng-template #loading>
-  <lu-ghost-paragraph [length]="10"></lu-ghost-paragraph>
-  <lu-ghost-paragraph [length]="300"></lu-ghost-paragraph>
-  <lu-ghost-paragraph [length]="200"></lu-ghost-paragraph>
+  <laji-info-page-loading></laji-info-page-loading>
 </ng-template>
 `
 })

--- a/projects/laji/src/app/shared-modules/info-page/info-page.module.ts
+++ b/projects/laji/src/app/shared-modules/info-page/info-page.module.ts
@@ -4,15 +4,16 @@ import { InfoPageComponent } from './info-page.component';
 import { LajiUiModule } from '../../../../../laji-ui/src/public-api';
 import { UtilitiesModule } from '../utilities/utilities.module';
 import { SharedModule } from '../../shared/shared.module';
+import { InfoPageLoadingComponent } from './info-page-loading.component';
 
 @NgModule({
-  declarations: [InfoPageComponent],
+  declarations: [InfoPageComponent, InfoPageLoadingComponent],
   imports: [
     CommonModule,
     LajiUiModule,
     UtilitiesModule,
     SharedModule
   ],
-  exports: [InfoPageComponent]
+  exports: [InfoPageComponent, InfoPageLoadingComponent]
 })
 export class InfoPageModule { }

--- a/projects/laji/src/app/shared/directive/if-width-above-breakpoint.directive.ts
+++ b/projects/laji/src/app/shared/directive/if-width-above-breakpoint.directive.ts
@@ -4,6 +4,7 @@ import {
   BreakpointState
 } from '@angular/cdk/layout';
 import { Subscription } from 'rxjs';
+import { PlatformService } from '../../root/platform.service';
 
 type Breakpoint = 'xs'|'sm'|'md'|'lg';
 const breakpoints = {
@@ -41,7 +42,8 @@ export class IfWidthAboveBreakpointDirective implements OnDestroy {
   constructor(
     private view: ViewContainerRef,
     private template: TemplateRef<any>,
-    private breakpointObserver: BreakpointObserver
+    private breakpointObserver: BreakpointObserver,
+    private platformService: PlatformService
   ) {}
 
   ngOnDestroy() {
@@ -50,7 +52,7 @@ export class IfWidthAboveBreakpointDirective implements OnDestroy {
 
   private initBreakPointSubscription() {
     this.breakpointSubscription?.unsubscribe();
-    if (!this.breakpoint) {
+    if (!this.breakpoint || this.platformService.isServer) {
       return;
     }
 

--- a/projects/laji/src/app/shared/directive/if-width-above-breakpoint.directive.ts
+++ b/projects/laji/src/app/shared/directive/if-width-above-breakpoint.directive.ts
@@ -34,6 +34,14 @@ export class IfWidthAboveBreakpointDirective implements OnDestroy {
     }
   }
 
+  @Input()
+  set lajiIfWidthAboveBreakpointServerSide(template: TemplateRef<any>) {
+    if (this.platformService.isServer) {
+      this.view.clear();
+      this.view.createEmbeddedView(template);
+    }
+  }
+
   private breakpoint?: Breakpoint;
   private matchesBreakpoint?: boolean;
   private elseTemplate?: TemplateRef<any>;


### PR DESCRIPTION
Since this is related to the server side rendering, it can only be tested with local ssr or after it has been merged. Observation front page (https://laji.fi/observation) looks weird while it is loading because the server can't know the screen width and it always shows the mobile view first. I changed it so that is shows a loading component on the server side.