### PR TITLE
CollectionAndRecordquality filter values not properly set 184654630

### DIFF
--- a/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
+++ b/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
@@ -238,25 +238,25 @@ export class SelectSubcategoriesComponent implements OnChanges {
           const splitParamGlobal = param.split(',');
           this.loopInsideOptions(this.subCategories, this.options, splitParamGlobal, false);
         } else {
-          const splitParamCategories = this.arrFromUrlString(param);
+          const splitParamCategories = arrFromUrlString(param);
           this.loopInsideOptions(this.subCategories, this.options, splitParamCategories, true);
         }
       } else {
         this.unselectedOptions = this.unselectedOptions ? this.unselectedOptions : {};
       }
     }
-  }
 
-  private arrFromUrlString(urlString: string): string[] {
-    const rebuilt = urlString.split(';').filter(s => s.length > 0);
-    const finalRebuilt = [];
+    function arrFromUrlString(urlString: string): string[] {
+      const rebuilt = urlString.split(';').filter(s => s.length > 0);
+      const finalRebuilt = [];
 
-    rebuilt.forEach((element) => {
-      const subSplit = element.split(':');
-      finalRebuilt[subSplit[0]] = subSplit[1].split(',');
-    });
+      rebuilt.forEach((element) => {
+        const subSplit = element.split(':');
+        finalRebuilt[subSplit[0]] = subSplit[1].split(',');
+      });
 
-    return finalRebuilt;
+      return finalRebuilt;
+    }
   }
 
   private loopInsideOptions(subCategories, options, splitParam, excludeGlobal = false) {

--- a/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
+++ b/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
@@ -248,7 +248,7 @@ export class SelectSubcategoriesComponent implements OnChanges {
   }
 
   private rebuiltParamSubCategory(urlString) {
-    const rebuilt = urlString.slice(0, -1).split(';');
+    const rebuilt = urlString.charAt(urlString.length - 1) === ';' ? urlString.slice(0, -1).split(';') : urlString.split(';');
     const finalRebuilt = [];
 
     rebuilt.forEach((element) => {

--- a/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
+++ b/projects/laji/src/app/shared-modules/select/select-subcategories/select-subcategories.component.ts
@@ -238,7 +238,7 @@ export class SelectSubcategoriesComponent implements OnChanges {
           const splitParamGlobal = param.split(',');
           this.loopInsideOptions(this.subCategories, this.options, splitParamGlobal, false);
         } else {
-          const splitParamCategories = this.rebuiltParamSubCategory(param);
+          const splitParamCategories = this.arrFromUrlString(param);
           this.loopInsideOptions(this.subCategories, this.options, splitParamCategories, true);
         }
       } else {
@@ -247,8 +247,8 @@ export class SelectSubcategoriesComponent implements OnChanges {
     }
   }
 
-  private rebuiltParamSubCategory(urlString) {
-    const rebuilt = urlString.charAt(urlString.length - 1) === ';' ? urlString.slice(0, -1).split(';') : urlString.split(';');
+  private arrFromUrlString(urlString: string): string[] {
+    const rebuilt = urlString.split(';').filter(s => s.length > 0);
     const finalRebuilt = [];
 
     rebuilt.forEach((element) => {


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/184654630, testable here https://184654630.dev.laji.fi/observation/list?collectionAndRecordQuality=PROFESSIONAL:EXPERT_VERIFIED,COMMUNITY_VERIFIED,NEUTRAL,UNCERTAIN;HOBBYIST:EXPERT_VERIFIED,COMMUNITY_VERIFIED,NEUTRAL;AMATEUR:EXPERT_VERIFIED,COMMUNITY_VERIFIED, problem was that for laji.fi to set the filters properly that last COMMUNITY_VERIFIED needed to be followed by a semicolon, now it works with or without it.