### PR TITLE
Fix deleting local document [#184661048]

### DIFF
--- a/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
@@ -51,13 +51,13 @@ export class DocumentService {
   }
 
   deleteDocument(id: string) {
-    return this.documentApi.delete(id, this.userService.getToken()).pipe(
-      mergeMap(() => this.userService.user$),
-      tap(person => {
+    const isTmpDoc = id.match(/^T:\d+$/);
+    const del$ = isTmpDoc
+      ? this.userService.user$.pipe(tap(person => {
         this.documentStorage.removeItem(id, person);
-        delete this.cache[this.getCacheKey(id)];
-      })
-    );
+      }))
+      : this.documentApi.delete(id, this.userService.getToken());
+    return del$.pipe(tap(() => delete this.cache[this.getCacheKey(id)]));
   }
 
   saveTemplate(templateData: TemplateForm): Observable<Document> {

--- a/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
@@ -51,7 +51,7 @@ export class DocumentService {
   }
 
   deleteDocument(id: string) {
-    const isTmpDoc = id.match(/^T:\d+$/);
+    const isTmpDoc = FormService.isTmpId(id);
     const del$ = isTmpDoc
       ? this.userService.user$.pipe(tap(person => {
         this.documentStorage.removeItem(id, person);

--- a/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
+++ b/projects/laji/src/app/shared-modules/own-submissions/service/document.service.ts
@@ -6,7 +6,7 @@ import { Util } from '../../../shared/service/util.service';
 import { Observable, of } from 'rxjs';
 import { TemplateForm } from '../models/template-form';
 import { DocumentStorage } from '../../../storage/document.storage';
-import { mergeMap, switchMap, shareReplay, tap } from 'rxjs/operators';
+import { mergeMap, switchMap, shareReplay, tap, take } from 'rxjs/operators';
 import { Rights } from '../../../shared/service/form-permission.service';
 import { Person } from '../../../shared/model/Person';
 import { JSONPath } from 'jsonpath-plus';
@@ -53,7 +53,7 @@ export class DocumentService {
   deleteDocument(id: string) {
     const isTmpDoc = FormService.isTmpId(id);
     const del$ = isTmpDoc
-      ? this.userService.user$.pipe(tap(person => {
+      ? this.userService.user$.pipe(take(1), tap(person => {
         this.documentStorage.removeItem(id, person);
       }))
       : this.documentApi.delete(id, this.userService.getToken());


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185412289
https://185412289.dev.laji.fi/vihko

Old implementation tried to always delete the document through the API. It failed for local documents since they don't exist, resulting in a "hups" and the local doc not being removed.

I fixed the logic to first check if the doc is local one, and accordingly remove it from the local or remote source.