### PR TITLE
Obs viewer fails if geometry missing #185412397

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/viewer-map/viewer-map.component.html
+++ b/projects/laji/src/app/shared-modules/document-viewer/viewer-map/viewer-map.component.html
@@ -2,7 +2,7 @@
   <div style="max-width: 500px; height: 300px; margin-top:20px;">
     <laji-map [options]="mapOptions" (loaded)="onMapLoad()"></laji-map>
   </div>
-  <ng-container *ngIf="data && !hideCoordinates">
+  <ng-container *ngIf="data?.[active] && !hideCoordinates">
     <laji-viewer-coordinates
       [sourceOfCoordinates]="data[active].sourceOfCoordinates"
       [coordinateAccuracy]="data[active].coordinateAccuracy"

--- a/projects/laji/src/app/shared-modules/document-viewer/viewer-map/viewer-map.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/viewer-map/viewer-map.component.ts
@@ -67,7 +67,7 @@ export class ViewerMapComponent implements OnInit, OnChanges {
 
   setActiveIndex(idx: number) {
     this.active = idx;
-    if (!this.lajiMap.map) {
+    if (!this.data?.[0] || !this.lajiMap.map) {
       return;
     }
     if (this.data[0].geoJSON && this._data.featureCollection !== this.getFeatureCollection(this.data[0].geoJSON) ) {


### PR DESCRIPTION
Task here https://www.pivotaltracker.com/story/show/185412397, there were couple of places where code assumed wrongly that there would be coordinates.