### PR TITLE
Add technical news to all pages #185049817

### DIFF
--- a/projects/laji/src/app/+information/information.component.html
+++ b/projects/laji/src/app/+information/information.component.html
@@ -1,8 +1,10 @@
+TEST
 <ng-container *ngIf="information$ | async; let information">
   <lu-sidebar position="right" [staticWidth]="280" [displayNav]="!!information.children">
     <main class="d-flex">
       <div class="d-flex justify-center flex-grow">
         <div class="mt-4 mb-8 mx-4 d-flex flex-col flex-nowrap width-0 information-container">
+          <laji-technical-news></laji-technical-news>
           <ol class="breadcrumb">
             <ng-container *ngFor="let parent of information.parents; let i = index">
               <li *ngIf="i !== 0">

--- a/projects/laji/src/app/+information/information.component.html
+++ b/projects/laji/src/app/+information/information.component.html
@@ -1,4 +1,3 @@
-TEST
 <ng-container *ngIf="information$ | async; let information">
   <lu-sidebar position="right" [staticWidth]="280" [displayNav]="!!information.children">
     <main class="d-flex">

--- a/projects/laji/src/app/+information/information.module.ts
+++ b/projects/laji/src/app/+information/information.module.ts
@@ -4,9 +4,9 @@ import { SharedModule } from '../shared/shared.module';
 import { routing } from './information.routes';
 import { InformationComponent } from './information.component';
 import { LajiUiModule } from 'projects/laji-ui/src/public-api';
-
+import { TechnicalNewsModule } from '../shared-modules/technical-news/technical-news.module';
 @NgModule({
-  imports: [routing, SharedModule, RouterModule, LajiUiModule],
+  imports: [routing, SharedModule, RouterModule, LajiUiModule, TechnicalNewsModule],
   declarations: [InformationComponent],
 })
 export class InformationModule {}

--- a/projects/laji/src/app/+information/information.module.ts
+++ b/projects/laji/src/app/+information/information.module.ts
@@ -5,6 +5,7 @@ import { routing } from './information.routes';
 import { InformationComponent } from './information.component';
 import { LajiUiModule } from 'projects/laji-ui/src/public-api';
 import { TechnicalNewsModule } from '../shared-modules/technical-news/technical-news.module';
+
 @NgModule({
   imports: [routing, SharedModule, RouterModule, LajiUiModule, TechnicalNewsModule],
   declarations: [InformationComponent],

--- a/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.html
@@ -1,4 +1,5 @@
 <div class="container margin-top-20">
+  <laji-technical-news></laji-technical-news>
   <div class="row">
     <div class="col-sm-12">
       <laji-informal-group-select

--- a/projects/laji/src/app/+taxonomy/species/species.component.html
+++ b/projects/laji/src/app/+taxonomy/species/species.component.html
@@ -1,5 +1,6 @@
 <lu-sidebar [position]="'right'" [staticWidth]="300">
   <main>
+    <laji-technical-news></laji-technical-news>
     <div class="info-box mb-3">
       <ng-container *lajiForTypes="['vir']; exclude: true">
         <h1>{{ 'species.search' | translate }}</h1>

--- a/projects/laji/src/app/+taxonomy/taxon/taxon.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/taxon.component.html
@@ -10,6 +10,7 @@
         ></laji-taxon-tree>
       </nav>
       <main>
+        <laji-technical-news></laji-technical-news>
         <ng-container *ngTemplateOutlet="infoCard"></ng-container>
       </main>
     </lu-sidebar>


### PR DESCRIPTION
Task here https://www.pivotaltracker.com/story/show/185049817, probably not on all pages, but then news should now show up on all taxon pages and cms-pages.