### PR TITLE
Species card language bug #183147160

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.ts
@@ -32,11 +32,11 @@ export class TaxonInfoComponent implements OnChanges, OnDestroy {
     this.availableTaxonNames = {vernacularNames: [], colloquialVernacularNames: []};
 
     this.langs.forEach(value => {
-      if (this.taxon.vernacularName?.hasOwnProperty(value) && this.taxon.vernacularName[value] !== '') {
+      if (this.taxon?.vernacularName?.[value]) {
         this.availableVernacularNames.push({lang: value});
         this.availableTaxonNames.vernacularNames.push({lang: value});
       }
-      if (this.taxon.colloquialVernacularName?.hasOwnProperty(value) && this.taxon.colloquialVernacularName[value] !== '') {
+      if (this.taxon?.colloquialVernacularName?.[value]) {
         this.availableTaxonNames.colloquialVernacularNames.push({lang: value});
       }
     });


### PR DESCRIPTION
Task here https://www.pivotaltracker.com/story/show/183147160, species card had an issue where if taxon changed certain language related things weren't reinitialized when needed, leading to problems with some variables remaining as they were for the first taxon viewed.