### PR TITLE
Map close-button fixes [#186220191]

### DIFF
--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.html
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.html
@@ -38,8 +38,8 @@
   </laji-map>
 </div>
 <div *ngIf="selectedObservationCoordinates" class="cluster-info">
-  <div class="d-flex justify-end">
-    <button class="btn btn-default btn-small my-3" (click)="resetTable()">{{ 'close' | translate }}</button>
+  <div class="d-flex justify-start">
+    <button class="btn btn-primary btn-small my-3" (click)="resetTable()">{{ 'closeTable' | translate }}</button>
   </div>
   <laji-observation-map-table [coordinates]="selectedObservationCoordinates" [visualizationMode]="visualizationMode" [query]="query"></laji-observation-map-table>
 </div>

--- a/projects/laji/src/i18n/fi.json
+++ b/projects/laji/src/i18n/fi.json
@@ -101,6 +101,7 @@
   "close": "Sulje",
   "closed.intro": "Vihko on suljettu huoltotöiden ajaksi. Ilmoitamme <a href=\"/\">etusivulla</a>, kun se on jälleen käytettävissä.",
   "closed.title": "Suljettu",
+  "closeTable": "Sulje taulukko",
   "collection.abbreviation": "Aineiston lyhenne",
   "collection.citation": "Suositeltu viittaus",
   "collection.collectionLocation": "Aineiston sijainti",


### PR DESCRIPTION
https://186220191.dev.laji.fi/observation/map
https://www.pivotaltracker.com/n/projects/2346653/stories/186220191

Now the map close-button is aligned to left, shown in primary color, and has the correct title.