### PR TITLE
Image tab mode persists [#186078537]

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/images/images.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/images/images.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges } from '@angular/core';
 import { QueryParamsHandling } from '@angular/router';
+import { ViewType } from '../../../shared/gallery/image-gallery';
 
 @Component({
   selector: 'laji-images',
@@ -20,8 +21,8 @@ export class ImagesComponent implements OnChanges {
   @Input() linkOptions: {tab: string; queryParams: any; queryParamsHandling: QueryParamsHandling};
   @Input() sort: string[];
   @Input() shortcut = true;
-  @Input() view: 'compact'|'annotation'|'full'|'full2' = 'annotation';
-  @Input() views = ['compact', 'full'];
+  @Input() view: ViewType = 'annotation';
+  @Input() views: ViewType[] = ['compact', 'full'];
 
   documentImages;
   gatheringImages;

--- a/projects/laji/src/app/shared/gallery/gallery/gallery.component.html
+++ b/projects/laji/src/app/shared/gallery/gallery/gallery.component.html
@@ -8,7 +8,7 @@
       [showExtraInfo]="showExtraInfo"
       [showLinkToSpeciesCard]="showLinkToSpeciesCard"
       [linkOptions]="linkOptions"
-      [view]="view"
+      [(view)]="view"
       [views]="views"
       [modalImages]="images"
       [shortcut]="shortcut"

--- a/projects/laji/src/app/shared/gallery/gallery/gallery.component.ts
+++ b/projects/laji/src/app/shared/gallery/gallery/gallery.component.ts
@@ -16,6 +16,7 @@ import { Logger } from '../../logger/logger.service';
 import {catchError, delay, map, tap} from 'rxjs/operators';
 import { IImageSelectEvent } from '../image-gallery/image.interface';
 import { QueryParamsHandling } from '@angular/router';
+import { ViewType } from '../image-gallery';
 
 @Component({
   selector: 'laji-gallery',
@@ -40,8 +41,8 @@ export class GalleryComponent implements OnChanges {
   @Input() shortcut: boolean;
   @Input() linkOptions: {tab: string; queryParams: any; queryParamsHandling: QueryParamsHandling};
   @Input() sort: string[];
-  @Input() view: 'compact'|'annotation'|'full'|'full2'|'full3' = 'compact';
-  @Input() views = ['compact', 'full'];
+  @Input() view: ViewType = 'compact';
+  @Input() views: ViewType[] = ['compact', 'full'];
   @Output() selected = new EventEmitter<IImageSelectEvent>();
   @Output() hasData = new EventEmitter<boolean>();
   @Output() images = new EventEmitter<TaxonomyImage[]>();

--- a/projects/laji/src/app/shared/gallery/gallery/gallery.component.ts
+++ b/projects/laji/src/app/shared/gallery/gallery/gallery.component.ts
@@ -40,7 +40,7 @@ export class GalleryComponent implements OnChanges {
   @Input() shortcut: boolean;
   @Input() linkOptions: {tab: string; queryParams: any; queryParamsHandling: QueryParamsHandling};
   @Input() sort: string[];
-  @Input() view: 'compact'|'annotation'|'full'|'full2' = 'compact';
+  @Input() view: 'compact'|'annotation'|'full'|'full2'|'full3' = 'compact';
   @Input() views = ['compact', 'full'];
   @Output() selected = new EventEmitter<IImageSelectEvent>();
   @Output() hasData = new EventEmitter<boolean>();

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
@@ -58,6 +58,8 @@ import { DOCUMENT } from '@angular/common';
  * This is modified to out needs
  */
 
+export type ViewType = 'compact'|'annotation'|'full'|'full2'|'full3';
+
 @Component({
   selector: 'laji-image-gallery',
   styleUrls: ['./image-modal.component.css'],
@@ -70,8 +72,8 @@ export class ImageModalComponent implements OnInit, OnDestroy, OnChanges {
   public loading = false;
   public showRepeat = false;
   @Input() eventOnClick = false;
-  @Input() view: 'compact'|'annotation'|'full'|'full2'|'full3' = 'compact';
-  @Input() views = ['compact', 'full'];
+  @Input() view: ViewType = 'compact';
+  @Input() views: ViewType[] = ['compact', 'full'];
   @Input() showExtraInfo = true;
   @Input() modalImages: Image[];
   @Input() imagePointer: number;
@@ -171,7 +173,7 @@ export class ImageModalComponent implements OnInit, OnDestroy, OnChanges {
     this.overlay?.destroy();
   }
 
-  setView(viewType: 'compact'|'annotation'|'full'|'full2'|'full3') {
+  setView(viewType: ViewType) {
     if (this.view !== viewType) {
       this.view = viewType;
       this.viewChange.emit(viewType);

--- a/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
+++ b/projects/laji/src/app/shared/gallery/image-gallery/image-modal.component.ts
@@ -85,6 +85,7 @@ export class ImageModalComponent implements OnInit, OnDestroy, OnChanges {
   @Output() cancelEvent = new EventEmitter<any>();
   @Output() imageSelect = new EventEmitter<IImageSelectEvent>();
   @Output() showModal = new EventEmitter<boolean>();
+  @Output() viewChange = new EventEmitter<'compact'|'annotation'|'full'|'full2'|'full3'>();
   public overlay: ComponentRef<ImageModalOverlayComponent>;
   // private _overlay: ComponentLoader<ImageModalOverlayComponent>;
   private showModalSub: Subscription;
@@ -170,9 +171,10 @@ export class ImageModalComponent implements OnInit, OnDestroy, OnChanges {
     this.overlay?.destroy();
   }
 
-  setView(viewType) {
+  setView(viewType: 'compact'|'annotation'|'full'|'full2'|'full3') {
     if (this.view !== viewType) {
       this.view = viewType;
+      this.viewChange.emit(viewType);
     }
   }
 


### PR DESCRIPTION
https://186078537.dev.laji.fi/observation/images
https://www.pivotaltracker.com/n/projects/2346653/stories/186078537

Now the image tab's view mode (large images or small images) persists after changing the paginator page. This is done by emitting the view state to parent. Also ViewType is implemented in this PR as a refactor.