### PR TITLE
Fix modal doesn't touch body overflow if it's not been hijacked yet

### DIFF
--- a/projects/laji-ui/src/lib/modal/modal/modal.component.ts
+++ b/projects/laji-ui/src/lib/modal/modal/modal.component.ts
@@ -94,7 +94,7 @@ export class ModalComponent implements OnDestroy {
       return false;
     }
     this.hideElement();
-    this.restoreBodyOverflow();
+    this.releaseBodyOverflow();
     this.isShown = false;
     this.onShownChange.emit(false);
     this.cdr.markForCheck();
@@ -114,7 +114,7 @@ export class ModalComponent implements OnDestroy {
     this.renderer.setStyle(this.document.body, 'overflow', 'hidden');
   }
 
-  private restoreBodyOverflow() {
+  private releaseBodyOverflow() {
     if (this.originalBodyOverflow) {
       this.renderer.setStyle(this.document.body, 'overflow', this.originalBodyOverflow);
     } else {

--- a/projects/laji-ui/src/lib/modal/modal/modal.component.ts
+++ b/projects/laji-ui/src/lib/modal/modal/modal.component.ts
@@ -82,10 +82,8 @@ export class ModalComponent implements OnDestroy {
     if (this.isShown) {
       return;
     }
-    this.originalBodyOverflow = this.document.body.style.overflow;
     this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'block');
-
-    this.renderer.setStyle(this.document.body, 'overflow', 'hidden');
+    this.hijackBodyOverflow();
     this.isShown = true;
     this.onShownChange.emit(true);
     this.cdr.markForCheck();
@@ -96,7 +94,7 @@ export class ModalComponent implements OnDestroy {
       return false;
     }
     this.hideElement();
-
+    this.restoreBodyOverflow();
     this.isShown = false;
     this.onShownChange.emit(false);
     this.cdr.markForCheck();
@@ -108,12 +106,19 @@ export class ModalComponent implements OnDestroy {
   }
 
   private hideElement() {
+    this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'none');
+  }
+
+  private hijackBodyOverflow() {
+    this.originalBodyOverflow = this.document.body.style.overflow;
+    this.renderer.setStyle(this.document.body, 'overflow', 'hidden');
+  }
+
+  private restoreBodyOverflow() {
     if (this.originalBodyOverflow) {
       this.renderer.setStyle(this.document.body, 'overflow', this.originalBodyOverflow);
     } else {
       this.renderer.removeStyle(this.document.body, 'overflow');
     }
-
-    this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'none');
   }
 }

--- a/projects/laji-ui/src/lib/modal/modal/modal.component.ts
+++ b/projects/laji-ui/src/lib/modal/modal/modal.component.ts
@@ -82,7 +82,7 @@ export class ModalComponent implements OnDestroy {
     if (this.isShown) {
       return;
     }
-    this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'block');
+    this.showElement();
     this.hijackBodyOverflow();
     this.isShown = true;
     this.onShownChange.emit(true);
@@ -103,6 +103,10 @@ export class ModalComponent implements OnDestroy {
 
   getContentNode(): HTMLElement {
     return this.elementRef.nativeElement.querySelector('.lu-modal-content');
+  }
+
+  private showElement() {
+    this.renderer.setStyle(this.elementRef.nativeElement, 'display', 'block');
   }
 
   private hideElement() {


### PR DESCRIPTION
Currently the modal hides itself on construction. This can cause it to remove body's overflow. This PR makes the body overflow control more fine-grained: modal construction hides the main element, but doesn't touch body overflow until the modal is actually shown. Then, the modal "hijacks" the body overflow, and "releases" it when it hides.