### PR TITLE
Fix window references

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
@@ -1,11 +1,11 @@
 import {
-  Component, Input, Renderer2, OnDestroy, ChangeDetectorRef, ElementRef, ViewChild, AfterViewInit, Inject, PLATFORM_ID, ContentChildren, QueryList, Output, EventEmitter
+  Component, Input, Renderer2, OnDestroy, ChangeDetectorRef, ElementRef, ViewChild, AfterViewInit, ContentChildren, QueryList, Output, EventEmitter
 } from '@angular/core';
 import { trigger, state, style, transition, animate, group, query, animateChild } from '@angular/animations';
-import { isPlatformBrowser } from '@angular/common';
 import { fromEvent, Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { SidebarLinkComponent } from './sidebar-link/sidebar-link.component';
+import { PlatformService } from 'projects/laji/src/app/root/platform.service';
 
 const mobileBreakpoint = 768;
 
@@ -87,9 +87,13 @@ export class SidebarComponent implements OnDestroy, AfterViewInit {
 
   destroyCloseOnClickListener: () => void;
 
-  constructor(private renderer: Renderer2, private cdr: ChangeDetectorRef, @Inject(PLATFORM_ID) private platformId: any) {
-    if (isPlatformBrowser(this.platformId)) {
-      this.open = !(window.innerWidth < mobileBreakpoint);
+  constructor(
+    private renderer: Renderer2,
+    private cdr: ChangeDetectorRef,
+    private platformService: PlatformService
+  ) {
+    if (this.platformService.isBrowser) {
+      this.open = !(this.platformService.window.innerWidth < mobileBreakpoint);
     } else {
       this.open = false;
     }
@@ -99,7 +103,7 @@ export class SidebarComponent implements OnDestroy, AfterViewInit {
     this.checkScreenWidth();
     this.preCheckScreenWidth = false;
     this.cdr.detectChanges();
-    fromEvent(window, 'resize').pipe(
+    fromEvent(this.platformService.window, 'resize').pipe(
       debounceTime(500),
       distinctUntilChanged(),
       takeUntil(this.unsubscribe$)
@@ -122,7 +126,7 @@ export class SidebarComponent implements OnDestroy, AfterViewInit {
     if (event && event['ignore-sidebar']) {
       return;
     }
-    const isMobile = window.innerWidth < mobileBreakpoint;
+    const isMobile = this.platformService.window.innerWidth < mobileBreakpoint;
     if (this.mobile !== isMobile) {
       if (isMobile) {
         this.sidebarMinWidth = 0;
@@ -155,11 +159,11 @@ export class SidebarComponent implements OnDestroy, AfterViewInit {
     try {
       const event = new Event('resize');
       event['ignore-sidebar'] = true;
-      window.dispatchEvent(event);
+      this.platformService.window.dispatchEvent(event);
     } catch (e) {
-      const evt: any = window.document.createEvent('UIEvents');
-      evt.initUIEvent('resize', true, false, window, 0);
-      window.dispatchEvent(evt);
+      const evt: any = this.platformService.window.document.createEvent('UIEvents');
+      evt.initUIEvent('resize', true, false, this.platformService.window, 0);
+      this.platformService.window.dispatchEvent(evt);
     }
   }
 

--- a/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.ts
+++ b/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.ts
@@ -3,6 +3,7 @@ import { Form } from '../../../../shared/model/Form';
 import { LajiFormComponent } from '../laji-form/laji-form.component';
 import { LajiFormUtil } from '../laji-form-util.service';
 import { Readonly } from '../../../../shared-modules/own-submissions/service/document.service';
+import { PlatformService } from '../../../../root/platform.service';
 
 export type LajiFormFooterStatus = '' | 'success' | 'error' | 'unsaved';
 
@@ -39,6 +40,8 @@ export class LajiFormFooterComponent {
   _touchedCounter: number;
   _touchedCounterOnErrors: number;
 
+  constructor(private platformService: PlatformService) { }
+
   @Input()
   set form(form: Form.SchemaForm) {
     if (!form) {
@@ -66,7 +69,7 @@ export class LajiFormFooterComponent {
 
   @Input()
   set errors(errors: any) {
-    this.hasOnlyWarnings = document.querySelector('.warning-panel') && this._hasOnlyWarnings(errors);
+    this.hasOnlyWarnings = this.platformService.document.querySelector('.warning-panel') && this._hasOnlyWarnings(errors);
     this._touchedCounterOnErrors = this._touchedCounter;
   }
 
@@ -95,6 +98,6 @@ export class LajiFormFooterComponent {
 
   highlightErrorContainer() {
     this.lajiForm.popErrorListIfNeeded();
-    LajiFormUtil.scrollIntoViewIfNeeded(document.querySelector('.laji-form-error-list'));
+    LajiFormUtil.scrollIntoViewIfNeeded(this.platformService.document.querySelector('.laji-form-error-list'));
   }
 }

--- a/projects/laji/src/app/root/platform.service.ts
+++ b/projects/laji/src/app/root/platform.service.ts
@@ -13,7 +13,7 @@ export class PlatformService {
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: Object, // eslint-disable-line @typescript-eslint/ban-types
-    @Inject(DOCUMENT) private document: Document,
+    @Inject(DOCUMENT) public document: Document,
   ) {
     this.window = document.defaultView;
   }

--- a/projects/laji/src/app/shared-modules/info/info/info.component.ts
+++ b/projects/laji/src/app/shared-modules/info/info/info.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, HostListener, Input, ViewChild } from '@angular/core';
 import { ModalComponent } from 'projects/laji-ui/src/lib/modal/modal/modal.component';
 import { PopoverPlacement } from 'projects/laji-ui/src/lib/popover/popover.directive';
+import { PlatformService } from '../../../root/platform.service';
 
 @Component({
   selector: 'laji-info',
@@ -19,7 +20,10 @@ export class InfoComponent {
 
   useModal: boolean;
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  constructor(
+    private cdr: ChangeDetectorRef,
+    private platformService: PlatformService
+  ) {}
 
   toggleModal() {
     if (!this.useModal) { return; }
@@ -28,7 +32,7 @@ export class InfoComponent {
 
   @HostListener('window:resize', ['$event'])
   onResize() {
-    this.useModal = window.innerWidth <= 767;
+    this.useModal = this.platformService.window.innerWidth <= 767;
     this.cdr.markForCheck();
   }
 }


### PR DESCRIPTION
Found during SSR testing that these references to `window` made the SSR crash.

The `window` should be accessed through the platform browser, because it's not in node API.
