### PR TITLE
Fix sidebar animation in ssr hydration

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
@@ -19,6 +19,7 @@ const mobileBreakpoint = 768;
         width: '{{sidebarMinWidth}}px'
       }), {params: {sidebarMinWidth: 0}}),
       state('open', style({
+        width: 'unset'
       })),
       transition('open=>closed', group([
         query('@sidebarOpen_content', [
@@ -40,6 +41,7 @@ const mobileBreakpoint = 768;
       })),
       state('open', style({
         opacity: 1,
+        display: 'block'
       })),
       transition('closed<=>open', animate('300ms ease')),
     ]),


### PR DESCRIPTION
I honestly don't know what's going on with hydration + animations. Why are animations played on the server at all? Anyways, the animation was being stuck in the "closed" state... this change just makes sure that the "open" state is the inverse of the closed state. Seems to fix the issue. Although do note that it does look a bit strange that the navbar starts from the closed state on the SSR version and then opens up when js loads on the client. Kinda weird, but idk what to do about that.