### PR TITLE
Fix eslint not finding tsconfig on some systems

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "root": true,
   "ignorePatterns": [
     "projects/laji/src/test.ts"
@@ -9,6 +9,7 @@
         "*.ts"
       ],
       "parserOptions": {
+        tsconfigRootDir: __dirname,
         "project": [
           "tsconfig.json",
           "projects/laji/e2e/tsconfig.e2e.json"

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
         "*.ts"
       ],
       "parserOptions": {
-        tsconfigRootDir: __dirname,
+        "tsconfigRootDir": __dirname,
         "project": [
           "tsconfig.json",
           "projects/laji/e2e/tsconfig.e2e.json"

--- a/projects/bird-atlas/.eslintrc.json
+++ b/projects/bird-atlas/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/exhibition-screen/.eslintrc.json
+++ b/projects/exhibition-screen/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/iucn/.eslintrc.json
+++ b/projects/iucn/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/kerttu-global/.eslintrc.json
+++ b/projects/kerttu-global/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/label-designer-electron/.eslintrc.json
+++ b/projects/label-designer-electron/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/label-designer-element/.eslintrc.json
+++ b/projects/label-designer-element/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/label-designer/.eslintrc.json
+++ b/projects/label-designer/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [

--- a/projects/laji-ui/.eslintrc.json
+++ b/projects/laji-ui/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "ignorePatterns": [
     "src/lib/typeahead/**/*.ts"

--- a/projects/vir/.eslintrc.json
+++ b/projects/vir/.eslintrc.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "../../.eslintrc.json"
+    "../../.eslintrc.js"
   ],
   "rules": {
     "@angular-eslint/component-selector": [


### PR DESCRIPTION
Running neovim on windows eslint was unable to find tsconfig (it thought that the root directory was at the location of the current file...). Unfortunately I was not able to find a fix that doesn't touch project files, but I don't think this fix should break anything.