### PR TITLE
Fix observation form sidebar sticky header

### DIFF
--- a/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
+++ b/projects/laji-ui/src/lib/sidebar/sidebar.component.ts
@@ -41,7 +41,7 @@ const mobileBreakpoint = 768;
       })),
       state('open', style({
         opacity: 1,
-        display: 'block'
+        display: 'flex'
       })),
       transition('closed<=>open', animate('300ms ease')),
     ]),


### PR DESCRIPTION
Fixes the issue with observation form sidebar header (search button section) that was mentioned today, i.e. it now stays on top correctly when the sidebar is scrolled down.

Related: https://github.com/luomus/laji/pull/472

`display: flex` is set in the default styles in scss so now angular animations matches it...

Ideally the open state in angular animations would just unset the display property, however attempting to do that inexplicably breaks SSR hydration (the sidebar will stay at `display: none`).