### PR TITLE
Fix "Observer is not" filter [#185803929]

### DIFF
--- a/projects/laji/src/app/+observation/form/observation-form.component.html
+++ b/projects/laji/src/app/+observation/form/observation-form.component.html
@@ -123,6 +123,7 @@
     (asEditorChange)="onAsEditorChange($event)"
     [asNotEditorOrObserver]="formQuery.asNotEditorOrObserver"
     (asNotEditorOrObserverChange)="onAsNotEditorOrObserverChange($event)"
+    (asEditorOrObserverChange)="onAsEditorOrObserverChange($event)"
     [includeQualityIssues]="query.qualityIssues"
     (qualityIssuesFilterChange)="onOwnQualityIssuesFilterChange($event)">
   </laji-own-observations-filter>

--- a/projects/laji/src/app/+observation/form/observation-form.component.ts
+++ b/projects/laji/src/app/+observation/form/observation-form.component.ts
@@ -357,6 +357,12 @@ export class ObservationFormComponent implements OnInit, OnDestroy {
     this.onFormQueryChange();
   }
 
+  onAsEditorOrObserverChange(value: boolean) {
+    this.formQuery.asObserver = value;
+    this.formQuery.asEditor = value;
+    this.onFormQueryChange();
+  }
+
   onOwnQualityIssuesFilterChange(value: string) {
     this.query.qualityIssues = value;
     this.onQueryChange();

--- a/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
+++ b/projects/laji/src/app/+observation/form/own-observations-filter/own-observations-filter.component.ts
@@ -23,6 +23,7 @@ export class OwnObservationsFilterComponent {
   @Output() asObserverChange = new EventEmitter<boolean>();
   @Output() asEditorChange = new EventEmitter<boolean>();
   @Output() asNotEditorOrObserverChange = new EventEmitter<boolean>();
+  @Output() asEditorOrObserverChange = new EventEmitter<boolean>();
   @Output() qualityIssuesFilterChange = new EventEmitter<string>();
 
   private observerEditorSideEffects(value) {
@@ -54,8 +55,7 @@ export class OwnObservationsFilterComponent {
     if (value) {
       this.asEditor = false;
       this.asObserver = false;
-      this.asEditorChange.emit(false);
-      this.asObserverChange.emit(false);
+      this.asEditorOrObserverChange.emit(false);
     }
   }
 


### PR DESCRIPTION
https://185803929.dev.laji.fi/observation/list
https://www.pivotaltracker.com/n/projects/2346653/stories/185803929

The observer is not -filter ("exclude") clears both "as observer" and "as editor" filters properly.