### PR TITLE
Subtaxon row links [#185825107]

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-overview.component.html
@@ -154,7 +154,7 @@
           {
             name: 'scientificName',
             label: 'taxonomy.scientific.name',
-            cellTemplate: 'taxonScientificName',
+            cellTemplate: 'taxonScientificNameLink',
             sortable: true
           },
           {


### PR DESCRIPTION
https://185825107.dev.laji.fi/taxon/MX.63082
https://www.pivotaltracker.com/n/projects/2346653/stories/185825107

The scientific name column in subtaxon rows links to the subtaxon's page. Why scientific name and not vernacular name? Because it could be fixed with a one-liner and not all taxa have vernacular names (common in fungi).