### PR TITLE
Fix save button text overflow [#186579462]

### DIFF
--- a/projects/laji-ui/src/lib/_utils.scss
+++ b/projects/laji-ui/src/lib/_utils.scss
@@ -172,6 +172,17 @@ $displays: flex, block, inline, inline-block, none;
   }
 }
 
+.whitespace-nowrap {
+  white-space: nowrap !important;
+}
+@each $breakpoint, $px in $breakpoints {
+  @media only screen and (max-width: $px) {
+    .#{$breakpoint}\:whitespace-nowrap {
+      white-space: nowrap !important;
+    }
+  }
+}
+
 $basis: (
   "0": 100%,
   "1": 10%,

--- a/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.html
+++ b/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.html
@@ -7,10 +7,10 @@
       <button type="button" [disabled]="saving" class="btn btn-success" (click)="lock.emit(true)"><i class="fa fa-unlock"></i></button>
     </ng-template>
   </div>
-  <button *ngIf="show.save && !template" class="btn btn-success" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPublic.emit()">{{ buttonLabel('save') | translate }}</button>
-  <button *ngIf="show.temp && !template" class="btn btn-default" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPrivate.emit()">{{ buttonLabel('temp') | translate }}</button>
+  <button *ngIf="show.save && !template" class="btn btn-success whitespace-nowrap" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPublic.emit()">{{ buttonLabel('save') | translate }}</button>
+  <button *ngIf="show.temp && !template" class="btn btn-default whitespace-nowrap" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPrivate.emit()">{{ buttonLabel('temp') | translate }}</button>
   <button *ngIf="template" class="btn btn-success" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitTemplate.emit()">{{ 'haseka.form.saveTemplate' | translate }}</button>
-  <div [ngSwitch]="status" class="flex-grow status">
+  <ng-container [ngSwitch]="status" class="status">
     <div *ngSwitchCase="'success'" class="success">
       {{ 'haseka.form.success' | translate }}
     </div>
@@ -31,7 +31,7 @@
     <span *ngIf="readonly === readonlyStates.noEdit">
         {{ 'haseka.form.readonly' | translate }}
     </span>
-  </div>
-  <button *ngIf="show.cancel" class="btn btn-danger pull-right" [disabled]="saving" type="submit" (click)="leave.emit()">{{ buttonLabel('cancel') | translate }}</button>
+  </ng-container>
+  <button *ngIf="show.cancel" class="btn btn-danger whitespace-nowrap" [disabled]="saving" type="submit" (click)="leave.emit()">{{ buttonLabel('cancel') | translate }}</button>
   <laji-feedback *ngIf="displayFeedback" [iconOnly]="true" [fixed]="false"></laji-feedback>
 </div>

--- a/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.html
+++ b/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.html
@@ -10,7 +10,7 @@
   <button *ngIf="show.save && !template" class="btn btn-success whitespace-nowrap" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPublic.emit()">{{ buttonLabel('save') | translate }}</button>
   <button *ngIf="show.temp && !template" class="btn btn-default whitespace-nowrap" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitPrivate.emit()">{{ buttonLabel('temp') | translate }}</button>
   <button *ngIf="template" class="btn btn-success" [disabled]="saving || disableIfOnlyWarnings()" type="submit" (click)="submitTemplate.emit()">{{ 'haseka.form.saveTemplate' | translate }}</button>
-  <ng-container [ngSwitch]="status" class="status">
+  <div [ngSwitch]="status" class="flex-grow status">
     <div *ngSwitchCase="'success'" class="success">
       {{ 'haseka.form.success' | translate }}
     </div>
@@ -31,7 +31,7 @@
     <span *ngIf="readonly === readonlyStates.noEdit">
         {{ 'haseka.form.readonly' | translate }}
     </span>
-  </ng-container>
+  </div>
   <button *ngIf="show.cancel" class="btn btn-danger whitespace-nowrap" [disabled]="saving" type="submit" (click)="leave.emit()">{{ buttonLabel('cancel') | translate }}</button>
   <laji-feedback *ngIf="displayFeedback" [iconOnly]="true" [fixed]="false"></laji-feedback>
 </div>

--- a/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.scss
+++ b/projects/laji/src/app/+project-form/form/laji-form/laji-form-footer/laji-form-footer.component.scss
@@ -15,7 +15,7 @@
   display: flex;
   flex-flow: row nowrap;
   > div, > button, > lu-button {
-    margin-right: $sp-default;
+    margin-right: $sp-1;
   }
 
   button, .lock-button {
@@ -25,8 +25,6 @@
 }
 
 .status {
-  padding: $sp-btn;
-
   .success {
     color: $success-7;
   }


### PR DESCRIPTION
https://186579462.dev.laji.fi/project/JX.519/form
https://www.pivotaltracker.com/n/projects/2346653/stories/186579462

Removed empty spaces between the save buttons and used no-wrap to prevent text overflow on small screens.