### PR TITLE
Named places 'all' filter as empty to API query

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.html
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.html
@@ -71,7 +71,7 @@
           <laji-np-choose [namedPlaces]="data.namedPlaces"
                           [documentForm]="data.documentForm"
                           [placeForm]="data.placeForm"
-                          [userID]="data.user.id"
+                          [userID]="data.user?.id"
                           [activeNP]="data.activeNP?.id"
                           [formRights]="data.formRights"
                           (activePlaceChange)="onActivePlaceChange($event)"></laji-np-choose>

--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
@@ -260,8 +260,8 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
   }
 
   onActivePlaceChange(activeNP: string) {
-    this.vm$.pipe(take(1)).subscribe(({activeNP: _activeNP}) => {
-      if (activeNP && activeNP === _activeNP?.id) {
+    this.vm$.pipe(take(1)).subscribe(({activeNP: currentActiveNP}) => {
+      if (activeNP && activeNP === currentActiveNP?.id) {
         this.infoView?.npClick();
       }
       this.activeIdChange.emit(activeNP);
@@ -314,6 +314,7 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
     if (documentForm.options?.restrictAccess && selected.indexOf('reserve') === -1) {
       selected.push('reserve');
     }
+    selected.push('id');
 
     const query: NamedPlaceQuery = {
       collectionID: documentForm.collectionID,

--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
@@ -328,6 +328,13 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
       return of(null);
     }
 
+    if (query.municipality === 'all') {
+      delete query.municipality;
+    }
+    if (query.birdAssociationArea === 'all') {
+      delete query.birdAssociationArea;
+    }
+
     return this.namedPlaceService.getAllNamePlaces(query)
       .pipe(
         catchError(() => throwError(this.translate.instant('np.loadError')))


### PR DESCRIPTION
Currently the named places filtering works kind of accidentally. Let's look at the invasive species named places view for example:

https://dev.laji.fi/en/project/MHL.33/form/places

If you select some municipality, and then again 'All municipalities', the API query will have `&municipality=all`. The old API has some logic that filters non QNames for some query params. It's implemented in a very messy way, and I also just don't agree that we should do that in the API. So, in the new API I'm not going to do that kind of filtering for the params - if anything, I'd rather throw an exception for a bad query param. But I don't think that's really necessary. So, this PR fixes the query so that it won't have `municipality=all`. Instead, there just won't be a municipality filter (same as all).

Testable at https://240405.dev.laji.fi/en/project/MHL.33/form/places

Includes also:
    * `id` isn't anymore automatically added to the `selectedFields` of the named place query by the API, so I added it here.
    * null pointer error in named place view, when user is undefined (broken atm eg https://beta.laji.fi/project/MHL.1/form/MHL.1/places when unlogged)
