### PR TITLE
Modify-button visible for secondary data #186261663

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
@@ -181,9 +181,8 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
         map(rights => ({doc, rights})),
       )),
       switchMap(doc => doc.doc.formId
-        ? this.formService.getForm(IdService.getId(doc.doc.formId)).pipe(
+        ? this.formService.getFormInListFormat(IdService.getId(doc.doc.formId)).pipe(
           map(form => {
-            console.log(form.options?.secondaryCopy);
             const isSecondary = !!form.options?.secondaryCopy;
             doc.rights.hasEditRights = !isSecondary;
             doc.rights.hasDeleteRights = !isSecondary;


### PR DESCRIPTION
Task: https://www.pivotaltracker.com/story/show/186261663, testable here: https://186261663.dev.laji.fi/.

Solving this required adding a query to form endpoint to read the field denoting a form as member of secondary collection, which I'm not too keen on.