### PR TITLE
Update geoserver-dev urls

### DIFF
--- a/projects/iucn/src/environments/environment.prod.ts
+++ b/projects/iucn/src/environments/environment.prod.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api.rahtiapp.fi',
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   displayDevRibbon: false
 };

--- a/projects/iucn/src/environments/environment.ts
+++ b/projects/iucn/src/environments/environment.ts
@@ -20,7 +20,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   displayDevRibbon: true
 };

--- a/projects/kerttu-global/src/environments/environment.dev.ts
+++ b/projects/kerttu-global/src/environments/environment.dev.ts
@@ -15,7 +15,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'en',
   languages: ['en', 'es', 'fr'],

--- a/projects/kerttu-global/src/environments/environment.prod.ts
+++ b/projects/kerttu-global/src/environments/environment.prod.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api.rahtiapp.fi',
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'en',
   languages: ['en', 'es', 'fr'],

--- a/projects/kerttu-global/src/environments/environment.ts
+++ b/projects/kerttu-global/src/environments/environment.ts
@@ -20,7 +20,7 @@ export const environment = {
   // kerttuApi: 'http://localhost:5000',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'en',
   languages: ['en', 'es', 'fr'],

--- a/projects/laji/src/environments/environment.beta.ts
+++ b/projects/laji/src/environments/environment.beta.ts
@@ -20,7 +20,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: true

--- a/projects/laji/src/environments/environment.dev-embedded.ts
+++ b/projects/laji/src/environments/environment.dev-embedded.ts
@@ -15,7 +15,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: true

--- a/projects/laji/src/environments/environment.embedded.ts
+++ b/projects/laji/src/environments/environment.embedded.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api.rahtiapp.fi',
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: false

--- a/projects/laji/src/environments/environment.local-beta.ts
+++ b/projects/laji/src/environments/environment.local-beta.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: true

--- a/projects/laji/src/environments/environment.local-prod.ts
+++ b/projects/laji/src/environments/environment.local-prod.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api.rahtiapp.fi',
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: false

--- a/projects/laji/src/environments/environment.local.ts
+++ b/projects/laji/src/environments/environment.local.ts
@@ -21,7 +21,7 @@ export const environment = {
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
   // protaxApi: 'http://localhost:8080',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: true

--- a/projects/laji/src/environments/environment.prod.ts
+++ b/projects/laji/src/environments/environment.prod.ts
@@ -14,7 +14,7 @@ export const environment = {
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api.rahtiapp.fi',
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: false

--- a/projects/laji/src/environments/environment.ts
+++ b/projects/laji/src/environments/environment.ts
@@ -20,7 +20,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
   protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',
   displayDevRibbon: false

--- a/projects/vir/src/environments/environment.dev.ts
+++ b/projects/vir/src/environments/environment.dev.ts
@@ -81,7 +81,7 @@ export const environment = {
       en: ''
     },
   },
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   observationMapOptions: {availableOverlayNameBlacklist: []},
   displayDevRibbon: true
 };

--- a/projects/vir/src/environments/environment.prod.ts
+++ b/projects/vir/src/environments/environment.prod.ts
@@ -80,7 +80,7 @@ export const environment = {
       en: ''
     },
   },
-  geoserver: 'https://geoserver.laji.fi',
+  geoserver: 'https://geoserver.laji.fi/geoserver',
   observationMapOptions: {availableOverlayNameBlacklist: []},
   displayDevRibbon: false
 };

--- a/projects/vir/src/environments/environment.ts
+++ b/projects/vir/src/environments/environment.ts
@@ -61,7 +61,7 @@ export const environment = {
       en: ''
     },
   },
-  geoserver: 'https://geoserver-dev.laji.fi',
+  geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   observationMapOptions: {availableOverlayNameBlacklist: []},
   displayDevRibbon: true
 };


### PR DESCRIPTION
The geoserver development instance will no
longer use a reverse proxy and all content
will now be served at the default /geoserver
endpoint.