### PR TITLE
Fix document viewer checking write rights [#187698581]

### DIFF
--- a/projects/laji/src/app/+project-form-edit/laji-form-builder/laji-form-builder.component.ts
+++ b/projects/laji/src/app/+project-form-edit/laji-form-builder/laji-form-builder.component.ts
@@ -50,7 +50,7 @@ export class LajiFormBuilderComponent implements AfterViewInit, OnDestroy {
     this.lajiFormBuilderUpdateSub?.unsubscribe();
   }
 
-  lajiFormBuilderImport = from(import('@luomus/laji-form-builder')).pipe(tap(() => console.log('mport')), map(p => (p as any).default), shareReplay()) as Observable<any>;
+  lajiFormBuilderImport = from(import('@luomus/laji-form-builder')).pipe( map(p => (p as any).default), shareReplay()) as Observable<any>;
 
   private mount() {
     this.ngZone.runOutsideAngular(() => {

--- a/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
@@ -76,8 +76,6 @@ export class DocumentAnnotationComponent implements AfterViewInit, OnChanges, On
   documentID: string;
   personID: string;
   isEditor = false;
-  hasEditRights = false;
-  hasDeleteRights = false;
   personRoleAnnotation: Annotation.AnnotationRoleEnum;
   activeGathering: any;
   mapData: any = [];
@@ -236,8 +234,6 @@ export class DocumentAnnotationComponent implements AfterViewInit, OnChanges, On
     docAndRights$
       .subscribe(({doc, rights}) => {
         this.isEditor = rights.isEditor;
-        this.hasEditRights = rights.hasEditRights;
-        this.hasDeleteRights = rights.hasDeleteRights;
         this.parseDoc(doc, doc);
       },
         () => this.parseDoc(undefined, false)

--- a/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
@@ -183,10 +183,10 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
       switchMap(doc => doc.doc.formId
         ? this.formService.getFormInListFormat(IdService.getId(doc.doc.formId)).pipe(
           map(form => {
-            const isSecondary = !!form.options?.secondaryCopy;
-            doc.rights.hasEditRights = !isSecondary;
-            doc.rights.hasDeleteRights = !isSecondary;
-
+            if (!!form.options?.secondaryCopy) {
+              doc.rights.hasEditRights = false;
+              doc.rights.hasDeleteRights = false;
+            }
             return doc;
           })
         )
@@ -198,6 +198,7 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
       .subscribe(({doc, rights}) => {
           this.hasEditRights = rights.hasEditRights;
           this.hasDeleteRights = rights.hasDeleteRights;
+        console.log(rights);
           this.parseDoc(doc, doc);
         },
         () => this.parseDoc(undefined, false)

--- a/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
@@ -198,7 +198,6 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
       .subscribe(({doc, rights}) => {
           this.hasEditRights = rights.hasEditRights;
           this.hasDeleteRights = rights.hasDeleteRights;
-        console.log(rights);
           this.parseDoc(doc, doc);
         },
         () => this.parseDoc(undefined, false)


### PR DESCRIPTION
The document viewer dispalyed the document writable (= shows edit & delete buttons) based on just looking at the form's secondaryCopy option. This made all documents with non-secondaryCopy form display the buttons. I made it to act on the secondaryCopy option only if it's false.

Also removed few unused variables from the document annotation component.
