### PR TITLE
Fix observation map sometimes showing wrong data

### DIFF
--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
@@ -170,8 +170,8 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
   private pointGeometryPageSize = 10000;
   private activeZoomThresholdLevel = 0;
   private activeZoomThresholdBounds?: any;
-  private dataFetchSubscription: Subscription;
   private mapMoveSubscription: Subscription;
+  private mapDataSubscription?: Subscription;
   private activeGeometryHash: string;
 
   constructor(
@@ -214,8 +214,8 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.dataFetchSubscription?.unsubscribe();
     this.mapMoveSubscription?.unsubscribe();
+    this.mapDataSubscription?.unsubscribe();
   }
 
   onCreate(e) {
@@ -436,14 +436,19 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
   private updateMap() {
     const bounds = this.activeZoomThresholdBounds;
     const query = this.prepareQuery(bounds);
+
     const hash = JSON.stringify(query) + this.useFinnishMap;
     if (hash === this.previousQueryHash) { return; }
     this.previousQueryHash = hash;
-    forkJoin({
+
+    this.mapDataSubscription?.unsubscribe();
+
+    this.mapDataSubscription = forkJoin({
       drawData: this.getDrawData$(query),
       dataOptions: this.getDataOptions$(query, bounds)
     }).subscribe(({drawData, dataOptions}) => {
       this.mapData = [drawData, dataOptions];
+      this.cdr.markForCheck();
     });
   }
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187698638
https://187698638.dev.laji.fi/observation/map

This is a little difficult to test since the bug doesn't happen every time. It was caused by not unsubscribing the map data subscription before creating a new one.