### PR TITLE
Fix named place linking for forms without sub forms [fixes #187659711]

### DIFF
--- a/projects/laji/src/app/+project-form/form/form.routes.ts
+++ b/projects/laji/src/app/+project-form/form/form.routes.ts
@@ -108,6 +108,11 @@ export const routes: Routes = [
 
   },
   {
+    path: ':formOrDocument/link', component: NamedPlaceLinkerWrapperComponent,
+    data: {displayFeedback: false},
+    pathMatch: 'prefix'
+  },
+  {
     path: ':formOrDocument/:document', component: FormComponent,
     canDeactivate: [DocumentDeActivateGuard],
     data: {displayFeedback: false},
@@ -131,12 +136,6 @@ export const routes: Routes = [
     path: ':formOrDocument/template', component: FormComponent,
     canDeactivate: [DocumentDeActivateGuard],
     data: {displayFeedback: false, template: true},
-    pathMatch: 'prefix'
-
-  },
-  {
-    path: ':formOrDocument/link', component: NamedPlaceLinkerWrapperComponent,
-    data: {displayFeedback: false},
     pathMatch: 'prefix'
 
   },

--- a/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-wrapper.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place-linker/named-place-linker-wrapper.component.ts
@@ -13,7 +13,7 @@ export class NamedPlaceLinkerWrapperComponent implements OnInit {
     private browserService: BrowserService
   ) {}
   ngOnInit() {
-    this.documentID = this.route.snapshot.params['document'];
+    this.documentID = this.route.snapshot.params['document'] || this.route.snapshot.params['formOrDocument'];
   }
 
   linked() {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187659711

The root reason for this bug is that the project form routing is a bit awkward. It uses a single path param for either a sub form or a document, so I hadn't checked that the routing works also for forms without a sub form.