### PR TITLE
Use laji-ui placement service in typeahead instead of ngx-bootstrap

### DIFF
--- a/projects/laji-ui/src/lib/typeahead/component-loader/component-loader.class.ts
+++ b/projects/laji-ui/src/lib/typeahead/component-loader/component-loader.class.ts
@@ -346,12 +346,13 @@ export class ComponentLoader<T> {
     }
 
     this.onShown.subscribe(() => {
+      if (!this._renderer) { console.warn("Component loader: expected renderer to exist"); return; }
       this._posService.position({
         element: this._componentRef?.location,
         target: this._elementRef,
         attachment: this.attachment,
         appendToBody: this.container === 'body'
-      });
+      }, this._renderer);
     });
 
     this._zoneSubscription = this._ngZone.onStable.subscribe(() => {

--- a/projects/laji-ui/src/lib/typeahead/component-loader/testing/test-setup.ts
+++ b/projects/laji-ui/src/lib/typeahead/component-loader/testing/test-setup.ts
@@ -1,1 +1,0 @@
-import 'jest-preset-angular/setup-jest';

--- a/projects/laji-ui/src/lib/typeahead/positioning/positioning.service.ts
+++ b/projects/laji-ui/src/lib/typeahead/positioning/positioning.service.ts
@@ -46,7 +46,7 @@ export interface PositioningOptions {
 export class PositioningService {
   private options?: Options;
   private update$$ = new Subject<null>();
-  private positionElements = new Map();
+  private positionElements = new Map<HTMLElement, PositioningOptions>();
   private triggerEvent$?: Observable<number|Event|null>;
   private isDisabled = false;
 
@@ -72,21 +72,9 @@ export class PositioningService {
             return;
           }
 
-          // We could call placementService.update here, but I don't think it's necessary
-          // The old ngx-bootstrap positioning logic has been entirely replaced
-          return;
-          this.positionElements
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            .forEach((positionElement: any) => {
-              positionElements(
-                _getHtmlElement(positionElement.target),
-                _getHtmlElement(positionElement.element),
-                positionElement.attachment,
-                positionElement.appendToBody,
-                this.options,
-                rendererFactory.createRenderer(null, null)
-              );
-            });
+          for (let el of this.positionElements.keys()) {
+            this.placementService.update(el);
+          }
         });
       });
     }
@@ -116,7 +104,7 @@ export class PositioningService {
     const element: HTMLElement = options.element?.['nativeElement'] ?? options.element;
     const target: HTMLElement = options.target?.['nativeElement'] ?? options.target;
     this.placementService.attach(element, target, <Placement>options.attachment, {window, document: this.document, renderer: renderer})
-    //this.positionElements.set(_getHtmlElement(options.element), options);
+    this.positionElements.set(_getHtmlElement(options.element), options);
   }
 
   calcPosition(): void {
@@ -125,7 +113,7 @@ export class PositioningService {
 
   deletePositionElement(elRef: ElementRef): void {
     this.placementService.detach(elRef.nativeElement);
-    //this.positionElements.delete(_getHtmlElement(elRef));
+    this.positionElements.delete(_getHtmlElement(elRef));
   }
 
   setOptions(options: Options) {

--- a/projects/laji-ui/src/lib/typeahead/positioning/testing/test-setup.ts
+++ b/projects/laji-ui/src/lib/typeahead/positioning/testing/test-setup.ts
@@ -1,1 +1,0 @@
-import 'jest-preset-angular/setup-jest';

--- a/projects/laji-ui/src/lib/typeahead/typeahead-container.component.ts
+++ b/projects/laji-ui/src/lib/typeahead/typeahead-container.component.ts
@@ -47,6 +47,11 @@ let nextWindowId = 0;
       overflow-y: auto;
       height: 100px;
     }
+
+    :host {
+      top: 0;
+      z-index: 10000 !important;
+    }
   `
   ],
   animations: [typeaheadAnimation]


### PR DESCRIPTION
Basically circumvents the positioning service that was copy pasted from ngx-bootstrap entirely. Instead using the placement service that I wrote some time ago for tooltips/popovers/etc.

The typeahead is an absolute monster. It's difficult to comprehend how it's possible to have thousands of LOC for what amounts to a simple dropdown. It seems really bad performance wise as well. Eg. it doesn't use `OnPush` and I checked that it was calling the positioning logic constantly even when no change was happening...

I added some checks for invalid values, but in practice I never saw them come up when testing. The z-index is to ensure that the dropdown opens on top always (such as on new annotation form).

https://www.pivotaltracker.com/n/projects/2346653/stories/187852117
https://187852117.dev.laji.fi/

List of affected components (stuff that uses the typeahead):
- observation form: taxon
- observation form: observer name
- new annotation form
- "find person"
- taxon autocomplete
  - excel import mapping
  - line transect result
- taxon select (why do we have two?)
  - species form (the filters on the list)
  - species info card
  - invasive species control project
  - iucn filters (?)
  - iucn about page
- kerttu species select