### PR TITLE
Fix "editors" field being copied to documents from the named place

### DIFF
--- a/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/+project-form/form/document-form/document-form.facade.ts
@@ -442,6 +442,7 @@ export class DocumentFormFacade {
 
     let removeList = [
       ...(form.excludeFromCopy),
+      '$.editors',
       '$.gatheringEvent.leg'
     ];
     if (form.options?.namedPlaceOptions?.includeUnits) {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187867645