### PR TITLE
Change protax api url

### DIFF
--- a/projects/iucn/src/environments/environment.prod.ts
+++ b/projects/iucn/src/environments/environment.prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://login.laji.fi/login',
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api.rahtiapp.fi',
+  protaxApi: 'https://protax-api.laji.fi',
   geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   displayDevRibbon: false

--- a/projects/iucn/src/environments/environment.ts
+++ b/projects/iucn/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   displayDevRibbon: true

--- a/projects/kerttu-global/src/environments/environment.dev.ts
+++ b/projects/kerttu-global/src/environments/environment.dev.ts
@@ -14,7 +14,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'en',

--- a/projects/kerttu-global/src/environments/environment.prod.ts
+++ b/projects/kerttu-global/src/environments/environment.prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://login.laji.fi/login',
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api.rahtiapp.fi',
+  protaxApi: 'https://protax-api.laji.fi',
   geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'en',

--- a/projects/kerttu-global/src/environments/environment.ts
+++ b/projects/kerttu-global/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   // kerttuApi: 'http://localhost:5000',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'en',

--- a/projects/laji/src/environments/environment.beta.ts
+++ b/projects/laji/src/environments/environment.beta.ts
@@ -19,7 +19,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.dev-embedded.ts
+++ b/projects/laji/src/environments/environment.dev-embedded.ts
@@ -14,7 +14,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.embedded.ts
+++ b/projects/laji/src/environments/environment.embedded.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://login.laji.fi/login',
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api.rahtiapp.fi',
+  protaxApi: 'https://protax-api.laji.fi',
   geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.local-beta.ts
+++ b/projects/laji/src/environments/environment.local-beta.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.local-prod.ts
+++ b/projects/laji/src/environments/environment.local-prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://login.laji.fi/login',
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api.rahtiapp.fi',
+  protaxApi: 'https://protax-api.laji.fi',
   geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.local.ts
+++ b/projects/laji/src/environments/environment.local.ts
@@ -19,7 +19,7 @@ export const environment = {
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   // kerttuApi: 'http://localhost:5000',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   // protaxApi: 'http://localhost:8080',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',

--- a/projects/laji/src/environments/environment.prod.ts
+++ b/projects/laji/src/environments/environment.prod.ts
@@ -13,7 +13,7 @@ export const environment = {
   loginUrl: 'https://login.laji.fi/login',
   selfPage: 'https://login.laji.fi/self',
   kerttuApi: 'https://kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api.rahtiapp.fi',
+  protaxApi: 'https://protax-api.laji.fi',
   geoserver: 'https://geoserver.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard.laji.fi',
   defaultLang: 'fi',

--- a/projects/laji/src/environments/environment.ts
+++ b/projects/laji/src/environments/environment.ts
@@ -19,7 +19,7 @@ export const environment = {
   loginUrl: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/login',
   selfPage: 'https://fmnh-ws-test.it.helsinki.fi/laji-auth/self',
   kerttuApi: 'https://staging-kerttu-backend.laji.fi',
-  protaxApi: 'https://protax-api-protax-api-staging.rahtiapp.fi',
+  protaxApi: 'https://protax-api-dev.laji.fi',
   geoserver: 'https://geoserver-dev.laji.fi/geoserver',
   dashboardUrl: 'https://dashboard-dev.laji.fi',
   defaultLang: 'fi',


### PR DESCRIPTION
Test that the new url works: go to https://32.dev.laji.fi/theme/protax, switch to the "File selector" tab and upload the [protax-example-10.txt](https://github.com/user-attachments/files/16086135/protax-example-10.txt) file. The new urls are connected to Rahti 2.
