### PR TITLE
User service fixes

### DIFF
--- a/projects/laji/src/app/shared/api/PersonApi.ts
+++ b/projects/laji/src/app/shared/api/PersonApi.ts
@@ -260,7 +260,8 @@ export class PersonApi {
       return EMPTY;
     }
     const url = this.basePath + `/person-token/${token}`;
-    return this.http.delete(url, {observe: 'response'});
+    // expecting 200 "ok"
+    return this.http.delete(url, {observe: 'body', responseType: 'text'});
   }
 
 }

--- a/projects/laji/src/app/shared/route/only-logged-in.ts
+++ b/projects/laji/src/app/shared/route/only-logged-in.ts
@@ -8,7 +8,6 @@ import { take, tap } from 'rxjs/operators';
 
 @Injectable({providedIn: 'root'})
 export class OnlyLoggedIn  {
-
   constructor(
     private userService: UserService,
     private platformService: PlatformService
@@ -21,10 +20,10 @@ export class OnlyLoggedIn  {
     return this.userService.isLoggedIn$.pipe(
       take(1),
       tap(isLoggedIn => {
- if (!isLoggedIn) {
-        this.userService.redirectToLogin(state.url, route.data);
-      }
-})
+        if (!isLoggedIn) {
+          this.userService.redirectToLogin(state.url, route.data);
+        }
+      })
     );
   }
 

--- a/projects/laji/src/app/shared/service/user.service.ts
+++ b/projects/laji/src/app/shared/service/user.service.ts
@@ -63,17 +63,17 @@ interface PersistentState {
 
 namespace UserState {
   export interface Loading {
-    _tag: 'loading'
+    _tag: 'loading';
   }
 
   export interface Ready {
-    _tag: 'user_state'
-    person: Person | null,
-    settings: UserSettings
+    _tag: 'user_state';
+    person: Person | null;
+    settings: UserSettings;
   }
 
   export interface NotLoggedIn {
-    _tag: 'not_logged_in'
+    _tag: 'not_logged_in';
   }
 }
 
@@ -233,7 +233,7 @@ export class UserService implements OnDestroy {
 
   logout(cb?: () => void): void {
     if (this.persistentState.loginState._tag !== 'logged_in') {
-      console.warn('Attempted logout while not being logged in.')
+      console.warn('Attempted logout while not being logged in.');
       return;
     }
     this.subLogout = this.personApi.removePersonToken(this.persistentState.loginState.token).pipe(
@@ -255,7 +255,7 @@ export class UserService implements OnDestroy {
 
   getToken(): string {
     if (this.store.value.loginState._tag !== 'logged_in') {
-      console.warn("Attempted to get token while user is not logged in");
+      console.warn('Attempted to get token while user is not logged in');
       return '';
     }
     return this.store.value.loginState.token;


### PR DESCRIPTION
- Fixes blank page when page should be redirected by the `OnlyLoggedIn` guard
- Fixes logout always erroring, because it was expecting json from the api (though the logout did succeed)
- Refactored user service to use tagged unions to represent loading states