### PR TITLE
Fix redirection with query parameters

### DIFF
--- a/projects/laji/src/app/+user/login/user-login.component.ts
+++ b/projects/laji/src/app/+user/login/user-login.component.ts
@@ -25,10 +25,8 @@ export class UserLoginComponent implements OnInit, AfterViewInit, OnDestroy {
 
   ngAfterViewInit() {
     if (this.platformService.isBrowser) {
-      const next = this.route.snapshot.queryParams['next'] || '/';
-      this.router.navigate(
-        this.localizeRouterService.translateRoute([next])
-      );
+      const next = this.route.snapshot.queryParams['next'] || this.localizeRouterService.translateRoute('/');
+      this.router.navigateByUrl(next);
     }
   }
 


### PR DESCRIPTION
Fix redirection with the `next` parameter not working if the path contains query parameters