### PR TITLE
Increase warehouse list query timeout

### DIFF
--- a/projects/laji/src/app/shared/api/WarehouseApi.ts
+++ b/projects/laji/src/app/shared/api/WarehouseApi.ts
@@ -376,7 +376,7 @@ export class WarehouseApi {
 
     this.addQueryToQueryParams(this.queryWithMetaData(query, selected, orderBy, pageSize, page), queryParameters);
 
-    return this.http.get<PagedResult<any>>(path, {params: queryParameters});
+    return this.http.get<PagedResult<any>>(path, {params: queryParameters, headers: { timeout: "60000" }});
   }
 
   //Get filter to use in selection filters


### PR DESCRIPTION
Doubles the warehouse list query timeout.

Lengthy discussion in https://luomus-ict.slack.com/archives/CNKL7GM0B/p1726561828664829, so this doesn't solve the root problem that warehouse has become slow. But this fixes the problem to some extent on the front side, as the request doesn't timeout so soon.

An example for a slow query that in production that timeouts: https://laji.fi/observation/list?finnish=true

I tested the changes against production by running the app locally with `npm run start:local-prod`.
