### PR TITLE
fix polygon registration catch block path to error [closes #547]

### DIFF
--- a/projects/laji/src/app/+observation/result/observation-result.component.ts
+++ b/projects/laji/src/app/+observation/result/observation-result.component.ts
@@ -214,7 +214,7 @@ export class ObservationResultComponent implements OnChanges {
     return this.warehouseApi.registerPolygon(polygon, this.userService.getToken(), 'WGS84').pipe(
       map((response: any) => '' + response.id),
       catchError(e => {
-        const error = e.error?.error;
+        const { error } = e;
         const {message, localizedMessage} = error;
         if (error.status >= 400 && message || localizedMessage) {
           const localizedError = localizedMessage?.[this.translate.currentLang];


### PR DESCRIPTION
Fixes a bug where you draw a large polygon to the observation map and nothing seems to happen.

Not sure if the catch block has ever worked. I tested the behaviour against the old API, and it doesn't work even there so idk...
