### PR TITLE
Adding a new field resets order in excel import generation #185861037

### DIFF
--- a/projects/laji/src/app/shared-modules/spreadsheet/excel-generator/excel-generator.component.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/excel-generator/excel-generator.component.ts
@@ -87,9 +87,7 @@ export class ExcelGeneratorComponent {
       return;
     }
     if (this.selected.indexOf(field.key) === -1) {
-      this.selected = this.fields.filter(
-        f => this.selected.includes(f.key) || f.key === field.key
-      ).map(f => f.key);
+      this.selected = this.selected.concat(field.key);
     } else {
       this.selected = this.selected.filter(val => val !== field.key || field.required);
     }


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/185861037
https://185861037.dev.laji.fi/vihko/tools/generate

Changed and simplified adding new columns to excel generation to keep the user defied order.