### PR TITLE
Sidebar displays observations from another form #187298216

### DIFF
--- a/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest-documents.facade.ts
@@ -113,7 +113,10 @@ export class LatestDocumentsFacade implements OnDestroy {
   private updateRemote() {
     if (this.updateSub && this.updateSubKey === this.getSubKey()) {
       return;
+    } else if (this.updateSub) {
+      this.updateSub.unsubscribe();
     }
+
     this.updateSubKey = this.getSubKey();
     this.updateState({..._state, loading: true});
     this.updateSub = this.documentApi.findAll(this.userService.getToken(), '1', '10', { collectionID: this.collectionID }).pipe(

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.html
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.html
@@ -20,7 +20,7 @@
     </table>
   </ng-container>
   <laji-spinner [spinning]="loading$ | async" [overlay]="true">
-      <ng-container *ngIf="!tmpOnly">
+      <ng-container *ngIf="!tmpOnly && !firstLoad">
         <ng-container *ngIf="latest$ | async; let latest">
           <h4 *ngIf="latest.length > 0">{{ 'haseka.users.latest' | translate }}</h4>
           <div class="row">

--- a/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
+++ b/projects/laji/src/app/shared-modules/latest-documents/latest/haseka-users-latest.component.ts
@@ -3,6 +3,7 @@ import { Document } from '../../../shared/model/Document';
 import { Observable } from 'rxjs';
 import { LatestDocumentsFacade } from '../latest-documents.facade';
 import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-document.service';
+import { tap } from 'rxjs/operators';
 
 
 @Component({
@@ -20,6 +21,7 @@ export class UsersLatestComponent implements OnInit, OnDestroy {
 
   @Output() showViewer = new EventEmitter<Document>();
 
+  public firstLoad = true;
   public loading$: Observable<boolean>;
   public tmpDocuments$ = this.latestFacade.tmpDocuments$;
   public latest$ = this.latestFacade.latest$;
@@ -30,7 +32,11 @@ export class UsersLatestComponent implements OnInit, OnDestroy {
     private latestFacade: LatestDocumentsFacade,
     private deleteOwnDocument: DeleteOwnDocumentService
   ) {
-    this.loading$ = this.latestFacade.loading$;
+    this.loading$ = this.latestFacade.loading$.pipe(tap(loading => {
+      if (this.firstLoad && !loading) {
+        this.firstLoad = false;
+      }
+    }));
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/187298216
https://187298216.dev.laji.fi/vihko/home

Fixed by hiding the latest documents in sidebar until the latestDocumentFacade is done loading if the call to it is first since page load, to keep documents still in latestDocumentFacade potentially from other projects from showing up. LatestDocumentFacade also could cause page to update with wrong projects documents after pagechange due to hanging subscription to latest documents, so I added unsuscribe call to it when the query changes.