### PR TITLE
Annotation viewer: hotkey alt+t for missing taxon field #186579144

### DIFF
--- a/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
+++ b/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
@@ -559,11 +559,11 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
   @HostListener('document:keydown', ['$event'])
   annotationKeyDown(e: KeyboardEvent) {
       if (e.keyCode === 84 && e.altKey) { // alt + t --> focus input taxon
-          this.taxonElement.nativeElement.focus();
+          this.taxonElement?.nativeElement.focus();
       }
 
       if (e.keyCode === 67 && e.altKey) { // alt + c --> focus comment textarea
-          this.commentElement.nativeElement.focus();
+          this.commentElement?.nativeElement.focus();
       }
 
       if (this.expert && e.keyCode === 49 && e.altKey) { // alt + 1 --> add convincing


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/186579144
https://186579144.dev.laji.fi/observation/list

Fixed error message for not logged in user or otherwise missing taxon field in annotation view by making element focus call use optional chaining to account for taxon input element possibly being null. Did same for comment field hotkey which could theoretically cause same issue.