### PR TITLE
Fix null pointer error for undefined user in np-info

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/np-info/np-info.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/np-info/np-info.component.ts
@@ -213,6 +213,9 @@ export class NpInfoComponent implements OnInit, OnChanges, AfterViewInit {
       return;
     }
     this.userService.user$.pipe(take(1)).subscribe(person => {
+      if (!person) {
+        return;
+      }
       this.editButtonVisible = (this.namedPlace.owners && this.namedPlace.owners.indexOf(person.id) !== -1) || this.formRights.admin;
       this.formReservable = !!this.documentForm?.options?.namedPlaceOptions?.reservationUntil;
       this.useLocalDocumentViewer = this.documentForm?.options?.documentsViewableForAll;


### PR DESCRIPTION
Repro:

1. goto http://beta.laji.fi/project/MHL.1/form/MHL.1/places?activeNP=MNP.27447 when unlogged
-> Error is thrown

Fix testable in https://241004.dev.laji.fi/project/MHL.1/form/MHL.1/places?activeNP=MNP.27447

There's something wrong in the user service logic. Even though the `user$` is stated as `Observable<Person | undefined>`, if you look at the actual type of it (hover in you IDE or however you do it), it's just `Observable<Person>`. This is interesting, as I though stating a type has stronger preference than type inference.

There might be similar errors somewhere as the typing is wrong (`user$` can emit `undefined` even though the typing says otherwise), but I don't have time to dig deeper just now.
