### PR TITLE
Update form permissions logic according to laji-api changes

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
@@ -14,7 +14,6 @@ import { DialogService } from '../../../../shared/service/dialog.service';
 import { UserService } from '../../../../shared/service/user.service';
 import { FooterService } from '../../../../shared/service/footer.service';
 import { NamedPlaceQuery } from '../../../../shared/api/NamedPlaceApi';
-import { ProjectFormService } from '../../../../shared/service/project-form.service';
 import { NpInfoComponent } from '../np-info/np-info.component';
 import { FormService } from '../../../../shared/service/form.service';
 
@@ -85,7 +84,6 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
     private userService: UserService,
     private toastrService: ToastrService,
     private formPermissionService: FormPermissionService,
-    private projectFormService: ProjectFormService,
     private formService: FormService
   ) {}
   @ViewChild(NpChooseComponent) chooseView: NpChooseComponent;

--- a/projects/laji/src/app/shared/model/FormPermission.ts
+++ b/projects/laji/src/app/shared/model/FormPermission.ts
@@ -12,16 +12,12 @@
  */
 
 export interface FormPermission {
-    id: string;
-
-    collectionID?: string;
-
-    admins?: Array<string>;
-
-    editors?: Array<string>;
-
-    permissionRequests?: Array<string>;
-
+  collectionID: string;
+  admins: Array<string>;
+  editors: Array<string>;
+  permissionRequests: Array<string>;
+  restrictAccess?: 'MHL.restrictAccessLoose' | 'MHL.restrictAccessStrict';
+  hasAdmins?: boolean;
 }
 
 export namespace FormPermission {

--- a/projects/laji/src/app/shared/service/form-permission.service.ts
+++ b/projects/laji/src/app/shared/service/form-permission.service.ts
@@ -103,7 +103,7 @@ export class FormPermissionService {
 
   getRights(form: Form.List): Observable<Rights> {
     const {collectionID} = form;
-    const notLoggedIn$ = this.getFormPermission(collectionID).pipe(map(permissions => ({
+    const notLoggedInRights$ = this.getFormPermission(collectionID).pipe(map(permissions => ({
       edit: false,
       admin: false,
       ictAdmin: false,
@@ -116,13 +116,13 @@ export class FormPermissionService {
         view: true,
         admin: false,
         ictAdmin: isIctAdmin(user)
-      }) : notLoggedIn$));
+      }) : notLoggedInRights$));
     }
     return this.userService.isLoggedIn$.pipe(
       take(1),
       switchMap(loggedIn => {
         if (!loggedIn || this.platformService.isServer) {
-          return notLoggedIn$;
+          return notLoggedInRights$;
         }
         return this.userService.user$.pipe(
           take(1),
@@ -140,8 +140,8 @@ export class FormPermissionService {
             edit: this.isEditAllowed(formPermission, person, form),
             admin: this.isAdmin(formPermission, person),
             ictAdmin: isIctAdmin(person)
-          }) : notLoggedIn$),
-          catchError(() => notLoggedIn$)
+          }) : notLoggedInRights$),
+          catchError(() => notLoggedInRights$)
         );
       })
     );

--- a/projects/laji/src/app/shared/service/form-permission.service.ts
+++ b/projects/laji/src/app/shared/service/form-permission.service.ts
@@ -71,7 +71,7 @@ export class FormPermissionService {
     return this.formPermissionApi.findByCollectionID(collectionID, personToken).pipe(
       catchError((err: HttpErrorResponse) => {
         if (err.status === 404) {
-          return of({ id: '', collectionID, admins: [], editors: [], permissionRequests: [] });
+          return of({ collectionID, admins: [], editors: [], permissionRequests: [] });
         }
         return throwError(err);
       }),
@@ -102,46 +102,46 @@ export class FormPermissionService {
   }
 
   getRights(form: Form.List): Observable<Rights> {
-    const notLoggedIn = {
+    const {collectionID} = form;
+    const notLoggedIn$ = this.getFormPermission(collectionID).pipe(map(permissions => ({
       edit: false,
       admin: false,
       ictAdmin: false,
-      view: form.options?.restrictAccess !== RestrictAccess.restrictAccessStrict
-    };
-    const {collectionID} = form;
-    if (!collectionID || (!form.options?.restrictAccess && !form.options?.hasAdmins)) {
-      return this.userService.user$.pipe(map(user => user ? {
+      view: permissions.restrictAccess !== RestrictAccess.restrictAccessStrict
+    })));
+
+    if (!collectionID) {
+      return this.userService.user$.pipe(switchMap(user => user ? of({
         edit: true,
         view: true,
         admin: false,
         ictAdmin: isIctAdmin(user)
-      } : notLoggedIn));
+      }) : notLoggedIn$));
     }
     return this.userService.isLoggedIn$.pipe(
       take(1),
-      switchMap(login => {
-        if (!login || this.platformService.isServer) {
-          return ObservableOf(notLoggedIn);
+      switchMap(loggedIn => {
+        if (!loggedIn || this.platformService.isServer) {
+          return notLoggedIn$;
         }
         return this.userService.user$.pipe(
           take(1),
           switchMap(person =>
               this.getFormPermission(collectionID, this.userService.getToken()).pipe(
               catchError(() => of({
-                id: '',
                 collectionID,
                 admins: [],
                 editors: []
               } as FormPermission)),
               map((formPermission: FormPermission) => ({person, formPermission}))
               )),
-          switchMap(({person, formPermission}) => ObservableOf(person ? {
+          switchMap(({person, formPermission}) => person ? of({
             view: this.isEditAllowed(formPermission, person, form) || form.options?.restrictAccess === RestrictAccess.restrictAccessLoose,
             edit: this.isEditAllowed(formPermission, person, form),
             admin: this.isAdmin(formPermission, person),
             ictAdmin: isIctAdmin(person)
-          } : notLoggedIn)),
-          catchError(() => ObservableOf(notLoggedIn))
+          }) : notLoggedIn$),
+          catchError(() => notLoggedIn$)
         );
       })
     );


### PR DESCRIPTION
Form permissions logic has changed in the API so that instead of having a hard coded list of which forms are related, the permissions are inherited based on the collectionID.

This broke the laji.fi code for line transect form. I updated the logic based on:

* Form permissions has to be checked always, even though the user is not logged in. Earlier, for unlogged user, the view permissions were checked directly from the form's `MHL.restrictAccess` property. This doesn't work anymore, since the property might be inherited.
* The new API's `/formPermissions/:collectionID` returns `restrictAccess` and `hasAdmins` properties, which are checked with inheritance with mind. So, for example the API returns `{ restrictAccess: "MHL.restrictAccessLoose", hasAdmins: true }` for collectionID `HR.2962`, even though the form with that collectionID doesn't have those properties; they are inherited from the parent collection `HR.61`. This way we don't have to duplicate the inheritance check client side.

Fixes the following problem:

* For line-transect admins, for example https://beta.laji.fi/project/MHL.1/form/MHL.28/places?birdAssociationArea=ML.1094 should show "Luo uusi" button. Currently it doesn't because it's trying to check the admin rights directly from the form instead of what the server says about the permissions.

The not-logged in part can't actually be tested in practice, because we don't have a form that would have `MHL.restrictAccessStrict` with sub forms.

Fixes https://github.com/luomus/laji-api/issues/12
