### PR TITLE
Fix various bugs with the common panel/accordion component

### DIFF
--- a/projects/laji/src/app/shared/panel/panel.component.html
+++ b/projects/laji/src/app/shared/panel/panel.component.html
@@ -6,11 +6,7 @@
     <strong class="panel-title" [innerHtml]="title"></strong>
   </ng-template>
 </div>
-<div class="panel-collapse" [ngClass]="{closed: hideInside}"
-     (@visibilityState.done)="animationDone($event)"
-     (@visibilityState.start)="animationStart($event)"
-     [@visibilityState]="open ? 'in' : 'out'"
-     role="tabpanel" aria-labelledby="">
+<div class="panel-collapse" [ngStyle]="{display: open ? 'block' : 'none' }" role="tabpanel" aria-labelledby="">
   <div class="panel-body">
     <ng-content></ng-content>
   </div>

--- a/projects/laji/src/app/shared/panel/panel.component.html
+++ b/projects/laji/src/app/shared/panel/panel.component.html
@@ -6,7 +6,7 @@
     <strong class="panel-title" [innerHtml]="title"></strong>
   </ng-template>
 </div>
-<div class="panel-collapse" [ngStyle]="{display: open ? 'block' : 'none' }" role="tabpanel" aria-labelledby="">
+<div class="panel-collapse" [ngStyle]="{display: open ? 'block' : 'none' }" role="tabpanel">
   <div class="panel-body">
     <ng-content></ng-content>
   </div>

--- a/projects/laji/src/app/shared/panel/panel.component.ts
+++ b/projects/laji/src/app/shared/panel/panel.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @angular-eslint/component-selector */
-import {Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
+import { Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 
 @Component({
   selector: '[laji-panel]',

--- a/projects/laji/src/app/shared/panel/panel.component.ts
+++ b/projects/laji/src/app/shared/panel/panel.component.ts
@@ -1,21 +1,12 @@
 /* eslint-disable @angular-eslint/component-selector */
-import { Inject, PLATFORM_ID, AfterViewInit, ChangeDetectorRef, Component, EventEmitter, Input, NgZone, OnChanges, Output, TemplateRef } from '@angular/core';
-import { animate, state, style, transition, trigger } from '@angular/animations';
-import { isPlatformBrowser } from '@angular/common';
+import {Component, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 
 @Component({
   selector: '[laji-panel]',
   templateUrl: './panel.component.html',
   styleUrls: ['./panel.component.scss'],
-  animations: [
-    trigger('visibilityState', [
-      state('in' , style({ height: '*' })),
-      state('out', style({ height: 0 })),
-      transition('in <=> out', animate('100ms'))
-    ])
-  ]
 })
-export class PanelComponent implements AfterViewInit {
+export class PanelComponent {
   @Input() title?: string;
   @Input() headingTemplate?: TemplateRef<any>;
   @Input() index?: number;
@@ -23,27 +14,6 @@ export class PanelComponent implements AfterViewInit {
   @Input() autoToggle = false;
   @Input() headerLink = true;
   @Output() activate = new EventEmitter();
-  public hideInside = true;
-
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: number,
-  ) {}
-
-  ngAfterViewInit() {
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
-    }
-
-    // This hack force triggers angular animation state transition.
-    // For some reason hydration+animations don't play together well
-    // and the animation system thinks that the state transition was already executed
-    // by the time we load in
-    const open = this.open;
-    this.open = false;
-    setTimeout(() => {
-      this.open = open;
-    });
-  }
 
   activateCurrent() {
     if (this.autoToggle) {
@@ -53,26 +23,5 @@ export class PanelComponent implements AfterViewInit {
       value: this.index,
       open: this.open
     });
-  }
-
-  animationStart(event: any) {
-    if (event.toState === 'out') {
-      this.hideInside = true;
-    }
-  }
-
-  animationDone(event: any) {
-    if (event.toState === 'in') {
-      this.hideInside = false;
-    }
-
-    // Another hack related to hydration+animations not working together.
-    // SSR outputs the following html:
-    // <div ... role="tabpanel" aria-labelledby class="panel-collapse ... ng-trigger ng-trigger-visibilityState" style="height: *;">
-    // but `height: *` is not valid html, which is probably causing issues.
-    // Here we are sending a resize event when height has an actual sensible value which allows the children heights to be recalculated:
-    if (isPlatformBrowser(this.platformId)) {
-      window.dispatchEvent(new Event('resize'));
-    }
   }
 }

--- a/projects/laji/src/app/shared/panel/panel.component.ts
+++ b/projects/laji/src/app/shared/panel/panel.component.ts
@@ -33,6 +33,7 @@ export class PanelComponent implements AfterViewInit {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
+
     // This hack force triggers angular animation state transition.
     // For some reason hydration+animations don't play together well
     // and the animation system thinks that the state transition was already executed
@@ -63,6 +64,15 @@ export class PanelComponent implements AfterViewInit {
   animationDone(event: any) {
     if (event.toState === 'in') {
       this.hideInside = false;
+    }
+
+    // Another hack related to hydration+animations not working together.
+    // SSR outputs the following html:
+    // <div ... role="tabpanel" aria-labelledby class="panel-collapse ... ng-trigger ng-trigger-visibilityState" style="height: *;">
+    // but `height: *` is not valid html, which is probably causing issues.
+    // Here we are sending a resize event when height has an actual sensible value which allows the children heights to be recalculated:
+    if (isPlatformBrowser(this.platformId)) {
+      window.dispatchEvent(new Event('resize'));
     }
   }
 }


### PR DESCRIPTION
Related (copied from slack):

Ramble about angular animations: There have been various issues with the panels including this one, things overlapping on the observation page, taxon info card maps breaking, etc. These are all caused by angular animations (especially in combination with ssr/hydration).

Issues:
1. the SSR generated html includes invalid syntax like style=""height=*;" (this comes from angular animations wildcard).
2. After hydration completes animation state doesn't update even if the predicate changes during hydration
3. Since the animation targets the height property, sometimes the height updates correctly, but no resize event is emitted to child nodes (which breaks the map)
4. Other stuff I guess...

We do have animations on some other components that seem to not have issues (eg. sidebar), but I can't seem to figure out why it breaks for laji-panel . Luckily the animations are pretty unnecessary for the component so I will just remove them. These issues have been horrible to debug.

https://www.pivotaltracker.com/story/show/188283099
Fixes bullet points 1 and 3.