### PR TITLE
Use Date() instead of inhouse date interpretation [fixes #581]

### DIFF
--- a/projects/laji/src/app/shared/service/util.service.ts
+++ b/projects/laji/src/app/shared/service/util.service.ts
@@ -143,7 +143,7 @@ export class Util {
   public static isLocalNewestDocument(local: Document, remote: Document): boolean {
     if (remote && remote.dateEdited) {
       if (!local || !local.dateEdited ||
-        Util.getDateFromString(local.dateEdited) < Util.getDateFromString(remote.dateEdited)) {
+        new Date(local.dateEdited) < new Date(remote.dateEdited)) {
         return false;
       }
     }
@@ -163,19 +163,6 @@ export class Util {
 
   public static isObject(any: any): any is Record<string, unknown> {
     return typeof any === 'object' && any !== null && !Array.isArray(any);
-  }
-
-  private static getDateFromString(dateString: string) {
-    const reggie = /(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/;
-    const dateArray = reggie.exec(dateString) || [];
-    return new Date(
-      (+dateArray[1]),
-      (+dateArray[2]) - 1, // Careful, month starts at 0!
-      (+dateArray[3]),
-      (+dateArray[4]),
-      (+dateArray[5]),
-      (+dateArray[6])
-    );
   }
 
   private static mergeClone(value: any, options: any) {


### PR DESCRIPTION
Fixes bug described in #581

~(waiting for approval still, but I wrote this PR anyway while it's still fresh in my mind)~ (Approved)

The bug appeared with the new API. From the new API's [breaking changes documentation](https://github.com/luomus/laji-api/blob/master/breaking-changes.md):

> Document dateCreated & dateEdited uses zulu date (eg if clock in Finland is 17.25:09 on 21.3.2024, it's 2024-03-21T15:25:09.850Z instead of 2024-03-21T17:25:09+02:00)

This change was introduced because in modern Javascript world, the `Date` API is reliable and consistent across environments. The old API used `moment`, which shouldn't be used anymore. The new API's date format is what `new Date().toISOString()` gives.

`Date()` interprets both formats ok. I tested with `node`:

```
$ node
Welcome to Node.js v16.20.2.
Type ".help" for more information.
> function getDateFromString(dateString) { const reggie = /(\d{4})-(\d{2})-(\d{2})[T\s](\d{2}):(\d{2}):(\d{2})/; const dateArray = reggie.exec(dateString) || []; return new Date( (+dateArray[1]), (+dateArray[2]) - 1, (+dateArray[3]), (+dateArray[4]), (+dateArray[5]), (+dateArray[6])); }  // inhouse solution
undefined
> getDateFromString("2024-03-21T17:25:09+02:00") // conversion of old format with the inhouse solution
2024-03-21T15:25:09.000Z
> new Date("2024-03-21T17:25:09+02:00") // conversion of old format with Date
2024-03-21T15:25:09.000Z
> new Date("2024-03-21T15:25:09.000Z") // conversion of new format with Date
2024-03-21T15:25:09.000Z
```