### PR TITLE
Refactor informal taxon groups usage according to api changes

### DIFF
--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
@@ -1,7 +1,7 @@
 <laji-spinner [spinning]="!selectedInformalGroup && !informalGroups">
   <laji-informal-list-breadcrumb *ngIf="showBreadcrumb"
                                  [informalGroup]="selectedInformalGroup"
-                                 [parentGroups]="parentGroups"
+                                 [parentGroup]="parentGroup"
                                  (informalGroupSelect)="informalGroupSelect.emit($event)">
   </laji-informal-list-breadcrumb>
   <laji-informal-list [informalTaxonGroups]="informalGroups"

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
@@ -17,7 +17,7 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
 
   public selectedInformalGroup: InformalTaxonGroup | undefined;
   public informalGroups: InformalTaxonGroup[] = [];
-  public parentGroups: InformalTaxonGroup[] = [];
+  public parentGroup?: InformalTaxonGroup;
 
   private sub = new Subscription();
 
@@ -42,7 +42,6 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
   }
 
   private refreshInformalGroups() {
-    this.parentGroups = [];
     this.selectedInformalGroup = undefined;
 
     if (!this.id) {
@@ -59,7 +58,7 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
       this.selectedInformalGroup = data[1];
     });
 
-    this.informalTaxonService.informalTaxonGroupGetParents(this.id, this.translate.currentLang)
-      .subscribe(data => this.parentGroups = data, () => {});
+    this.informalTaxonService.informalTaxonGroupGetParent(this.id, this.translate.currentLang)
+      .subscribe(data => this.parentGroup = data, () => {});
   }
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
@@ -2,8 +2,8 @@
   <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
     <a (click)="informalGroupSelect.emit()" tabindex="0" role="button" luKeyboardClickable>{{ 'observation.active.informalTaxonGroupAll' | translate }}</a>
   </li>
-  <li *ngFor="let group of parentGroups; let i = index; let active = last;">
-    <a (click)="informalGroupSelect.emit(group.id)" tabindex="0" role="button" luKeyboardClickable>{{ group.name }}</a>
+  <li *ngIf="parentGroup">
+    <a (click)="informalGroupSelect.emit(parentGroup.id)" tabindex="0" role="button" luKeyboardClickable>{{ parentGroup.name }}</a>
   </li>
   <li *ngIf="informalGroup" class="active">
     <span>{{ informalGroup.name }}</span>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
@@ -9,6 +9,6 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 
 export class InformalListBreadcrumbComponent {
   @Input() informalGroup?: InformalTaxonGroup;
-  @Input() parentGroups!: Array<InformalTaxonGroup>;
+  @Input() parentGroup?: Array<InformalTaxonGroup>;
   @Output() informalGroupSelect = new EventEmitter<string>();
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
@@ -9,6 +9,6 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 
 export class InformalListBreadcrumbComponent {
   @Input() informalGroup?: InformalTaxonGroup;
-  @Input() parentGroup?: Array<InformalTaxonGroup>;
+  @Input() parentGroup?: InformalTaxonGroup;
   @Output() informalGroupSelect = new EventEmitter<string>();
 }

--- a/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.ts
+++ b/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.ts
@@ -10,6 +10,7 @@ import { SelectedOption, TreeOptionsChangeEvent, TreeOptionsNode } from '../tree
 import { Util } from '../../shared/service/util.service';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
 import { RedListTaxonGroup } from '../../shared/model/RedListTaxonGroup';
+import { ArrayResult } from '../../shared/model/ArrayResult';
 
 export interface InformalGroupEvent {
   [key: string]: string[];
@@ -60,7 +61,7 @@ export abstract class ExtendedGroupSelectComponent<T extends RedListTaxonGroup|I
 
   abstract findByIds(groupIds: string[], lang: string): Observable<PagedResult<T>>;
   abstract convertToInformalTaxonGroup(group: T): InformalTaxonGroup;
-  abstract getTree(lang: string): Observable<PagedResult<T>>;
+  abstract getTree(lang: string): Observable<ArrayResult<T>>;
   abstract getOptions(query: Record<string, any>): string[][];
   abstract prepareEmit(includedOptions: string[], excludedOptions?: string[]): InformalGroupEvent;
 

--- a/projects/laji/src/app/shared-modules/extended-group-select/observation-extended-group-select.component.ts
+++ b/projects/laji/src/app/shared-modules/extended-group-select/observation-extended-group-select.component.ts
@@ -9,6 +9,7 @@ import { ExtendedGroupSelectComponent, InformalGroupEvent } from './extended-gro
 import { InformalTaxonGroup } from '../../shared/model/InformalTaxonGroup';
 import { PagedResult } from '../../shared/model/PagedResult';
 import { RedListTaxonGroup } from '../../shared/model/RedListTaxonGroup';
+import { ArrayResult } from '../../shared/model/ArrayResult';
 
 export const OBSERVATION_GROUP_SELECT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -39,14 +40,14 @@ export class ObservationExtendedGroupSelectComponent extends ExtendedGroupSelect
   }
 
   findByIds(groupIds: string[], lang: string): Observable<PagedResult<RedListTaxonGroup>> {
-    return this.informalTaxonService.informalTaxonGroupFind(lang, undefined, undefined, {idIn: groupIds});
+    return this.informalTaxonService.informalTaxonGroupFind(lang, undefined, undefined, groupIds);
   }
 
   convertToInformalTaxonGroup(group: InformalTaxonGroup): InformalTaxonGroup {
     return {...group};
   }
 
-  getTree(lang: string): Observable<PagedResult<InformalTaxonGroup>> {
+  getTree(lang: string): Observable<ArrayResult<InformalTaxonGroup>> {
     return this.informalTaxonService.informalTaxonGroupGetTree(lang);
   }
 

--- a/projects/laji/src/app/shared/api/InformalTaxonGroupApi.ts
+++ b/projects/laji/src/app/shared/api/InformalTaxonGroupApi.ts
@@ -46,7 +46,7 @@ export class InformalTaxonGroupApi {
    * @param pageSize Page size
    */
   public informalTaxonGroupFind(lang?: string, page?: string, pageSize?: string, idIn?: string[]): Observable<PagedResult<InformalTaxonGroup>> {
-    return this.http.get<PagedResult<InformalTaxonGroup>>(this.basePath, { params: Util.withNonNullableKeys({ lang, page, pageSize, idIn }) });
+    return this.http.get<PagedResult<InformalTaxonGroup>>(this.basePath, { params: Util.withNonNullableValues({ lang, page, pageSize, idIn }) });
   }
 
   /**
@@ -59,7 +59,7 @@ export class InformalTaxonGroupApi {
     if (!id.length) {
       throw new Error('Required parameter id was empty when calling informalTaxonGroupFindById.');
     }
-    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}`, {params:  Util.withNonNullableKeys({ lang })});
+    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}`, {params:  Util.withNonNullableValues({ lang })});
   }
 
   /**
@@ -70,7 +70,7 @@ export class InformalTaxonGroupApi {
    * @param pageSize Page size
    */
   public informalTaxonGroupFindRoots(lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
-    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/roots`, { params: Util.withNonNullableKeys({ lang }) });
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/roots`, { params: Util.withNonNullableValues({ lang }) });
   }
 
   /**
@@ -82,7 +82,7 @@ export class InformalTaxonGroupApi {
    * @param pageSize Page size
    */
   public informalTaxonGroupGetChildren(id: string, lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
-    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/children`, { params: Util.withNonNullableKeys({ lang }) } );
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/children`, { params: Util.withNonNullableValues({ lang }) } );
   }
 
   /**
@@ -92,7 +92,7 @@ export class InformalTaxonGroupApi {
    * @param lang Language of fields that have multiple languages. Return english if asked language not found.
    */
   public informalTaxonGroupGetParent(id: string, lang?: string): Observable<InformalTaxonGroup> {
-    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}/parent`, { params: Util.withNonNullableKeys({ lang })});
+    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}/parent`, { params: Util.withNonNullableValues({ lang })});
   }
 
   /**
@@ -103,7 +103,7 @@ export class InformalTaxonGroupApi {
    * @param pageSize Page size
    */
   public informalTaxonGroupGetTree(lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
-    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/tree`, { params: Util.withNonNullableKeys({ lang }) });
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/tree`, { params: Util.withNonNullableValues({ lang }) });
   }
 
   /**
@@ -115,6 +115,6 @@ export class InformalTaxonGroupApi {
    * @param pageSize Page size
    */
   public informalTaxonGroupGetWithSiblings(id: string, lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
-    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/siblings`, { params: Util.withNonNullableKeys({ lang }) });
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/siblings`, { params: Util.withNonNullableValues({ lang }) });
   }
 }

--- a/projects/laji/src/app/shared/api/InformalTaxonGroupApi.ts
+++ b/projects/laji/src/app/shared/api/InformalTaxonGroupApi.ts
@@ -29,13 +29,11 @@ import { HttpClient } from '@angular/common/http';
 import { Util } from '../service/util.service';
 import { InformalTaxonGroup } from '../model/InformalTaxonGroup';
 import { environment } from '../../../environments/environment';
-
-
-'use strict';
+import { ArrayResult } from '../model/ArrayResult';
 
 @Injectable({providedIn: 'root'})
 export class InformalTaxonGroupApi {
-  protected basePath = environment.apiBase;
+  protected basePath = `${environment.apiBase}/informal-taxon-groups`;
 
   constructor(protected http: HttpClient) {
   }
@@ -47,12 +45,8 @@ export class InformalTaxonGroupApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public informalTaxonGroupFind(lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups';
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
+  public informalTaxonGroupFind(lang?: string, page?: string, pageSize?: string, idIn?: string[]): Observable<PagedResult<InformalTaxonGroup>> {
+    return this.http.get<PagedResult<InformalTaxonGroup>>(this.basePath, { params: Util.withNonNullableKeys({ lang, page, pageSize, idIn }) });
   }
 
   /**
@@ -61,20 +55,11 @@ export class InformalTaxonGroupApi {
    * @param id
    * @param lang Language of fields that have multiple languages. Return english if asked language not found. If multi is selected fields will contain language objects
    */
-  public informalTaxonGroupFindById(id: string, lang?: string, extraHttpRequestParams?: any): Observable<InformalTaxonGroup> {
-    const path = this.basePath + '/informal-taxon-groups/{id}'
-        .replace('{' + 'id' + '}', String(id));
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-    // verify required parameter 'id' is not null or undefined
-    if (id === null || id === undefined) {
-      throw new Error('Required parameter id was null or undefined when calling informalTaxonGroupFindById.');
+  public informalTaxonGroupFindById(id: string, lang?: string): Observable<InformalTaxonGroup> {
+    if (!id.length) {
+      throw new Error('Required parameter id was empty when calling informalTaxonGroupFindById.');
     }
-    if (lang !== undefined) {
-      queryParameters['lang'] = lang;
-    }
-
-    return this.http.get<InformalTaxonGroup>(path, {params: queryParameters});
+    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}`, {params:  Util.withNonNullableKeys({ lang })});
   }
 
   /**
@@ -84,12 +69,8 @@ export class InformalTaxonGroupApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public informalTaxonGroupFindRoots(lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/roots';
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
+  public informalTaxonGroupFindRoots(lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/roots`, { params: Util.withNonNullableKeys({ lang }) });
   }
 
   /**
@@ -100,60 +81,18 @@ export class InformalTaxonGroupApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public informalTaxonGroupGetChildren(id: string, lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/{id}/children'
-        .replace('{' + 'id' + '}', String(id));
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-    // verify required parameter 'id' is not null or undefined
-    if (id === null || id === undefined) {
-      throw new Error('Required parameter id was null or undefined when calling informalTaxonGroupGetChildren.');
-    }
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
+  public informalTaxonGroupGetChildren(id: string, lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/children`, { params: Util.withNonNullableKeys({ lang }) } );
   }
 
   /**
-   * Get parents for a informal group
+   * Get parent for a informal group
    *
    * @param id
    * @param lang Language of fields that have multiple languages. Return english if asked language not found.
    */
-  public informalTaxonGroupGetParents(id: string, lang?: string, extraHttpRequestParams?: any): Observable<Array<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/{id}/parents'
-        .replace('{' + 'id' + '}', String(id));
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-    // verify required parameter 'id' is not null or undefined
-    if (id === null || id === undefined) {
-      throw new Error('Required parameter id was null or undefined when calling informalTaxonGroupGetChildren.');
-    }
-    if (lang !== undefined) {
-      queryParameters['lang'] = lang;
-    }
-
-    return this.http.get<InformalTaxonGroup[]>(path, {params: queryParameters});
-  }
-
-  /**
-   * Get current groups parents and parents siblings
-   *
-   * @param id
-   * @param lang Language of fields that have multiple languages. Return english if asked language not found.
-   * @param page Page number
-   * @param pageSize Page size
-   */
-  public informalTaxonGroupGetParentLevel(id: string, lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/{id}/parentLevel'
-        .replace('{' + 'id' + '}', String(id));
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-    // verify required parameter 'id' is not null or undefined
-    if (id === null || id === undefined) {
-      throw new Error('Required parameter id was null or undefined when calling informalTaxonGroupGetParentLevel.');
-    }
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
+  public informalTaxonGroupGetParent(id: string, lang?: string): Observable<InformalTaxonGroup> {
+    return this.http.get<InformalTaxonGroup>(`${this.basePath}/${id}/parent`, { params: Util.withNonNullableKeys({ lang })});
   }
 
   /**
@@ -163,11 +102,8 @@ export class InformalTaxonGroupApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public informalTaxonGroupGetTree(lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/tree';
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
+  public informalTaxonGroupGetTree(lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/tree`, { params: Util.withNonNullableKeys({ lang }) });
   }
 
   /**
@@ -178,32 +114,7 @@ export class InformalTaxonGroupApi {
    * @param page Page number
    * @param pageSize Page size
    */
-  public informalTaxonGroupGetWithSiblings(id: string, lang?: string, page?: string, pageSize?: string, extraHttpRequestParams?: any): Observable<PagedResult<InformalTaxonGroup>> {
-    const path = this.basePath + '/informal-taxon-groups/{id}/siblings'
-        .replace('{' + 'id' + '}', String(id));
-
-    const queryParameters = {...Util.removeFromObject(extraHttpRequestParams)};
-    // verify required parameter 'id' is not null or undefined
-    if (id === null || id === undefined) {
-      throw new Error('Required parameter id was null or undefined when calling informalTaxonGroupGetWithSiblings.');
-    }
-
-    return this.httpGet<InformalTaxonGroup>(path, queryParameters, lang, page, pageSize);
-  }
-
-  private httpGet<T>(path: string, queryParameters: any, lang?: string, page?: string, pageSize?: string) {
-    if (lang !== undefined) {
-      queryParameters['lang'] = lang;
-    }
-
-    if (page !== undefined) {
-      queryParameters['page'] = page;
-    }
-
-    if (pageSize !== undefined) {
-      queryParameters['pageSize'] = pageSize;
-    }
-
-    return this.http.get<PagedResult<T>>(path, { params: queryParameters });
+  public informalTaxonGroupGetWithSiblings(id: string, lang?: string): Observable<ArrayResult<InformalTaxonGroup>> {
+    return this.http.get<ArrayResult<InformalTaxonGroup>>(`${this.basePath}/${id}/siblings`, { params: Util.withNonNullableKeys({ lang }) });
   }
 }

--- a/projects/laji/src/app/shared/group-select/group-select.component.ts
+++ b/projects/laji/src/app/shared/group-select/group-select.component.ts
@@ -7,6 +7,7 @@ import { Logger } from '../logger/logger.service';
 import { TranslateService } from '@ngx-translate/core';
 import { Group } from '../model/Group';
 import { PagedResult } from '../model/PagedResult';
+import { ArrayResult } from '../model/ArrayResult';
 
 @Directive()
 export abstract class GroupSelectComponent<T extends Group> implements ControlValueAccessor, OnChanges {
@@ -152,7 +153,7 @@ export abstract class GroupSelectComponent<T extends Group> implements ControlVa
     }
   }
 
-  getRoot(lang: string): Observable<PagedResult<T>> {
+  getRoot(lang: string): Observable<ArrayResult<T>> {
     if (this.rootGroups) {
       return this.findByIds(this.rootGroups, lang);
     }
@@ -161,9 +162,9 @@ export abstract class GroupSelectComponent<T extends Group> implements ControlVa
 
   abstract findById(groupId: string, lang: string): Observable<T>;
   abstract findByIds(groupIds: string[], lang: any): Observable<PagedResult<T>>;
-  abstract getWithSiblings(groupId: any, lang: string): Observable<PagedResult<T>>;
-  abstract getChildren(groupId: any, lang: string): Observable<PagedResult<T>>;
-  abstract findRoots(lang: any): Observable<PagedResult<T>>;
+  abstract getWithSiblings(groupId: any, lang: string): Observable<ArrayResult<T>>;
+  abstract getChildren(groupId: any, lang: string): Observable<ArrayResult<T>>;
+  abstract findRoots(lang: any): Observable<ArrayResult<T>>;
   abstract convertToInformalTaxonGroup(group: T): InformalTaxonGroup;
 
   empty() {

--- a/projects/laji/src/app/shared/group-select/observation-group-select.component.ts
+++ b/projects/laji/src/app/shared/group-select/observation-group-select.component.ts
@@ -8,6 +8,7 @@ import { GroupSelectComponent } from './group-select.component';
 import { InformalTaxonGroup } from '../model/InformalTaxonGroup';
 import { PagedResult } from '../model/PagedResult';
 import { RedListTaxonGroup } from '../model/RedListTaxonGroup';
+import { ArrayResult } from '../model/ArrayResult';
 
 export const OBSERVATION_GROUP_SELECT_VALUE_ACCESSOR: any = {
   provide: NG_VALUE_ACCESSOR,
@@ -39,18 +40,19 @@ export class ObservationGroupSelectComponent extends GroupSelectComponent<Inform
   }
 
   findByIds(groupIds: string[], lang: string | undefined): Observable<PagedResult<RedListTaxonGroup>> {
-    return this.informalTaxonService.informalTaxonGroupFind(lang, undefined, undefined, {idIn: groupIds});
+    console.log(groupIds);
+    return this.informalTaxonService.informalTaxonGroupFind(lang, undefined, undefined, groupIds);
   }
 
-  getWithSiblings(groupId: string, lang: string | undefined): Observable<PagedResult<RedListTaxonGroup>> {
+  getWithSiblings(groupId: string, lang: string | undefined): Observable<ArrayResult<RedListTaxonGroup>> {
     return this.informalTaxonService.informalTaxonGroupGetWithSiblings(groupId, lang);
   }
 
-  getChildren(groupId: string, lang: string | undefined): Observable<PagedResult<RedListTaxonGroup>> {
+  getChildren(groupId: string, lang: string | undefined): Observable<ArrayResult<RedListTaxonGroup>> {
     return this.informalTaxonService.informalTaxonGroupGetChildren(groupId, lang);
   }
 
-  findRoots(lang: string | undefined): Observable<PagedResult<RedListTaxonGroup>> {
+  findRoots(lang: string | undefined): Observable<ArrayResult<RedListTaxonGroup>> {
     return this.informalTaxonService.informalTaxonGroupFindRoots(lang);
   }
 

--- a/projects/laji/src/app/shared/group-select/observation-group-select.component.ts
+++ b/projects/laji/src/app/shared/group-select/observation-group-select.component.ts
@@ -40,7 +40,6 @@ export class ObservationGroupSelectComponent extends GroupSelectComponent<Inform
   }
 
   findByIds(groupIds: string[], lang: string | undefined): Observable<PagedResult<RedListTaxonGroup>> {
-    console.log(groupIds);
     return this.informalTaxonService.informalTaxonGroupFind(lang, undefined, undefined, groupIds);
   }
 

--- a/projects/laji/src/app/shared/model/ArrayResult.ts
+++ b/projects/laji/src/app/shared/model/ArrayResult.ts
@@ -1,0 +1,4 @@
+
+export interface ArrayResult<T> {
+  results: T[];
+}

--- a/projects/laji/src/app/shared/service/util.service.ts
+++ b/projects/laji/src/app/shared/service/util.service.ts
@@ -71,7 +71,7 @@ export class Util {
   }
 
   /**
-   * Remove undefined values from object and any key specified by the key parameter
+   * Remove all undefined and null values from object
    *
    * @param obj object to remove keys from
    * @param keys array of keys that should be removed

--- a/projects/laji/src/app/shared/service/util.service.ts
+++ b/projects/laji/src/app/shared/service/util.service.ts
@@ -2,6 +2,10 @@ import { NavigationEnd, Event } from '@angular/router';
 import * as merge from 'deepmerge';
 import { Document } from '../model/Document';
 
+export type WithNonNullableKeys<T, K extends keyof T> = T & {
+  [P in K]-?: NonNullable<T[P]>;
+};
+
 export class Util {
   /**
    * Clones the object using JSON stringify
@@ -65,6 +69,22 @@ export class Util {
       return cumulative;
     }, {} as Partial<T>);
   }
+
+  /**
+   * Remove undefined values from object and any key specified by the key parameter
+   *
+   * @param obj object to remove keys from
+   * @param keys array of keys that should be removed
+   */
+  public static withNonNullableKeys<T extends {[prop: string]: any}, K extends keyof T>(obj: T): WithNonNullableKeys<T, K> {
+    return Object.keys(obj).reduce((cumulative, current: keyof T) => {
+      if (obj[current] !== undefined && obj[current] !== null) {
+        (cumulative as any)[current] = obj[current];
+      }
+      return cumulative;
+    }, {} as WithNonNullableKeys<T, K>);
+  }
+
 
   /**
    * Add leading zero so that the length of return string will be 2

--- a/projects/laji/src/app/shared/service/util.service.ts
+++ b/projects/laji/src/app/shared/service/util.service.ts
@@ -74,9 +74,8 @@ export class Util {
    * Remove all undefined and null values from object
    *
    * @param obj object to remove keys from
-   * @param keys array of keys that should be removed
    */
-  public static withNonNullableKeys<T extends {[prop: string]: any}, K extends keyof T>(obj: T): WithNonNullableKeys<T, K> {
+  public static withNonNullableValues<T extends {[prop: string]: any}, K extends keyof T>(obj: T): WithNonNullableKeys<T, K> {
     return Object.keys(obj).reduce((cumulative, current: keyof T) => {
       if (obj[current] !== undefined && obj[current] !== null) {
         (cumulative as any)[current] = obj[current];


### PR DESCRIPTION
* Use `informal-taxon-groups/:id/parent` instead of `informal-taxon-groups/:id/parents` (reasoning in
  https://github.com/luomus/laji-api/issues/51)
* Refactor informal taxon groups client
* Fix null pointer error in `informal-list-breadcrumb` (currently broken in https://beta.laji.fi/taxon/browse?informalGroupFilters=MVL.342 - open the console and there are errors spitted)

Closes #700
