### PR TITLE
Remove taxon author name capitalization

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.scss
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.scss
@@ -23,7 +23,6 @@
 
 .author {
   font-size: 1.2em;
-  text-transform: capitalize;
 }
 
 


### PR DESCRIPTION
Remove capitalization because it capitalizes words that should begin with lowercase, e.g. "ex".