### PR TITLE
Reduce ssr dw queries

### DIFF
--- a/projects/laji/src/app/+home/home.component.html
+++ b/projects/laji/src/app/+home/home.component.html
@@ -87,7 +87,7 @@
         <h3 class="width-0 d-inline" translate>{{ 'finbif-bib.title' | translate }}</h3>
         <laji-info>{{ 'finbif-bib.intro' | translate }}</laji-info>
       </div>
-      <div class="finBif-publications" innerHTML="{{ (publications$ | async)?.content }}"></div>
+      <div *lajiBrowserOnly class="finBif-publications" innerHTML="{{ (publications$ | async)?.content }}"></div>
       <a class="btn btn-default" [routerLink]="['/theme/publications'] | localize">
         {{ 'finbif-bib.seeAll' | translate }}
       </a>

--- a/projects/laji/src/app/graph-ql/graph-ql.module.ts
+++ b/projects/laji/src/app/graph-ql/graph-ql.module.ts
@@ -1,12 +1,12 @@
 import { Apollo, ApolloModule } from 'apollo-angular';
 import { HttpLink } from 'apollo-angular/http';
 import { InMemoryCache } from '@apollo/client/core';
-import { NgModule, TransferState } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { AcceptLanguageInterceptor } from './accept-language.interceptor';
 import { TranslateService } from '@ngx-translate/core';
-import { concatMap, tap } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { GraphQLService } from './service/graph-ql.service';
 import { PlatformService } from '../root/platform.service';
@@ -24,7 +24,6 @@ import { PlatformService } from '../root/platform.service';
 })
 export class GraphQLModule {
   private readonly cache: InMemoryCache;
-  private currentLang?: string;
 
   constructor(
     private apollo: Apollo,
@@ -37,9 +36,6 @@ export class GraphQLModule {
     });
 
     translateService.onLangChange.pipe(
-      tap(langChange => {
-        this.currentLang = langChange.lang;
-      }),
       concatMap(() => from(this.cache.reset()))
     ).subscribe(() => {}, (e) => console.error(e));
 

--- a/projects/laji/src/app/graph-ql/graph-ql.module.ts
+++ b/projects/laji/src/app/graph-ql/graph-ql.module.ts
@@ -1,17 +1,15 @@
 import { Apollo, ApolloModule } from 'apollo-angular';
-import {HttpLink} from 'apollo-angular/http';
-import {InMemoryCache, NormalizedCacheObject} from '@apollo/client/core';
-import { NgModule,  makeStateKey, TransferState } from '@angular/core';
+import { HttpLink } from 'apollo-angular/http';
+import { InMemoryCache } from '@apollo/client/core';
+import { NgModule, TransferState } from '@angular/core';
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 import { AcceptLanguageInterceptor } from './accept-language.interceptor';
 import { TranslateService } from '@ngx-translate/core';
-import { concatMap, filter } from 'rxjs/operators';
+import { concatMap, tap } from 'rxjs/operators';
 import { from } from 'rxjs';
 import { GraphQLService } from './service/graph-ql.service';
 import { PlatformService } from '../root/platform.service';
-
-const GRAPH_QL_STATE_KEY = makeStateKey<any>('graphql.state');
 
 @NgModule({
   declarations: [],
@@ -32,7 +30,6 @@ export class GraphQLModule {
     private apollo: Apollo,
     private httpLink: HttpLink,
     private translateService: TranslateService,
-    private transferState: TransferState,
     private platformService: PlatformService
   ) {
     this.cache = new InMemoryCache({
@@ -40,13 +37,8 @@ export class GraphQLModule {
     });
 
     translateService.onLangChange.pipe(
-      filter(langChange => {
-        // Dont reset the cache on first change since we might have carried the state from the server to browser!
-        if (this.currentLang === undefined) {
-          this.currentLang = langChange.lang;
-          return false;
-        }
-        return true;
+      tap(langChange => {
+        this.currentLang = langChange.lang;
       }),
       concatMap(() => from(this.cache.reset()))
     ).subscribe(() => {}, (e) => console.error(e));
@@ -56,26 +48,7 @@ export class GraphQLModule {
         uri: `${environment.apiBase}/graphql`
       }),
       cache: this.cache,
-      ...(this.platformService.isBrowser ? { ssrForceFetchDelay: 5000 } : { ssrMode: true })
+      ...(this.platformService.isBrowser ? {} : { ssrMode: true })
     });
-
-    if (this.platformService.isBrowser) {
-      this.onBrowser();
-    } else {
-      this.onServer();
-    }
-  }
-
-  private onBrowser() {
-    const state = this.transferState.get<NormalizedCacheObject>(
-      GRAPH_QL_STATE_KEY,
-      null as any,
-    );
-    this.cache.restore(state);
-    this.transferState.remove(GRAPH_QL_STATE_KEY);
-  }
-
-  private onServer() {
-    this.transferState.onSerialize(GRAPH_QL_STATE_KEY, () => this.cache.extract());
   }
 }

--- a/projects/laji/src/app/graph-ql/service/base-data.service.ts
+++ b/projects/laji/src/app/graph-ql/service/base-data.service.ts
@@ -85,7 +85,7 @@ const BASE_QUERY = gql`
 })
 export class BaseDataService {
 
-  private readonly query: QueryRef<IBaseData>;
+  private readonly query: QueryRef<IBaseData>|undefined;
   private readonly baseDataSub = new ReplaySubject<IBaseData>(1);
   private readonly baseData$ = this.baseDataSub.asObservable();
   private readonly labelMapSub = new ReplaySubject<Record<string, string>>(1);
@@ -103,9 +103,9 @@ export class BaseDataService {
 
     this.translationService.onLangChange.pipe(
       map(() => this.baseDataSub.next(undefined))
-    ).subscribe(() => this.query.refetch().then());
+    ).subscribe(() => this.query?.refetch().then());
 
-    this.query.valueChanges.pipe(
+    this.query?.valueChanges.pipe(
       map(({data}) => data)
     ).subscribe(data => this.baseDataSub.next(data));
 

--- a/projects/laji/src/app/graph-ql/service/graph-ql.service.ts
+++ b/projects/laji/src/app/graph-ql/service/graph-ql.service.ts
@@ -2,21 +2,28 @@ import { Apollo, QueryRef } from 'apollo-angular';
 import { ApolloQueryResult, OperationVariables, QueryOptions } from '@apollo/client/core';
 import { Injectable } from '@angular/core';
 import { EmptyObject, WatchQueryOptions } from 'apollo-angular/types';
-import { Observable } from 'rxjs';
+import { EMPTY, Observable } from 'rxjs';
+import { PlatformService } from '../../root/platform.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class GraphQLService {
 
-  constructor(private apollo: Apollo) { }
+  constructor(private apollo: Apollo, private platformService: PlatformService) { }
 
   query<T, V = EmptyObject>(options: QueryOptions<V>): Observable<ApolloQueryResult<T>> {
+    if (this.platformService.isServer) {
+      return EMPTY;
+    }
     return this.apollo.query<T, V>(options);
   }
 
 
-  watchQuery<TData, TVariables extends OperationVariables = EmptyObject>(options: WatchQueryOptions<TVariables, TData>): QueryRef<TData, TVariables> {
+  watchQuery<TData, TVariables extends OperationVariables = EmptyObject>(options: WatchQueryOptions<TVariables, TData>): QueryRef<TData, TVariables>|undefined {
+    if (this.platformService.isServer) {
+      return undefined;
+    }
     return this.apollo.watchQuery<TData, TVariables>(options);
   }
 

--- a/projects/laji/src/app/shared/api/WarehouseApi.ts
+++ b/projects/laji/src/app/shared/api/WarehouseApi.ts
@@ -508,6 +508,9 @@ export class WarehouseApi {
   }
 
   public getPolygonFeatureCollection(polygonId: string) {
+    if (this.platformService.isServer) {
+      return EMPTY;
+    }
     const path = this.basePath + '/warehouse/polygon/' + polygonId;
     const queryParameters = {format: 'geojson', crs: 'WGS84'};
     return this.http.get(path, {params: queryParameters});


### PR DESCRIPTION
#714

Reduces the number of queries in ssr to data warehouse by
- removing all graphql queries in the server
- removing all queries to `warehouse` endpoint in the server (most were already removed)
- hides the publications section in the front page in the server