### PR TITLE
Apply links to browse taxon -page [closes #696]

### DIFF
--- a/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.html
@@ -4,7 +4,6 @@
     <div class="col-sm-12">
       <laji-informal-group-select
         [id]="searchQuery.query.informalGroupFilters"
-        (informalGroupSelect)="informalGroupChange($event)"
       ></laji-informal-group-select>
     </div>
   </div>

--- a/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/browse-species.component.ts
@@ -14,6 +14,7 @@ export class BrowseSpeciesComponent implements OnInit, OnDestroy {
   loadedTabs = new LoadedElementsStore(['images', 'list']);
 
   private subQueryUpdate?: Subscription;
+  private queryParamsSubscription?: Subscription;
 
   constructor(
     public searchQuery: TaxonomySearchQuery,
@@ -24,17 +25,20 @@ export class BrowseSpeciesComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.loadedTabs.load(this.activeIndex);
     this.searchQuery.setQueryFromParams({...this.route.snapshot.queryParams, onlyFinnish: 'true'});
+
+    this.queryParamsSubscription = this.route.queryParams.subscribe(params => {
+      this.searchQuery.query.informalGroupFilters = params.informalGroupFilters;
+      this.searchQuery.updateUrl(['onlyFinnish']);
+    });
   }
 
   ngOnDestroy() {
     if (this.subQueryUpdate) {
       this.subQueryUpdate.unsubscribe();
     }
-  }
-
-  informalGroupChange(id: string) {
-    this.searchQuery.query.informalGroupFilters = id;
-    this.searchQuery.updateUrl(['onlyFinnish']);
+    if (this.queryParamsSubscription) {
+      this.queryParamsSubscription.unsubscribe();
+    }
   }
 
   @HostListener('window:popstate')

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.html
@@ -1,11 +1,9 @@
 <laji-spinner [spinning]="!selectedInformalGroup && !informalGroups">
   <laji-informal-list-breadcrumb *ngIf="showBreadcrumb"
                                  [informalGroup]="selectedInformalGroup"
-                                 [parentGroup]="parentGroup"
-                                 (informalGroupSelect)="informalGroupSelect.emit($event)">
+                                 [parentGroup]="parentGroup">
   </laji-informal-list-breadcrumb>
   <laji-informal-list [informalTaxonGroups]="informalGroups"
-                      [showAll]="showAll"
-                      (informalGroupSelect)="informalGroupSelect.emit($event)">
+                      [showAll]="showAll">
   </laji-informal-list>
 </laji-spinner>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-group-select.component.ts
@@ -13,7 +13,6 @@ export class InformalGroupSelectComponent implements OnInit, OnDestroy, OnChange
   @Input() id?: string;
   @Input() showBreadcrumb = true;
   @Input() showAll = false;
-  @Output() informalGroupSelect = new EventEmitter<string>();
 
   public selectedInformalGroup: InformalTaxonGroup | undefined;
   public informalGroups: InformalTaxonGroup[] = [];

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
@@ -1,9 +1,11 @@
 <ol class="breadcrumb" *ngIf="informalGroup && informalGroup.id">
   <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-    <a (click)="informalGroupSelect.emit()" tabindex="0" role="button" luKeyboardClickable>{{ 'observation.active.informalTaxonGroupAll' | translate }}</a>
+    <a [routerLink]="'/taxon/browse'" (click)="informalGroupSelect.emit()"
+      tabindex="0" role="button" luKeyboardClickable>{{ 'observation.active.informalTaxonGroupAll' | translate }}</a>
   </li>
   <li *ngIf="parentGroup">
-    <a (click)="informalGroupSelect.emit(parentGroup.id)" tabindex="0" role="button" luKeyboardClickable>{{ parentGroup.name }}</a>
+    <a [routerLink]="'/taxon/browse'" [queryParams]="{ informalGroupFilters: parentGroup.id }" (click)="informalGroupSelect.emit(parentGroup.id)"
+      tabindex="0" role="button" luKeyboardClickable>{{ parentGroup.name }}</a>
   </li>
   <li *ngIf="informalGroup" class="active">
     <span>{{ informalGroup.name }}</span>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.html
@@ -1,10 +1,10 @@
 <ol class="breadcrumb" *ngIf="informalGroup && informalGroup.id">
   <li routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-    <a [routerLink]="'/taxon/browse'" (click)="informalGroupSelect.emit()"
+    <a [routerLink]="'/taxon/browse'"
       tabindex="0" role="button" luKeyboardClickable>{{ 'observation.active.informalTaxonGroupAll' | translate }}</a>
   </li>
   <li *ngIf="parentGroup">
-    <a [routerLink]="'/taxon/browse'" [queryParams]="{ informalGroupFilters: parentGroup.id }" (click)="informalGroupSelect.emit(parentGroup.id)"
+    <a [routerLink]="'/taxon/browse'" [queryParams]="{ informalGroupFilters: parentGroup.id }"
       tabindex="0" role="button" luKeyboardClickable>{{ parentGroup.name }}</a>
   </li>
   <li *ngIf="informalGroup" class="active">

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list-breadcrumb/informal-list-breadcrumb.component.ts
@@ -10,5 +10,4 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 export class InformalListBreadcrumbComponent {
   @Input() informalGroup?: InformalTaxonGroup;
   @Input() parentGroup?: InformalTaxonGroup;
-  @Output() informalGroupSelect = new EventEmitter<string>();
 }

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
@@ -1,6 +1,6 @@
 <div class="d-flex flex-wrap">
   <a *ngFor="let group of informalTaxonGroups" [routerLink]="'/taxon/browse'" [queryParams]="{ informalGroupFilters: group.id }"
-    (click)="informalGroupSelect.emit(group.id)" class="group d-flex flex-nowrap items-center mr-3 mb-3"
+    class="group d-flex flex-nowrap items-center mr-3 mb-3"
     tabindex="0" role="button" luKeyboardClickable>
     <img class="group-image" [src]="'https://cdn.laji.fi/images/informalGroups/' + group.id + '.svg'" (error)="onImgError($event)" alt="">
     <div class="group-name">{{ group.name }}</div>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.html
@@ -1,5 +1,7 @@
 <div class="d-flex flex-wrap">
-  <a *ngFor="let group of informalTaxonGroups" (click)="informalGroupSelect.emit(group.id)" class="group d-flex flex-nowrap items-center mr-3 mb-3" tabindex="0" role="button" luKeyboardClickable>
+  <a *ngFor="let group of informalTaxonGroups" [routerLink]="'/taxon/browse'" [queryParams]="{ informalGroupFilters: group.id }"
+    (click)="informalGroupSelect.emit(group.id)" class="group d-flex flex-nowrap items-center mr-3 mb-3"
+    tabindex="0" role="button" luKeyboardClickable>
     <img class="group-image" [src]="'https://cdn.laji.fi/images/informalGroups/' + group.id + '.svg'" (error)="onImgError($event)" alt="">
     <div class="group-name">{{ group.name }}</div>
   </a>

--- a/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.ts
+++ b/projects/laji/src/app/+taxonomy/browse-species/informal-group-select/informal-list/informal-list.component.ts
@@ -10,7 +10,6 @@ import { InformalTaxonGroup } from '../../../../shared/model/InformalTaxonGroup'
 export class InformalListComponent {
   @Input() informalTaxonGroups!: InformalTaxonGroup[];
   @Input() showAll = false;
-  @Output() informalGroupSelect = new EventEmitter<string>();
 
   constructor(private renderer: Renderer2) {}
 

--- a/projects/laji/src/app/+taxonomy/species/service/taxonomy-columns.ts
+++ b/projects/laji/src/app/+taxonomy/species/service/taxonomy-columns.ts
@@ -25,7 +25,7 @@ export class TaxonomyColumns {
       name: 'scientificName',
       selectField: 'scientificName,cursiveName',
       label: 'taxonomy.scientific.name',
-      cellTemplate: 'taxonScientificName',
+      cellTemplate: 'taxonScientificNameLink',
       width: 200
     },
     {

--- a/projects/laji/src/app/+taxonomy/species/species-list/species-list.component.ts
+++ b/projects/laji/src/app/+taxonomy/species/species-list/species-list.component.ts
@@ -172,11 +172,6 @@ export class SpeciesListComponent implements OnInit, OnChanges, OnDestroy {
           }
 
           this.speciesPage = data;
-          this.speciesPage.results.map(r => {
-            if (r['id']) {
-              r['id'] = this.fullUri.transform(r['id']);
-            }
-          });
           this.loading = false;
           this.datatable?.refreshTable();
           this.cd.markForCheck();

--- a/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
+++ b/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
@@ -145,7 +145,8 @@
   </span>
 </ng-template>
 <ng-template let-row="row" #taxonScientificNameLink>
-  <a *ngIf="row.scientificName" title="{{row.scientificName}}" [routerLink]="['/taxon/' + row.id] | localize">
+  <a *ngIf="row.scientificName" title="{{row.scientificName}}"
+    [routerLink]="['/taxon/' + (row.id.includes('http') ? row.id.split('/').pop() : row.id)] | localize">
     <span [class.cursive]="row.cursiveName">{{ row.scientificName }}</span>
   </a>
 </ng-template>

--- a/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
+++ b/projects/laji/src/app/shared-modules/datatable/datatable-templates/datatable-templates.component.html
@@ -145,8 +145,7 @@
   </span>
 </ng-template>
 <ng-template let-row="row" #taxonScientificNameLink>
-  <a *ngIf="row.scientificName" title="{{row.scientificName}}"
-    [routerLink]="['/taxon/' + (row.id.includes('http') ? row.id.split('/').pop() : row.id)] | localize">
+  <a *ngIf="row.scientificName" title="{{row.scientificName}}" [routerLink]="['/taxon/' + row.id] | localize">
     <span [class.cursive]="row.cursiveName">{{ row.scientificName }}</span>
   </a>
 </ng-template>


### PR DESCRIPTION
https://696.dev.laji.fi/taxon/browse?informalGroupFilters=MVL.343
https://github.com/luomus/laji/issues/696

Three changes:

1. Made the "informal-list-breadcrumb" links (the path Kaikki / Putkilokasvit... etc.) clickable with right mouse button so that they can be opened to a new tab. This can be done by adding [routerLink], and taxon id as [queryParams].
2. Made the "informal-list" buttons clickable with the same method.
3. Used cell-template 'taxonScientificNameLink' for the list's scientificName column and changed the cell-template to check whether row.id is a link or id, and form the [routerLink] accordingly. It should therefore work with taxa and subordinate taxa.