### PR TITLE
Fix incorrect end date interpretation on observation search

### DIFF
--- a/projects/laji/src/app/+observation/form/date-form/date-form.component.html
+++ b/projects/laji/src/app/+observation/form/date-form/date-form.component.html
@@ -49,7 +49,7 @@
     </div>
     <laji-datepicker [(ngModel)]="firstLoadedSameOrAfter"></laji-datepicker>
 
-    <laji-datepicker [(ngModel)]="firstLoadedSameOrBefore"></laji-datepicker>
+    <laji-datepicker [(ngModel)]="firstLoadedSameOrBefore" [toLastOfYear]="true"></laji-datepicker>
 
     <div class="btn-group btn-group-xs mt-1">
       <button type="button" class="btn btn-default" (click)="onUpdateTime(1, 'firstLoadedSameOrAfter', 'firstLoadedSameOrBefore')">{{ 'observations.form.1d' | translate }}</button>


### PR DESCRIPTION
#706
https://706.dev.laji.fi/observation/list

Fix just adds a missing parameter to datepicker which sets it to last day of the year.