### PR TITLE
Fix community verified tag cannot be removed with annotation

### DIFF
--- a/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.html
+++ b/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.html
@@ -97,7 +97,7 @@
          <label>{{ 'annotation.removeTags' | translate }}</label>
          <div *ngFor="let item of annotationRemovableTags$ | async " class="list-checkbox">
            <main class="lu">
-               <lu-checkbox (input)="addToRemoveTags(item.id)" [disabled]="((annotation.addedTags.indexOf('MMAN.5') !== -1 || annotation.addedTags.indexOf('MMAN.3') !== -1))" [checked]="annotation.removedTags.indexOf(item.id) !== -1">
+               <lu-checkbox (input)="addToRemoveTags(item.id)" [disabled]="((annotation.addedTags.indexOf('MMAN.5') !== -1 && item.id !== 'MMAN.52') || annotation.addedTags.indexOf('MMAN.3') !== -1)" [checked]="annotation.removedTags.indexOf(item.id) !== -1">
                  <div class="pill" [ngClass]="{'success': item.quality==='positive', 'warning': item.quality==='check', 'danger': item.quality==='negative' }">{{ item.id | toQName | label }}</div>
                </lu-checkbox>
             </main>

--- a/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
+++ b/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
@@ -450,7 +450,7 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
           const tagId = tag.id as string;
           if (tagId !== value.id) {
             if ((tagId === 'MMAN.5' || tagId === 'MMAN.8' || tagId === 'MMAN.9' || tagId === 'MMAN.3'
-            || tagId === 'MMAN.50' || tagId === 'MMAN.51')
+            || tagId === 'MMAN.50' || tagId === 'MMAN.51' || tagId === 'MMAN.52')
             && this.annotationTagsObservation[value.id].type !== 'check' && this.annotationTagsObservation[value.id].type !== 'info'
             && this.annotation.removedTags.indexOf(tagId) === -1 && this.annotation.addedTags.indexOf(tagId) === -1) {
               this.addToRemoveTags(tagId);
@@ -469,8 +469,6 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
               this.addToRemoveTags(tagId);
             }
           });
-        } else {
-
         }
 
         if (this.annotation.removedTags.indexOf(value.id) !== -1 &&

--- a/projects/laji/src/environments/global.ts
+++ b/projects/laji/src/environments/global.ts
@@ -219,11 +219,11 @@ export const Global = { // eslint-disable-line @typescript-eslint/naming-convent
       quality: 'MMAN.typeCheck',
       type: 'check'
     },
-    /*'MMAN.52': {
+    'MMAN.52': {
       value: 'MMAN.52',
       quality: 'MMAN.typePositiveQuality',
       type: 'admin'
-    }*/
+    }
   },
   limit: {
     simpleDownload: 10000


### PR DESCRIPTION
#616
https://616.dev.laji.fi/observation/list?sourceId=KE.901&recordQuality=COMMUNITY_VERIFIED

Community verified tag could not be removed with annotations, fixed by enabling an commented out section of code and adding community verified tag to trigger the allowed tag removal clauses.