### PR TITLE
Fix taxon page showing incorrect text source

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.component.ts
@@ -139,8 +139,15 @@ export class TaxonIdentificationComponent implements OnChanges, AfterViewInit, O
 
   ngOnChanges(changes: SimpleChanges) {
     if (changes.taxon) {
+      this.resetDescriptionFields();
       this.taxonChange$.next();
     }
+  }
+
+  resetDescriptionFields() {
+    this.data.descriptionSources = [];
+    this.data.speciesCardAuthors = [];
+    this.data.speciesCardAuthorsTitle = undefined;
   }
 
   ngOnDestroy() {

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
@@ -88,9 +88,8 @@ export class TaxonIdentificationFacade implements OnDestroy {
         parentTaxonId: id,
         taxonRanks: rank,
         sortOrder: 'observationCountFinland DESC',
-        selectedFields: 'id,vernacularName,scientificName,cursiveName,taxonRank,hasChildren,countOfSpecies,observationCountFinland',
+        selectedFields: 'id,vernacularName,scientificName,cursiveName,taxonRank,hasChildren,countOfSpecies,observationCountFinland,descriptions',
         includeMedia: true,
-        includeDescriptions: true
       }
     ).pipe(
       switchMap(res => {


### PR DESCRIPTION
#738
https://738.dev.laji.fi/taxon/MX.51278/identification

Added cleanup function to onChange event handler to clear taxon description and author data which might contain old data when taxon changes to one which doesn't contain data to overwrite it with. 