### PR TITLE
Fix document viewer for unknown form

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
@@ -34,6 +34,7 @@ import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-doc
 import { HistoryService } from '../../../shared/service/history.service';
 import { DocumentPermissionService } from '../service/document-permission.service';
 import { FormService } from '../../../shared/service/form.service';
+import { Form } from '../../../shared/model/Form';
 
 @Component({
   selector: 'laji-document',
@@ -180,17 +181,17 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
       switchMap(doc => this.documentPermissionService.getRightsToWarehouseDocument(doc).pipe(
         map(rights => ({doc, rights})),
       )),
-      switchMap(doc => doc.doc.formId
-        ? this.formService.getFormInListFormat(IdService.getId(doc.doc.formId)).pipe(
-          map(form => {
-            if (!!form.options?.secondaryCopy) {
-              doc.rights.hasEditRights = false;
-              doc.rights.hasDeleteRights = false;
+      switchMap(({doc, rights}) => doc.formId
+        ? this.formService.getFormInListFormat(IdService.getId(doc.formId)).pipe(
+          map((form: Form.List | undefined) => {
+            if (!form || !!form.options?.secondaryCopy) {
+              rights.hasEditRights = false;
+              rights.hasDeleteRights = false;
             }
-            return doc;
+            return {doc, rights};
           })
         )
-        : of(doc)
+        : of({doc, rights})
       )
     );
 


### PR DESCRIPTION
Fixes the document viewer when a document has formId that doesn't exist.

Repro:

https://beta.laji.fi/observation/list?collectionId=HR.128&collectionIdNot=HR.173,HR.447,HR.160,HR.129,HR.48,HR.203,HR.93

Click some of the observation table rows to show the viewer. It says not loaded to warehouse, while you can see from the
network tab that it's loaded.
