### PR TITLE
Show create named place -button for admins [Fixes #804]

### DIFF
--- a/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
+++ b/projects/laji/src/app/+project-form/form/named-place/named-place/named-place.component.ts
@@ -187,7 +187,7 @@ export class NamedPlaceComponent implements OnInit, OnDestroy {
           tags,
           activeNP,
           description: documentForm.options?.namedPlaceOptions?.chooseDescription ?? 'np.defaultDescription',
-          allowEdit: (documentForm?.options?.namedPlaceOptions?.allowAddingPublic || formRights.admin) && !this.readonly,
+          allowEdit: (documentForm?.options?.namedPlaceOptions?.allowAddingPublic || formRights.admin || formRights.ictAdmin) && !this.readonly,
           mapOptionsData: NamedPlaceComponent.getMapOptions(documentForm),
           showMap: !documentForm.options?.namedPlaceOptions?.hideMapTab
         }

--- a/projects/laji/src/app/shared/service/form-permission.service.ts
+++ b/projects/laji/src/app/shared/service/form-permission.service.ts
@@ -130,20 +130,14 @@ export class FormPermissionService {
         }
         return this.userService.user$.pipe(
           take(1),
-          switchMap(person => {
-            if (form.options?.restrictAccess || form.options?.hasAdmins) {
-              return this.getFormPermission(collectionID, this.userService.getToken()).pipe(
-                catchError(() => of({
-                  collectionID,
-                  admins: [],
-                  editors: []
-                } as unknown as FormPermission)),
-                map((formPermission: FormPermission) => ({person, formPermission}))
-              );
-            } else {
-              return of({person, formPermission: { collectionID, admins: [], editors: [] } as unknown as FormPermission});
-            }
-          }),
+          switchMap(person => this.getFormPermission(collectionID, this.userService.getToken()).pipe(
+            catchError(() => of({
+              collectionID,
+              admins: [],
+              editors: []
+            } as unknown as FormPermission)),
+            map((formPermission: FormPermission) => ({person, formPermission}))
+          )),
           switchMap(({person, formPermission}) => person ? of({
             view: this.isEditAllowed(formPermission, person, form) || form.options?.restrictAccess === RestrictAccess.restrictAccessLoose,
             edit: this.isEditAllowed(formPermission, person, form),


### PR DESCRIPTION
Button for creating named places wasn't showing on forms like MHL.27 (ei-vakiolinjat) because it doesn't have hasAdmins. Now formPermissions are fetched even when collection doesn't have hasAdmins, and now the button is showing for users who have MHL.1 (linjalaskennat) admin rights.