### PR TITLE
Fix broken dna barcode link 809

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.html
@@ -73,7 +73,7 @@
     <li *ngFor="let export of taxon.taxonExpert">{{ export | users:'fullName' }}</li>
   </ul>
 </laji-taxon-info-row>
-<laji-taxon-info-row [label]="'taxonomy.bold' | translate" [keyTextContentGhost]="false">
+<laji-taxon-info-row [label]="'taxonomy.bold' | translate" *ngIf="taxon.hasBold">
    <laji-taxon-bold [taxon]="taxon"></laji-taxon-bold>
 </laji-taxon-info-row>
 <laji-taxon-info-row *ngIf="taxon.informalTaxonGroups && taxon.informalTaxonGroups.length > 0" [label]="'taxonomy.informalTaxonGroups' | translate">

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-overview/taxon-info/taxon-info.component.html
@@ -73,7 +73,7 @@
     <li *ngFor="let export of taxon.taxonExpert">{{ export | users:'fullName' }}</li>
   </ul>
 </laji-taxon-info-row>
-<laji-taxon-info-row [label]="'taxonomy.bold' | translate">
+<laji-taxon-info-row [label]="'taxonomy.bold' | translate" [keyTextContentGhost]="false">
    <laji-taxon-bold [taxon]="taxon"></laji-taxon-bold>
 </laji-taxon-info-row>
 <laji-taxon-info-row *ngIf="taxon.informalTaxonGroups && taxon.informalTaxonGroups.length > 0" [label]="'taxonomy.informalTaxonGroups' | translate">


### PR DESCRIPTION
Removes the grey placeholder block from DNA-barcode section if none exists.

Test branch here https://809.dev.laji.fi/, task #809 