### PR TITLE
Autocomplete against api v1

### DIFF
--- a/projects/laji-api-client-b/src/laji-api-client-b.service.ts
+++ b/projects/laji-api-client-b/src/laji-api-client-b.service.ts
@@ -125,7 +125,16 @@ export class LajiApiClientBService {
   }
 
   private getRequestOptions(queryParams: any, requestBody: any, lang: string) {
-    return { params: queryParams, body: requestBody, headers: {
+    return {
+      params: Object.keys((queryParams || {})).reduce((filteredQueryParams, key) => {
+        const param = (queryParams || {})[key];
+        if (param === undefined) {
+          return filteredQueryParams;
+        }
+        filteredQueryParams[key] = queryParams[key];
+        return filteredQueryParams;
+      }, {} as any),
+      body: requestBody, headers: {
 			'API-Version': '1',
 			'Accept-Language': lang
 		} };

--- a/projects/laji/src/app/+theme/sound-identification/sound-identification-table/sound-identification-table.component.html
+++ b/projects/laji/src/app/+theme/sound-identification/sound-identification-table/sound-identification-table.component.html
@@ -12,14 +12,14 @@
 
   <ng-template let-row="row" #clipSpan>
     <span>
-      {{row.start_time + "-" + row.end_time + "s"}} 
+      {{row.start_time + "-" + row.end_time + "s"}}
     </span>
   </ng-template>
 
   <ng-template let-row="row" #vernacularName>
-    <ng-container *ngIf="(getVernacularName(row.scientific_name) | async | multiLang); let vernacularName; else spinner">
+    <ng-container *ngIf="(getVernacularName(row.scientific_name) | async); let vernacularName; else spinner">
       <span>
-        {{vernacularName}} 
+        {{vernacularName}}
       </span>
     </ng-container>
   </ng-template>

--- a/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
+++ b/projects/laji/src/app/shared-modules/annotations/annotation-form-new/annotation-form-new.component.ts
@@ -8,7 +8,6 @@ import { AnnotationService } from '../../document-viewer/service/annotation.serv
 import { Observable, Subscription } from 'rxjs';
 import { Logger } from '../../../shared/logger/logger.service';
 import { TranslateService } from '@ngx-translate/core';
-import { LajiApi, LajiApiService } from '../../../shared/service/laji-api.service';
 import { AnnotationTag } from '../../../shared/model/AnnotationTag';
 import { Global } from '../../../../environments/global';
 import { IdService } from '../../../shared/service/id.service';
@@ -110,7 +109,6 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
   constructor(
     private annotationService: AnnotationService,
     private loggerService: Logger,
-    private lajiApi: LajiApiService,
     private api: LajiApiClientBService,
     private translate: TranslateService,
     private cd: ChangeDetectorRef,
@@ -136,18 +134,17 @@ export class AnnotationFormNewComponent implements OnInit , OnChanges, AfterCont
     this.cd.detectChanges();
   }
 
-  public getTaxa(token: string): Observable<any> {
-    return this.lajiApi.get(LajiApi.Endpoints.autocomplete, 'taxon', {
-      q: token,
-      limit: '10',
-      includePayload: true
-    }).pipe(
-      map(data => data.map((item: any) => {
+  public getTaxa(query: string) {
+    return this.api.get('/autocomplete/taxa', { query: {
+      query,
+      limit: 10
+    }}).pipe(
+      map(data => data.results.map(item => {
         let groups = '';
-        if (item.payload && item.payload.informalTaxonGroups) {
-          groups = item.payload.informalTaxonGroups.reduce((prev: string, curr: InformalTaxonGroup) => prev + ' ' + curr.id, groups);
+        if (item.informalGroups) {
+          groups = item.informalGroups.reduce((prev: string, curr: InformalTaxonGroup) => prev + ' ' + curr.id, groups);
         }
-        item['groups'] = groups;
+        (item as any)['groups'] = groups;
         return item;
       })));
   }

--- a/projects/laji/src/app/shared-modules/find-person/find-person.component.ts
+++ b/projects/laji/src/app/shared-modules/find-person/find-person.component.ts
@@ -1,8 +1,8 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { Person } from '../../shared/model/Person';
-import { LajiApi, LajiApiService } from '../../shared/service/laji-api.service';
-import { mergeMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 @Component({
   selector: 'laji-find-person',
@@ -20,7 +20,9 @@ export class FindPersonComponent implements OnInit {
   typeaheadLoading = false;
   value = '';
 
-  constructor(private lajiApi: LajiApiService) { }
+  constructor(
+    private api: LajiApiClientBService
+  ) { }
 
   ngOnInit() {
     this.dataSource = Observable.create((observer: any) => {
@@ -31,10 +33,8 @@ export class FindPersonComponent implements OnInit {
   }
 
   public getPerson(token: string): Observable<any> {
-    return this.lajiApi.get(LajiApi.Endpoints.autocomplete, 'person', {
-        q: token,
-        limit: '' + this.limit
-      });
+    return this.api.get('/autocomplete/persons', { query: { query: token, pageSize: this.limit } })
+    .pipe(map(({ results }) => results));
   }
 
   personSelected(event: any) {

--- a/projects/laji/src/app/shared-modules/spreadsheet/importer/cell-value-mapping/special-friend/special-friend.component.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/importer/cell-value-mapping/special-friend/special-friend.component.ts
@@ -41,6 +41,9 @@ export class SpecialFriendComponent implements OnInit {
     this.friendsService.allFriends()
       .subscribe((friends) => {
         friends.forEach(friend => {
+          if (!friend.value) {
+            return;
+          }
           validValues.push(friend.value);
           validIds.push(friend.key);
         });

--- a/projects/laji/src/app/shared-modules/taxon-select/taxon-select.component.ts
+++ b/projects/laji/src/app/shared-modules/taxon-select/taxon-select.component.ts
@@ -1,11 +1,10 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component,
 EventEmitter, Input, Output, ViewChild, OnInit, OnDestroy } from '@angular/core';
 import { Observable, of as ObservableOf, Subscription } from 'rxjs';
-import { distinctUntilChanged, switchMap, take } from 'rxjs/operators';
-import { TranslateService } from '@ngx-translate/core';
-import { LajiApi, LajiApiService } from '../../shared/service/laji-api.service';
+import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators';
 import { TaxonAutocompleteService } from '../../shared/service/taxon-autocomplete.service';
 import { BrowserService } from 'projects/laji/src/app/shared/service/browser.service';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 
 @Component({
@@ -64,8 +63,7 @@ export class TaxonSelectComponent implements OnInit, OnDestroy {
   public screenWidthSub?: Subscription;
 
   constructor(
-    private lajiApi: LajiApiService,
-    private translate: TranslateService,
+    private api: LajiApiClientBService,
     private cdr: ChangeDetectorRef,
     private browserService: BrowserService,
     private taxonAutocompleteService: TaxonAutocompleteService
@@ -163,13 +161,11 @@ export class TaxonSelectComponent implements OnInit, OnDestroy {
     this.typeahead.nativeElement.blur();
   }
 
-  public getTaxa(token: string): Observable<any> {
-    return this.lajiApi.get(LajiApi.Endpoints.autocomplete, 'taxon', {
-      q: token,
-      includePayload: true,
-      limit: '' + this.typeaheadLimit,
-      lang: this.translate.currentLang,
+  public getTaxa(query: string) {
+    return this.api.get('/autocomplete/taxa', { query: {
+      query,
+      limit: this.typeaheadLimit,
       ...this.searchParams
-    });
+    } }).pipe(map(({results}) => results));
   }
 }

--- a/projects/laji/src/app/shared/api/FormApiClient.ts
+++ b/projects/laji/src/app/shared/api/FormApiClient.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../environments/environment';
 import { of } from 'rxjs';
 import { TaxonAutocompleteService } from '../service/taxon-autocomplete.service';
 
-const AUTOCOMPLETE_TAXON_RESOURCE = '/autocomplete/taxon';
+const AUTOCOMPLETE_TAXON_RESOURCE = '/autocomplete/taxa';
 const MEDIA_RESOURCES = ['/images', '/audio'];
 
 @Injectable()
@@ -84,7 +84,7 @@ export class FormApiClient {
       }
     ).pipe(
       switchMap(response => resource === AUTOCOMPLETE_TAXON_RESOURCE ?
-        this.taxonAutocompleteService.getInfo(response.body as any[], queryParameters['q']).pipe(
+        this.taxonAutocompleteService.getInfo(response.body as any[], queryParameters['query']).pipe(
           map(taxa => ({
             ...response,
             body: taxa

--- a/projects/laji/src/app/shared/omni-search/omni-search.component.html
+++ b/projects/laji/src/app/shared/omni-search/omni-search.component.html
@@ -21,7 +21,7 @@
       </div>
     </div>
     <div class="taxon-match">
-      <h3><laji-taxon-name [capitalizeName]="true" [taxon]="taxon.payload"></laji-taxon-name></h3>
+      <h3><laji-taxon-name [capitalizeName]="true" [taxon]="taxon"></laji-taxon-name></h3>
 
       <div class="d-flex flex-gap-3">
         <div class="taxon-match-first-col">
@@ -50,7 +50,7 @@
         <div class="taxon-match-second-col d-flex flex-gap-2">
           <div>
             <div>
-              {{ 'omniSearch.rank' | translate }}: {{ taxon.payload.taxonRankId | label }}
+              {{ 'omniSearch.rank' | translate }}: {{ taxon.taxonRankId | label }}
             </div>
             <div>
               {{ 'omniSearch.groups' | translate }}: {{ taxon.informalTaxonGroups | multiLang | values }}

--- a/projects/laji/src/app/shared/service/laji-api.service.ts
+++ b/projects/laji/src/app/shared/service/laji-api.service.ts
@@ -5,7 +5,6 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { Area } from '../model/Area';
-import { Autocomplete } from '../model/Autocomplete';
 import { Checklist } from '../model/Checklist';
 import { PagedResult } from '../model/PagedResult';
 import { Source } from '../model/Source';
@@ -30,7 +29,6 @@ export namespace LajiApi {
     annotationsTags = 'annotations/tags',
     annotations = 'annotations',
     areas = 'areas',
-    autocomplete = 'autocomplete',
     documentStats = 'documents/stats',
     checklists = 'checklists',
     collections = 'collections',
@@ -46,8 +44,6 @@ export namespace LajiApi {
     images = 'images'
   }
 
-  export type AutocompleteField = 'taxon'|'collection'|'friends'|'unit'|'person';
-
   export enum AreaType {
     country = 'country',
     biogeographicalProvince = 'biogeographicalProvince',
@@ -55,12 +51,6 @@ export namespace LajiApi {
     oldMunicipality = 'oldMunicipality',
     birdAssociationArea = 'birdAssociationArea',
     iucnEvaluationArea = 'iucnEvaluationArea'
-  }
-
-  export enum AutocompleteMatchType {
-    exact = <any> 'exact',
-    partial = <any> 'exact,partial',
-    likely = <any> 'exact,likely'
   }
 
   export namespace Query {
@@ -93,23 +83,6 @@ export namespace LajiApi {
     export interface AreaQuery extends Lang, Paged {
       type?: LajiApi.AreaType;
       idIn?: string;
-    }
-
-    export interface AutocompleteQuery {
-      q?: string;
-      limit?: string;
-      includePayload?: boolean;
-      includeSelf?: boolean;
-      lang?: string;
-      checklist?: string;
-      informalTaxonGroup?: string;
-      personToken?: string;
-      matchType?: LajiApi.AutocompleteMatchType;
-      onlySpecies?: boolean;
-      onlyFinnish?: boolean;
-      onlyInvasive?: boolean;
-      excludeNameTypes?: string;
-      formID?: string;
     }
 
     export interface ChecklistQuery extends Lang, Paged {
@@ -233,7 +206,6 @@ export class LajiApiService {
     return this.httpClient.get<T>(url, options);
   }
 
-  get(endpoint: LajiApi.Endpoints.autocomplete, id: LajiApi.AutocompleteField, query: LajiApi.Query.AutocompleteQuery): Observable<Autocomplete[]>;
   get(endpoint: LajiApi.Endpoints.forms, id: string, query: LajiApi.Query.FormsSchemaQuery): Observable<Form.SchemaForm>;
   get(endpoint: LajiApi.Endpoints.forms, id: string, query: LajiApi.Query.FormsQuery): Observable<any>;
   get(endpoint: LajiApi.Endpoints.information, id: string, query?: LajiApi.Query.InformationQuery): Observable<Information>;


### PR DESCRIPTION
All autocomplete queries are done with the new API client. In addition, I made the API client filter undefined query params.

Here are the relevant breaking changes of the new API that are taken into account:

## Autocomplete

### `/autocomplete/person`

* renamed as `/autocomplete/persons`
* results are wrapped in `results`
* query param `q` renamed as `query`
* query param `limit` renamed as `pageSize` (supports pagination now)
* query param `includePayload` is removed, fields can be filtered with `selectedFields` instead

### `/autocomplete/friends`

* results are wrapped in `results`
* query param `q` renamed as `query`
* query param `limit` renamed as `pageSize` (supports pagination now)
* query param `includePayload` is removed, fields can be filtered with `selectedFields` instead
* query param `includeSelf` is removed, self is always included

### `/autocomplete/taxon`

* renamed as `/autocomplete/taxa`
* results are wrapped in `results`
* query param `q` renamed as `query`
* in the result, the `taxonRankId` renamed as `taxonRank`
* in the result, the `informalTaxonGroups` renamed as `informalGroups`
* in the result, the `matchType` renamed as `type`
* query param `includePayload` is removed, fields can be filtered with `selectedFields` instead
