### PR TITLE
Import handles utf-8 csv files

### DIFF
--- a/projects/laji/src/app/shared-modules/spreadsheet/service/spreadsheet.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/spreadsheet.service.ts
@@ -125,10 +125,7 @@ export class SpreadsheetService {
   }
 
   loadSheet(data: any, options: XLSX.ParsingOptions = {}): {data: any; errors: string[]} {
-    if (options.raw && !options.codepage) {
-      options = {...options, codepage: 65001}; // utf-8 encoding
-    }
-    const workBook: XLSX.WorkBook = XLSX.read(data, {type: 'array', cellDates: true, ...options});
+    const workBook: XLSX.WorkBook = XLSX.read(data, {type: 'array', cellDates: true, codepage: 65001, ...options});
     const sheetName: string = workBook.SheetNames[0];
     const sheet: XLSX.WorkSheet = workBook.Sheets[sheetName];
     this.setDateFormat(sheet, !!workBook.Workbook);


### PR DESCRIPTION
https://596.dev.laji.fi/vihko/tools/import
https://github.com/luomus/laji/issues/596

Fix import didn't work with utf-8 files.