### PR TITLE
Fix taxonomy usage of synonymOf

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.html
@@ -6,8 +6,8 @@
           <span class="scientificName" [class.cursive]="taxon.cursiveName">{{ taxon.scientificName }}</span>
           <span *ngIf="taxon.scientificNameAuthorship" class="author">{{ taxon.scientificNameAuthorship }}</span>
         </p>
-        <p *ngIf="taxon.nameAccordingTo" class="green-text">{{ 'taxonomy.acceptedName' | translate }}, {{ taxon.nameAccordingTo | checklist }}</p>
-        <p *ngIf="!taxon.nameAccordingTo && taxon.synonymOf">
+        <p *ngIf="!taxon.synonymOf" class="green-text">{{ 'taxonomy.acceptedName' | translate }}, {{ taxon.nameAccordingTo | checklist }}</p>
+        <p *ngIf="taxon.synonymOf">
           <span class="red-text" *ngIf="synonymType">{{ 'MX.has' + synonymType[0].toUpperCase() + synonymType.substring(1, synonymType.length - 1) | label | uppercase }} {{ 'taxonomy.ofTaxon' | translate }} </span>
           <a [routerLink]="['/taxon', taxon.synonymOf.id, 'taxonomy'] | localize" [queryParams]="{context: null}" [queryParamsHandling]="'merge'" target="_blank">
             <laji-taxon-name [capitalizeName]="true" [taxon]="taxon.synonymOf" [addLink]="false"></laji-taxon-name>

--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-taxonomy/taxon-taxonomy.component.ts
@@ -53,7 +53,7 @@ export class TaxonTaxonomyComponent implements OnChanges, OnDestroy {
       }
       this.synonymType = undefined;
 
-      if (!this.taxon.nameAccordingTo && this.taxon.synonymOf) {
+      if (this.taxon.synonymOf) {
         this.synonymSub = this.api.get('/taxa/{id}', {
           path: { id: this.taxon.synonymOf.id },
           query: {


### PR DESCRIPTION
The "accepted name" thingy doesn't rely on "nameAccordingTo", but just "synonymOf"