### PR TITLE
Use new API's batch job endpoints for Vihko spreadsheet

### DIFF
--- a/projects/laji/src/app/shared-modules/spreadsheet/importer/importer.component.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/importer/importer.component.ts
@@ -12,7 +12,6 @@ import {
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { forkJoin, from as ObservableFrom, Observable, of } from 'rxjs';
-import { Document } from '../../../shared/model/Document';
 import { FormService } from '../../../shared/service/form.service';
 import { IFormField, VALUE_IGNORE } from '../model/excel';
 import { CombineToDocument, IDocumentData, ImportService } from '../service/import.service';
@@ -32,9 +31,14 @@ import { FileService, instanceOfFileLoad } from '../service/file.service';
 import { IUserMappingFile, MappingFileService } from '../service/mapping-file.service';
 import { Form } from '../../../shared/model/Form';
 import { Logger } from '../../../shared/logger';
-import { DocumentJobPayload } from '../../../shared/api/DocumentApi';
 import { toHtmlSelectElement } from '../../../shared/service/html-element.service';
-import {ModalRef, ModalService} from 'projects/laji-ui/src/lib/modal/modal.service';
+import { ModalRef, ModalService } from 'projects/laji-ui/src/lib/modal/modal.service';
+
+import type { components } from 'projects/laji-api-client-b/generated/api';
+
+type Document = components['schemas']['document'];
+type PublicityRestrictions = Document['publicityRestrictions'];
+type BatchJob = components['schemas']['BatchJobValidationStatusResponse'];
 
 @Component({
   selector: 'laji-importer',
@@ -72,7 +76,7 @@ export class ImporterComponent implements OnInit, OnDestroy {
   header?: {[key: string]: string};
   fields?: {[key: string]: IFormField};
   dataColumns?: ImportTableColumn[];
-  jobPayload?: DocumentJobPayload;
+  job?: BatchJob;
   docCnt = 0;
   origColMap?: {[key: string]: string};
   colMap?: {[key: string]: string};
@@ -83,8 +87,8 @@ export class ImporterComponent implements OnInit, OnDestroy {
   mimeType?: string;
   errors: any;
   valid = false;
-  priv = Document.PublicityRestrictionsEnum.publicityRestrictionsPrivate;
-  publ = Document.PublicityRestrictionsEnum.publicityRestrictionsPublic;
+  priv: PublicityRestrictions = 'MZ.publicityRestrictionsPrivate';
+  publ: PublicityRestrictions = 'MZ.publicityRestrictionsPublic';
   excludedFromCopy: string[] = [];
   userMappings: any;
   separator = MappingService.valueSplitter;
@@ -456,9 +460,9 @@ export class ImporterComponent implements OnInit, OnDestroy {
     ObservableFrom(rowData).pipe(
       concatMap(data => this.augmentService.augmentDocument(data.document, this.excludedFromCopy)),
       toArray(),
-      switchMap(documents => this.importService.validateData(documents)),
-      tap(job => this.jobPayload = job),
-      switchMap(job => this.importService.waitToComplete('validate', job, (status) => {
+      switchMap(documents => this.importService.startBatchJob(documents)),
+      tap(job => this.job = job),
+      switchMap(job => this.importService.waitToComplete(job, (status) => {
         this.current = status.processed;
         this.cdr.markForCheck();
       })),
@@ -508,7 +512,7 @@ export class ImporterComponent implements OnInit, OnDestroy {
       );
   }
 
-  save(publicityRestrictions: Document.PublicityRestrictionsEnum) {
+  save(publicityRestrictions: PublicityRestrictions) {
     this.spreadsheetFacade.goToStep(Step.importing);
     this.showOnlyErroneous = false;
     let success = true;
@@ -522,14 +526,14 @@ export class ImporterComponent implements OnInit, OnDestroy {
     const rowData = this.parsedData!.filter(data => data.document !== null);
 
     this.importService.sendData({
-      ...this.jobPayload,
-      dataOrigin: [Document.DataOriginEnum.dataOriginSpreadsheetFile],
+      ...this.job,
+      dataOrigin: 'MY.dataOriginSpreadsheetFile',
       publicityRestrictions
     } as any).pipe(
-      switchMap(() => this.importService.waitToComplete('create', this.jobPayload as any, (status) => {
+      switchMap(() => this.importService.waitToComplete(this.job!, (status) => {
         ticker += add;
         this.current = status.processed === this.total ?
-          status.processed :
+          status.processed:
           Math.min(Math.max(this.total - 1, 0), ticker);
         this.cdr.markForCheck();
       })),

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/augment.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/augment.service.ts
@@ -4,9 +4,11 @@ import { from as ObservableFrom, Observable, of as ObservableOf } from 'rxjs';
 import { NamedPlace } from '../../../shared/model/NamedPlace';
 import { NamedPlaceApi } from '../../../shared/api/NamedPlaceApi';
 import { UserService } from '../../../shared/service/user.service';
-import { Document } from '../../../shared/model/Document';
 import { DocumentService } from '../../own-submissions/service/document.service';
 import { MappingService } from './mapping.service';
+import type { components } from 'projects/laji-api-client-b/generated/api';
+
+type Document = components['schemas']['document'];
 
 @Injectable()
 export class AugmentService {

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/import.service.ts
@@ -1,9 +1,5 @@
 import { Injectable } from '@angular/core';
-import { TranslateService } from '@ngx-translate/core';
 import { Observable, of } from 'rxjs';
-import { DocumentApi, DocumentJobPayload } from '../../../shared/api/DocumentApi';
-import { Document } from '../../../shared/model/Document';
-import { UserService } from '../../../shared/service/user.service';
 import {
   IFormField,
   LEVEL_DOCUMENT,
@@ -15,7 +11,11 @@ import {
 import { MappingService } from './mapping.service';
 import * as Hash from 'object-hash';
 import { catchError, delay, switchMap } from 'rxjs/operators';
-import { ArrayType } from '@angular/compiler';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import type { components } from 'projects/laji-api-client-b/generated/api';
+
+type Document = components['schemas']['document'];
+type BatchJob = components['schemas']['BatchJobValidationStatusResponse'];
 
 export interface IData {
   rowIdx: number;
@@ -74,9 +74,7 @@ export class ImportService {
 
   constructor(
     private mappingService: MappingService,
-    private documentApi: DocumentApi,
-    private userService: UserService,
-    private translateService: TranslateService
+    private api: LajiApiClientBService
   ) { }
 
   hasInvalidValue(value: unknown, field: IFormField) {
@@ -84,46 +82,36 @@ export class ImportService {
     return Array.isArray(mappedValue) ? mappedValue.indexOf(null) > -1 : mappedValue === null;
   }
 
-  validateData(document: Document|Document[]): Observable<any> {
-    return this.documentApi.validate(document, {
-      personToken: this.userService.getToken(),
-      lang: this.translateService.currentLang,
-      validationErrorFormat: 'jsonPath'
-    });
+  startBatchJob(documents: Document[]) {
+    return this.api.post('/documents/batch', undefined, documents);
   }
 
-  waitToComplete(type: keyof Pick<DocumentApi, 'validate'|'create'>, jobPayload: DocumentJobPayload, processCB: (status: JobStatus) => void): Observable<any> {
-    const personToken = this.userService.getToken();
-    const source$ = type === 'validate' ?
-      this.documentApi.validate(jobPayload, {personToken}) :
-      this.documentApi.create(jobPayload, personToken);
-    return source$.pipe(
+  waitToComplete(job: BatchJob, processCB: (status: BatchJob['status']) => void): Observable<BatchJob> {
+    return this.api.get('/documents/batch/{jobID}', { path: { jobID: job.id }, query: { validationErrorFormat: 'dotNotation' } }).pipe(
       switchMap(response => {
         processCB(response.status);
-        if (response.status.percentage === 100) {
+        if (response.phase === 'READY_TO_COMPLETE' || 'COMPLETED') {
           return of(response);
         }
         return of(response).pipe(
           delay(1000),
-          switchMap(() => this.waitToComplete(type, jobPayload, processCB))
+          switchMap(() => this.waitToComplete(job, processCB))
         );
       }),
       catchError((e) => {
         console.log('ERROR', e);
         return of(e).pipe(
           delay(1000),
-          switchMap(() => this.waitToComplete(type, jobPayload, processCB))
+          switchMap(() => this.waitToComplete(job, processCB))
         );
       })
     );
   }
 
   sendData(
-    job: DocumentJobPayload
+    job: BatchJob
   ): Observable<any> {
-    return this.documentApi.create(job, this.userService.getToken(), {
-      lang: this.translateService.currentLang
-    });
+    return this.api.post('/documents/batch/{jobID}', { path: { jobID: job.id } });
   }
 
   flatFieldsToDocuments(
@@ -287,7 +275,7 @@ export class ImportService {
     const docs: {[hash: string]: IDocumentData} = {};
     Object.keys(documents).forEach(hash => {
       if (!docs[hash]) {
-        docs[hash] = {document: {formID}, ref: {[hash]: {}}, rows: {}, skipped: []};
+        docs[hash] = {document: {formID} as Document, ref: {[hash]: {}}, rows: {}, skipped: []};
         const docData = this.findDocumentData(documents[hash]);
         docs[hash].rows[(docData as any).rowIdx] = true;
         if (ignoreRowsWithNoCount && !this.hasCountValue((docData as any).data) && combineBy === CombineToDocument.none) {


### PR DESCRIPTION
In the old API the document batch creation uses the same endpoint as creating a single document. The new API offers separate endpoints with proper Swagger documentation.

Unblocks luomus/laji-api#36