### PR TITLE
laji-taxon-name doesn't use lang fallback for alternativeVernacularName

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/info-card-header/info-card-header.component.html
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/info-card-header/info-card-header.component.html
@@ -18,8 +18,8 @@
   <div *ngIf="taxon.hasParent || taxon.hasChildren">
     <select class="form-control input-sm" [ngModel]="taxon.id" (ngModelChange)="taxonSelect.emit($event)">
       <option *ngFor="let sibling of siblings" [value]="sibling.id">
-        {{ sibling.vernacularName | multiLang:false | capitalize }}
-        <ng-container *ngIf="(sibling.vernacularName | multiLang:false ) && sibling.scientificName">
+        {{ sibling.vernacularName | capitalize }}
+        <ng-container *ngIf="sibling.vernacularName && sibling.scientificName">
           &ndash;
         </ng-container>
         {{ sibling.scientificName }}

--- a/projects/laji/src/app/shared/omni-search/omni-search.component.html
+++ b/projects/laji/src/app/shared/omni-search/omni-search.component.html
@@ -53,7 +53,7 @@
               {{ 'omniSearch.rank' | translate }}: {{ taxon.taxonRank | label }}
             </div>
             <div>
-              {{ 'omniSearch.groups' | translate }}: {{ taxon.informalTaxonGroups | multiLang | values }}
+              {{ 'omniSearch.groups' | translate }}: {{ taxon.informalTaxonGroups | values }}
             </div>
           </div>
           <div class="informal-group-image {{taxon.informalTaxonGroupsClass}}"></div>

--- a/projects/laji/src/app/shared/taxon-name/taxon-name.component.html
+++ b/projects/laji/src/app/shared/taxon-name/taxon-name.component.html
@@ -1,12 +1,12 @@
 <ng-container *ngIf="taxon">
-  <ng-container *ngIf="(taxon.vernacularName | multiLang:false)" [ngTemplateOutlet]="vernacularName"></ng-container>
-  <ng-container *ngIf="(taxon.vernacularName | multiLang:false) && (taxon.colloquialVernacularName | multiLang:false)">
-    (<ul class="separated-list colloquialVernacularName">
-      <li *ngFor="let obj of (taxon.colloquialVernacularName | multiLang:false)">{{obj}}</li>
+  <ng-container *ngIf="taxon.vernacularNameMultiLang | multiLang:false" [ngTemplateOutlet]="vernacularName"></ng-container>
+  <ng-container *ngIf="(taxon.vernacularNameMultiLang | multiLang:false) && (taxon.colloquialVernacularNameMultiLang | multiLang:false)">
+    (<ul class="separated-list colloquialVernacularNameMultiLang">
+      <li *ngFor="let obj of taxon.colloquialVernacularNameMultiLang">{{obj}}</li>
     </ul>
     <laji-info [placement]="'top'">{{ 'taxonomy.vernacular.colloquial.info' | translate }}</laji-info>)
   </ng-container>
-  <ng-container *ngIf="((taxon.vernacularName | multiLang:false) || taxon.alternativeVernacularName | multiLang:false | values) && taxon.scientificName">
+  <ng-container *ngIf="((taxon.vernacularNameMultiLang | multiLang:false) || taxon.alternativeVernacularNameMultiLang | multiLang:false | values) && taxon.scientificName">
     &ndash;
   </ng-container>
   <ng-container [ngTemplateOutlet]="scientificName"></ng-container>
@@ -21,13 +21,13 @@
       <span class="glyphicon glyphicon-warning-sign"></span>
   </ng-container>
 	<img *ngIf="((taxon.id || taxon.qname || taxonID) | toQName)?.startsWith('gbif:')" class="gbif-icon" src="/static/images/icons/gbif.svg" [luTooltip]="'species.tree.gbif.help' | translate" />
-  <div class="alternative-names mt-2" *ngIf="!hideObsoleteVernacularName && taxon?.obsoleteVernacularName | multiLang:false | values; let obsoleteVernacularName">
+  <div class="alternative-names mt-2" *ngIf="!hideObsoleteVernacularName && taxon?.obsoleteVernacularName | values; let obsoleteVernacularName">
     {{ obsoleteVernacularName }}
   </div>
   <ng-template #scientificName><ng-container *ngIf="taxon.cursiveName; else noCursive"><em>{{ taxon.scientificName }}</em></ng-container><ng-template #noCursive>{{ taxon.scientificName }}</ng-template></ng-template>
   <ng-template #vernacularName>
-    {{ capitalizeName ? (taxon.vernacularName | multiLang | capitalize) : (taxon.vernacularName | multiLang) }}
-    <ng-container *ngIf="taxon?.alternativeVernacularName | multiLang:false | values; let alternativeVernacularName">
+    {{ capitalizeName ? (taxon.vernacularNameMultiLang | multiLang:false |  capitalize) : taxon.vernacularNameMultiLang | multiLang:false }}
+    <ng-container *ngIf="taxon?.alternativeVernacularNameMultiLang | multiLang:false | values; let alternativeVernacularName">
       ({{ alternativeVernacularName }})
     </ng-container>
   </ng-template>


### PR DESCRIPTION
Demo https://251117.dev.laji.fi/taxon/MX.211218?showTree=true

Taxon refactoring had resulted in that due to API's lang fallback mechanism `laji-taxon-name` would show `alternativeVernacularName` in a fallback lang (en) when there wasn't a Finnish name available.

Also removed some unused multiLang pipes from ng templates since all taxa requests are done in user's selected lang