### PR TITLE
Improve error messages

### DIFF
--- a/projects/laji/src/app/shared/error/laji-error-handler.ts
+++ b/projects/laji/src/app/shared/error/laji-error-handler.ts
@@ -25,7 +25,7 @@ export class LajiErrorHandler extends ErrorHandler {
     super();
   }
 
-  handleError(error: { message: string | string[]; toString: () => any }) {
+  handleError(error: any) {
     if (this.pause || !error || (typeof error === 'object' && typeof error.message === 'string' && error.message.length === 0)) {
       return super.handleError(error);
     }


### PR DESCRIPTION
Error toast displays `errorCode` and `message` from API errors, if there's an `errorCode`. Otherwise it falls back to "hups" message.