### PR TITLE
Use <hr> instead of plain text in feedback message

### DIFF
--- a/projects/laji/src/app/shared/feedback/feedback.component.ts
+++ b/projects/laji/src/app/shared/feedback/feedback.component.ts
@@ -74,7 +74,7 @@ export class FeedbackComponent {
         LajiApi.Endpoints.feedback,
         {
           subject,
-          message: this.feedback.message + '\n\n---\n' + this.feedback.email,
+          message: this.feedback.message + '<hr>' + this.feedback.email,
           meta
         },
         {personToken: user && user.emailAddress ? this.userService.getToken() : undefined as any}


### PR DESCRIPTION
New API uses HTML instead of plain text for emails, so Helpdesk gets messages with "\n\n---\n" currently.