### PR TITLE
fix taxon identification not displaying all results

### DIFF
--- a/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
+++ b/projects/laji/src/app/+taxonomy/taxon/info-card/taxon-identification/taxon-identification.facade.ts
@@ -92,6 +92,7 @@ export class TaxonIdentificationFacade implements OnDestroy {
       sortOrder: 'observationCountFinland desc',
       selectedFields: 'id,vernacularName,scientificName,cursiveName,taxonRank,hasChildren,countOfSpecies,observationCountFinland,descriptions,multimedia',
       includeMedia: true,
+      pageSize: 1000,
     } }, {
       taxonRank: rank
     }).pipe(switchMap(res => {


### PR DESCRIPTION
The section first fetches children of the taxon, the infinite scroll then looks at the visible children, and gets a list of species under each visible child taxon. The first query for the children didn't have a page size defined so it defaulted to whatever the API default is (20?). Page size 1000 should hopefully cover all cases.

https://github.com/luomus/laji/issues/867