### PR TITLE
Allow html in front page intro text

### DIFF
--- a/projects/laji/src/app/+home/home.component.html
+++ b/projects/laji/src/app/+home/home.component.html
@@ -6,7 +6,7 @@
         <div class="flex-grow home-main">
           <h1>{{ 'home.main-page.title' | translate }}</h1>
           <laji-technical-news></laji-technical-news>
-          <p>{{ 'home.main-page.text' | translate }}</p>
+          <div [innerHTML]="'home.main-page.text' | translate" lajiRouteTransformer></div>
           <ng-container *ngTemplateOutlet="navigationThumbnails"></ng-container>
         </div>
         <laji-news-list class="d-block mb-3 home-news-list"></laji-news-list>


### PR DESCRIPTION
Allows html on front page intro text to make newsletter links from Crowdin possible. Implements https://github.com/luomus/meta/issues/205