### PR TITLE
History service improvements [Closes #908]

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document/document.component.ts
@@ -29,7 +29,7 @@ import { TemplateForm } from '../../own-submissions/models/template-form';
 import { Router } from '@angular/router';
 import { LocalizeRouterService } from '../../../locale/localize-router.service';
 import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-document.service';
-import { HistoryService } from '../../../shared/service/history.service';
+import { BrowserService } from '../../../shared/service/browser.service';
 import { DocumentPermissionService } from '../service/document-permission.service';
 import { FormService } from '../../../shared/service/form.service';
 import { Form } from '../../../shared/model/Form';
@@ -101,7 +101,7 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
     private router: Router,
     private localizeRouterService: LocalizeRouterService,
     private deleteDocumentService: DeleteOwnDocumentService,
-    private historyService: HistoryService,
+    private browserService: BrowserService,
     private documentPermissionService: DocumentPermissionService,
     private formService: FormService
   ) { }
@@ -343,15 +343,11 @@ export class DocumentComponent implements AfterViewInit, OnChanges, OnInit, OnDe
         return;
       }
 
-      if(this.historyService.isFirstLoad()) {
+      this.browserService.goBack(() => {
         this.router.navigate(
           this.localizeRouterService.translateRoute(['/vihko/home/'])
         );
-      } else {
-        this.router.navigate(
-          this.localizeRouterService.translateRoute([this.historyService.getPrevious()])
-        );
-      }
+      });
     }
   }
 

--- a/projects/laji/src/app/shared/service/history.service.ts
+++ b/projects/laji/src/app/shared/service/history.service.ts
@@ -9,7 +9,8 @@ const MAX_HISTORY = 30;
 @Injectable({providedIn: 'root'})
 export class HistoryService implements OnDestroy {
   private history: string[] = [];
-  private hasBack = false;
+  private anyPageLoaded = false;
+  private isInitialLoad = false;
   private routeSub?: Subscription;
 
   constructor(
@@ -23,13 +24,25 @@ export class HistoryService implements OnDestroy {
     this.routeSub = this.router.events.pipe(
       filter(Util.eventIsNavigationEnd)
     ).subscribe(({urlAfterRedirects}: NavigationEnd) => {
-      if (this.router.getCurrentNavigation()?.extras.replaceUrl
-        || urlAfterRedirects.match(/\/user\/(login|logout)/)
+      if (!this.anyPageLoaded) {
+        this.anyPageLoaded = true;
+        this.isInitialLoad = true;
+      } else {
+        this.isInitialLoad = false;
+      }
+
+      if (urlAfterRedirects.match(/\/user\/(login|logout)/)
         || this.history[this.history.length - 1] === urlAfterRedirects) {
         return;
       }
+
+      if (this.router.currentNavigation()?.extras.replaceUrl) {
+        this.history.pop();
+        this.history = [...this.history, urlAfterRedirects];
+        return;
+      }
+
       if (this.history[this.history.length - 2] === urlAfterRedirects) {
-        this.hasBack = true;
         this.history.pop();
       } else {
         this.history = [...this.history, urlAfterRedirects];
@@ -54,11 +67,7 @@ export class HistoryService implements OnDestroy {
     return this.history.length > 1;
   }
 
-  public getPrevious(): string {
-    return this.history[this.history.length - 2] || '';
-  }
-
   public isFirstLoad() {
-    return !(this.hasPrevious() || this.hasBack);
+    return this.isInitialLoad;
   }
 }


### PR DESCRIPTION
Closes: https://github.com/luomus/laji/issues/908
Branch: https://807.dev.laji.fi/project/MHL.1166/form/MHL.1166/places?activeNP=MNP.56680

On addresses with replaceUrl (meaning that only the latest query param change should be saved to history) there was an issue that the first visit to the replaceUrl didn't get saved. So reload on a replaceUrl page with params -> going to another page -> coming back would lose query params and now it doesn't because of this if case: `if (this.router.currentNavigation()?.extras.replaceUrl)`

Also, the confusing `hasBack` variable was replaced with `isInitialLoad` to check the situation where user loads the first page on the first time. Note that /user, /login and /logout paths are also now considered in `isInitialLoad` which makes home-data.service use cache-first on them as well, unlike the earlier no-cache. `getPrevious` was deleted as we can use `browserService.goBack` in `onDocumentDeleted`.
