### PR TITLE
Fix endangerment tab text overflow [Fixes #777]

### DIFF
--- a/projects/laji-ui/src/lib/directives/ghost-textcontent.directive.ts
+++ b/projects/laji-ui/src/lib/directives/ghost-textcontent.directive.ts
@@ -28,7 +28,7 @@ export class GhostTextContentDirective implements OnInit, OnDestroy {
           mutationObserver.disconnect();
         }
       });
-      this.mutationObserver.observe(this.el.nativeElement, { characterData: true, subtree: true });
+      this.mutationObserver.observe(this.el.nativeElement, { characterData: true, childList: true, subtree: true });
     }
   }
 


### PR DESCRIPTION
Issue: https://github.com/luomus/laji/issues/777
Branch: https://777.dev.laji.fi/taxon/MX.40482/endangerment

Enabling MutationObserver's childList option fixed the ghost text content overflow issue: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver/observe#childlist

Fixed with Copilot (Claude Sonnet 4.6).