### PR TITLE
Api client refactors

### DIFF
--- a/projects/laji/src/app/+haseka/haseka.component.ts
+++ b/projects/laji/src/app/+haseka/haseka.component.ts
@@ -4,7 +4,7 @@ import { UserService } from '../shared/service/user.service';
 import { NavigationEnd, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import { Document } from '../shared/model/Document';
-import { DocumentViewerFacade } from '../shared-modules/document-viewer/document-viewer.facade';
+import { DocumentViewerFacade, StoreDocument } from '../shared-modules/document-viewer/document-viewer.facade';
 import { getDescription, HeaderService } from '../shared/service/header.service';
 import { TranslateService } from '@ngx-translate/core';
 
@@ -57,7 +57,7 @@ export class HasekaComponent implements OnInit, OnDestroy {
   }
 
   showDocumentViewer(document: Document) {
-    this.documentViewerFacade.showDocument({document, own: true});
+    this.documentViewerFacade.showDocument({document: document as unknown as StoreDocument, own: true});
   }
 
 }

--- a/projects/laji/src/app/+observation/observation-data.service.ts
+++ b/projects/laji/src/app/+observation/observation-data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { filter, Observable, of } from 'rxjs';
 import { map, shareReplay, startWith } from 'rxjs';
 
 import { WarehouseQueryInterface } from '../shared/model/WarehouseQueryInterface';
@@ -7,31 +7,31 @@ import { SearchQueryService } from './search-query.service';
 import { WarehouseApi } from '../shared/api/WarehouseApi';
 import { PlatformService } from '../root/platform.service';
 import deepEqual from 'deep-equal';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { paths } from 'projects/laji-api-client-b/generated/api';
 
-export interface IObservationData {
-  unitsCount: number|null;
-  speciesCount: number|null;
-  securedCount: number|null;
+type WarehouseQueryUnitAggregateQParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
+
+export interface ObservationCounts {
+  unitsCount: number | null;
+  speciesCount: number | null;
+  securedCount: number | null;
 }
-
-const overrideType = {
-  qualityIssues: 'array'
-};
 
 @Injectable({
   providedIn: 'root'
 })
 export class ObservationDataService {
-  cacheCount$?: Observable<IObservationData>;
+  cacheCount$?: Observable<ObservationCounts>;
   lastQuery?: WarehouseQueryInterface;
 
   constructor(
     private searchQueryService: SearchQueryService,
     private platformService: PlatformService,
-    private warehouseService: WarehouseApi
+    private api: LajiApiClientBService,
   ) { }
 
-  getData(query: WarehouseQueryInterface): Observable<IObservationData> {
+  getData(query: WarehouseQueryInterface): Observable<ObservationCounts> {
     if (this.platformService.isServer) {
       return of(this.empty());
     }
@@ -50,20 +50,13 @@ export class ObservationDataService {
     }, query);
 
     this.lastQuery = newQuery;
-    this.cacheCount$ = this.warehouseService.warehouseQueryAggregateGet(query).pipe(
-      map((data) => data.results?.[0]),
-      map(res => {
-        ['count', 'speciesCount', 'securedCount'].forEach(key => {
-          if (res[key] === undefined) {
-            res[key] = null;
-          }
-        });
-        return res;
-      }),
+    this.cacheCount$ = this.api.get('/warehouse/query/unit/aggregate', { query: query as WarehouseQueryUnitAggregateQParams }).pipe(
+      filter(data => typeof data !== 'string'),
+      map(data => data.results?.[0]),
       map(res => ({
-        unitsCount: res.count,
-        speciesCount: res.speciesCount,
-        securedCount: res.securedCount
+        unitsCount: res['count'] ?? null,
+        speciesCount: res['speciesCount'] ?? null,
+        securedCount: res['securedCount'] ?? null
       })),
       startWith(this.empty()),
       shareReplay(1)

--- a/projects/laji/src/app/+observation/observation-data.service.ts
+++ b/projects/laji/src/app/+observation/observation-data.service.ts
@@ -4,7 +4,7 @@ import { map, shareReplay, startWith } from 'rxjs';
 
 import { WarehouseQueryInterface } from '../shared/model/WarehouseQueryInterface';
 import { SearchQueryService } from './search-query.service';
-import { WarehouseApi } from '../shared/api/WarehouseApi';
+import { WarehouseApi, WarehouseSubPath } from '../shared/api/WarehouseApi';
 import { PlatformService } from '../root/platform.service';
 import deepEqual from 'deep-equal';
 import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
@@ -29,6 +29,7 @@ export class ObservationDataService {
     private searchQueryService: SearchQueryService,
     private platformService: PlatformService,
     private api: LajiApiClientBService,
+    private oldApi: WarehouseApi
   ) { }
 
   getData(query: WarehouseQueryInterface): Observable<ObservationCounts> {
@@ -50,7 +51,10 @@ export class ObservationDataService {
     }, query);
 
     this.lastQuery = newQuery;
-    this.cacheCount$ = this.api.get('/warehouse/query/unit/aggregate', { query: query as WarehouseQueryUnitAggregateQParams }).pipe(
+    const obs$ = this.oldApi.subPath === WarehouseSubPath.default
+      ? this.api.get('/warehouse/query/unit/aggregate', { query: query as WarehouseQueryUnitAggregateQParams })
+      : this.oldApi.warehouseQueryAggregateGet(query);
+    this.cacheCount$ = obs$.pipe(
       filter(data => typeof data !== 'string'),
       map(data => data.results?.[0]),
       map(res => ({

--- a/projects/laji/src/app/+project-form/about/about.component.ts
+++ b/projects/laji/src/app/+project-form/about/about.component.ts
@@ -6,7 +6,7 @@ import { Observable } from 'rxjs';
 import { ProjectFormService } from '../../shared/service/project-form.service';
 import { FormPermissionService } from '../../shared/service/form-permission.service';
 import { Document } from '../../shared/model/Document';
-import { DocumentViewerFacade } from '../../shared-modules/document-viewer/document-viewer.facade';
+import { DocumentViewerFacade, StoreDocument } from '../../shared-modules/document-viewer/document-viewer.facade';
 import { components } from 'projects/laji-api-client-b/generated/api.d';
 
 type Form = components['schemas']['Form'];
@@ -57,7 +57,7 @@ export class AboutComponent implements OnInit {
   }
 
   showDocumentViewer(document: Document) {
-    this.documentViewerFacade.showDocument({document, own: true});
+    this.documentViewerFacade.showDocument({document: document as unknown as StoreDocument, own: true});
   }
 
   enterForm() {

--- a/projects/laji/src/app/+project-form/project-form.component.ts
+++ b/projects/laji/src/app/+project-form/project-form.component.ts
@@ -5,7 +5,7 @@ import { filter, map, mergeMap, startWith, switchMap, take } from 'rxjs';
 import { combineLatest, merge, Observable, of, Subscription, Subject, BehaviorSubject, forkJoin } from 'rxjs';
 import { UserService } from '../shared/service/user.service';
 import { Document } from '../shared/model/Document';
-import { DocumentViewerFacade } from '../shared-modules/document-viewer/document-viewer.facade';
+import { DocumentViewerFacade, StoreDocument } from '../shared-modules/document-viewer/document-viewer.facade';
 import { ProjectForm, ProjectFormService } from '../shared/service/project-form.service';
 import { FormPermissionService, Rights } from '../shared/service/form-permission.service';
 import { BrowserService } from '../shared/service/browser.service';
@@ -353,7 +353,7 @@ export class ProjectFormComponent implements OnInit, OnDestroy {
   }
 
   showDocumentViewer(document: Document) {
-    this.documentViewerFacade.showDocument({document, own: true});
+    this.documentViewerFacade.showDocument({document: document as unknown as StoreDocument, own: true});
   }
 
   trackByLabel(index: any, link: any) {

--- a/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.ts
+++ b/projects/laji/src/app/+viewer/viewer-print/viewer-print.component.ts
@@ -1,11 +1,10 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { FooterService } from '../../shared/service/footer.service';
-import { UserService } from '../../shared/service/user.service';
-import { DocumentApi } from '../../shared/api/DocumentApi';
-import { Document } from '../../shared/model/Document';
 import { Subscription } from 'rxjs';
 import { ActivatedRoute } from '@angular/router';
 import { PlatformService } from '../../root/platform.service';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { StoreDocument } from '../../shared-modules/document-viewer/document-viewer.facade';
 
 @Component({
     selector: 'laji-viewer-print',
@@ -17,7 +16,7 @@ export class ViewerPrintComponent implements OnInit, OnDestroy {
   uri: string | undefined;
   own: boolean | undefined;
   showFacts = false;
-  document: Document | undefined;
+  document: StoreDocument | undefined;
 
   loading = false;
   private subQuery!: Subscription;
@@ -26,8 +25,7 @@ export class ViewerPrintComponent implements OnInit, OnDestroy {
     private platformService: PlatformService,
     private footerService: FooterService,
     private route: ActivatedRoute,
-    private documentService: DocumentApi,
-    private userService: UserService,
+    private api: LajiApiClientBService,
   ) {}
 
   ngOnInit() {
@@ -35,10 +33,9 @@ export class ViewerPrintComponent implements OnInit, OnDestroy {
     this.subQuery = this.route.queryParams.subscribe(params => {
       const id = params['id'];
       if (id) {
-        this.documentService.findById(id, this.userService.getToken())
-          .subscribe(doc => {
-            this.document = doc;
-          });
+        this.api.get('/documents/{id}', { path: { id } }).subscribe(doc => {
+          this.document = doc;
+        });
       } else {
         this.uri = params['uri'];
         this.own = params['own'] === 'true';

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/collection-contest-local-print/collection-contest-print.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/collection-contest-local-print/collection-contest-print.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Document } from '../../../../shared/model/Document';
+import { StoreDocument } from '../../document-viewer.facade';
 
 @Component({
     selector: 'laji-collection-contest-print',
@@ -8,10 +8,9 @@ import { Document } from '../../../../shared/model/Document';
     standalone: false
 })
 export class CollectionContestPrintComponent {
-  @Input({ required: true }) document!: Document;
+  @Input({ required: true }) document!: StoreDocument;
   @Input() fields: any;
   @Input() mapData: any[] = [];
   @Input() imageData: {[key: string]: any} = {};
   @Input() formLogo?: string;
-
 }

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-print-view/document-local-print-view.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-print-view/document-local-print-view.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { Document } from '../../../../shared/model/Document';
+import { StoreDocument } from '../../document-viewer.facade';
 
 @Component({
     selector: 'laji-document-local-print-view',
@@ -8,7 +8,7 @@ import { Document } from '../../../../shared/model/Document';
     standalone: false
 })
 export class DocumentLocalPrintViewComponent {
-  @Input({ required: true }) document!: Document;
+  @Input({ required: true }) document!: StoreDocument;
   @Input() fields: any;
   @Input() mapData: any[] = [];
   @Input() imageData: {[key: string]: any} = {};

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.html
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.html
@@ -57,7 +57,7 @@
             <i class="glyphicon" [ngClass]="{'glyphicon-eye-close': showFacts, 'glyphicon-eye-open': !showFacts}"></i>
           </button>
           <div style="margin-top: 35px;">
-            @if (document.publicityRestrictions !== publicity.publicityRestrictionsPublic) {
+            @if (document.publicityRestrictions !== 'MZ.publicityRestrictionsPublic') {
               <lu-alert [type]="'warning'">
                 <span>
                   {{ 'viewer.notPublished' | translate }}

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.ts
@@ -1,9 +1,10 @@
 import { ChangeDetectorRef, Component, EventEmitter, Input, OnChanges, Output, SimpleChanges, ViewChild } from '@angular/core';
-import { Document } from '../../../../shared/model/Document';
+import { Document as OldDocument } from '../../../../shared/model/Document';
 import { ViewerMapComponent } from '../../viewer-map/viewer-map.component';
 import { SessionStorage } from 'ngx-webstorage';
 import { DocumentPermissionService, DocumentRights } from '../../service/document-permission.service';
 import { Observable } from 'rxjs';
+import { StoreDocument } from '../../document-viewer.facade';
 
 @Component({
     selector: 'laji-document-local-viewer-view',
@@ -14,7 +15,7 @@ import { Observable } from 'rxjs';
 export class DocumentLocalViewerViewComponent implements OnChanges {
   @ViewChild(ViewerMapComponent) map?: ViewerMapComponent;
 
-  @Input() document?: Document;
+  @Input() document?: StoreDocument;
   @Input() fields: any;
   @Input() mapData: any[] = [];
   @Input() imageData: {[key: string]: any} = {};
@@ -23,7 +24,6 @@ export class DocumentLocalViewerViewComponent implements OnChanges {
 
   @Output() documentDeleted = new EventEmitter();
 
-  publicity = Document.PublicityRestrictionsEnum;
   active = 0;
 
   rights$!: Observable<DocumentRights>;

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local.component.ts
@@ -1,17 +1,18 @@
 import { ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges,
 Output, EventEmitter, HostListener } from '@angular/core';
-import { forkJoin, Observable, of, Subscription } from 'rxjs';
+import { forkJoin, Observable, of, Subscription, throwError } from 'rxjs';
 import {delay, map, switchMap, tap} from 'rxjs';
 import { LajiApi, LajiApiService } from '../../../shared/service/laji-api.service';
 import { FormService } from '../../../shared/service/form.service';
-import { Document } from '../../../shared/model/Document';
-import { Units } from '../../../shared/model/Units';
+import { StoreDocument } from '../document-viewer.facade';
 import { TranslateService } from '@ngx-translate/core';
 import { DocumentInfoService } from '../../../shared/service/document-info.service';
 import { Image } from '../../../shared/model/Image';
 import { JSONPath } from 'jsonpath-plus';
 import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-document.service';
+import { components } from 'projects/laji-api-client-b/generated/api';
 
+type Unit = components['schemas']['store-unit'];
 
 @Component({
     selector: 'laji-document-local',
@@ -20,7 +21,7 @@ import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-doc
     standalone: false
 })
 export class DocumentLocalComponent implements OnChanges {
-  @Input({ required: true }) document!: Document;
+  @Input({ required: true }) document!: StoreDocument;
   @Input() view: 'viewer'|'print' = 'viewer';
   @Input() showSpinner = false;
 
@@ -68,7 +69,10 @@ export class DocumentLocalComponent implements OnChanges {
     }
   }
 
-  private parseDocument(doc: Document): Observable<any> {
+  private parseDocument(doc: StoreDocument): Observable<any> {
+    if (!doc.formID) {
+      return throwError(() => new Error(`Expected document to have a formID: ${doc}`));
+    }
     return this.getForm(doc.formID)
       .pipe(
         switchMap(form => {
@@ -95,8 +99,8 @@ export class DocumentLocalComponent implements OnChanges {
               observables.push(this.getImages(gathering));
             }
 
-            const units: Units[] = [];
-            (gathering.units || []).reduce((arr: Units[], unit: Units) => {
+            const units: Unit[] = [];
+            (gathering.units || []).reduce((arr: Unit[], unit: Unit) => {
               if (DocumentInfoService.isEmptyUnit(unit, form)) {
                 return arr;
               }

--- a/projects/laji/src/app/shared-modules/document-viewer/document-viewer.facade.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-viewer.facade.ts
@@ -2,10 +2,13 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs';
 import { hotObjectObserver } from '../../shared/observable/hot-object-observer';
-import { Document } from '../../shared/model/Document';
 import { IdService } from '../../shared/service/id.service';
 import { DocumentApi } from '../../shared/api/DocumentApi';
 import { UserService } from '../../shared/service/user.service';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { components } from 'projects/laji-api-client-b/generated/api';
+
+export type StoreDocument = components['schemas']['store-document'];
 
 interface IParametersBase {
   highlight?: string;
@@ -22,11 +25,11 @@ export interface IDocumentIdParameters extends IParametersBase {
 }
 
 export interface IDocumentParameters extends IParametersBase {
-  document: Document;
+  document: StoreDocument;
 }
 
 export interface IViewerState {
-  document?: Document|null;
+  document?: StoreDocument|null;
   highlight?: string;
   result?: Array<any>;
   own: boolean;
@@ -85,16 +88,19 @@ export class DocumentViewerFacade {
 
   constructor(
     private documentApi: DocumentApi,
+    private api: LajiApiClientBService,
     private userService: UserService
   ) {}
 
   showRemoteDocument(param: IDocumentIdParameters): void {
     this.updateState({..._state, showModal: true});
-    this.documentApi.findById(param.document, this.userService.getToken()).subscribe((document) => {
+    this.api.get('/documents/{id}', { path: { id: param.document } }).subscribe(document => {
       this.showDocument({
         ...param,
         document
       });
+    });
+    this.documentApi.findById(param.document, this.userService.getToken()).subscribe((document) => {
     });
   }
 
@@ -103,7 +109,8 @@ export class DocumentViewerFacade {
       ...param,
       document: {
         id: IdService.getId(param.document),
-        publicityRestrictions: Document.PublicityRestrictionsEnum.publicityRestrictionsPublic} as Document
+        publicityRestrictions: 'MZ.publicityRestrictionsPublic'
+      } as StoreDocument
     });
   }
 

--- a/projects/laji/src/app/shared-modules/document-viewer/document-viewer.facade.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-viewer.facade.ts
@@ -3,7 +3,6 @@ import { BehaviorSubject, Observable } from 'rxjs';
 import { distinctUntilChanged, map } from 'rxjs';
 import { hotObjectObserver } from '../../shared/observable/hot-object-observer';
 import { IdService } from '../../shared/service/id.service';
-import { DocumentApi } from '../../shared/api/DocumentApi';
 import { UserService } from '../../shared/service/user.service';
 import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 import { components } from 'projects/laji-api-client-b/generated/api';
@@ -87,7 +86,6 @@ export class DocumentViewerFacade {
   });
 
   constructor(
-    private documentApi: DocumentApi,
     private api: LajiApiClientBService,
     private userService: UserService
   ) {}
@@ -99,8 +97,6 @@ export class DocumentViewerFacade {
         ...param,
         document
       });
-    });
-    this.documentApi.findById(param.document, this.userService.getToken()).subscribe((document) => {
     });
   }
 

--- a/projects/laji/src/app/shared-modules/document-viewer/service/document-permission.service.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/service/document-permission.service.ts
@@ -7,6 +7,7 @@ import { FormPermissionService } from '../../../shared/service/form-permission.s
 import { switchMap, map, catchError } from 'rxjs';
 import { UserService } from '../../../shared/service/user.service';
 import { DocumentService } from '../../own-submissions/service/document.service';
+import { StoreDocument } from '../document-viewer.facade';
 
 export interface DocumentRights {
   isEditor: boolean;
@@ -66,7 +67,7 @@ export class DocumentPermissionService {
     );
   }
 
-  getRightsToLocalDocument(doc?: Document): Observable<DocumentRights> {
+  getRightsToLocalDocument(doc?: Document | StoreDocument): Observable<DocumentRights> {
     return this.userService.user$.pipe(
       switchMap(user => {
         if (!user?.id || !doc) {

--- a/projects/laji/src/app/shared-modules/document-viewer/viewer-modal/viewer-modal.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/viewer-modal/viewer-modal.component.ts
@@ -2,7 +2,6 @@ import { ChangeDetectionStrategy, Component, OnDestroy, ViewChild } from '@angul
 import { DocumentViewerFacade, IViewerState } from '../document-viewer.facade';
 import { Observable, Subscription } from 'rxjs';
 import { filter, tap } from 'rxjs';
-import { Document } from '../../../shared/model/Document';
 import {ModalComponent} from 'projects/laji-ui/src/lib/modal/modal/modal.component';
 
 @Component({
@@ -13,8 +12,8 @@ import {ModalComponent} from 'projects/laji-ui/src/lib/modal/modal/modal.compone
 })
 export class ViewerModalComponent implements OnDestroy {
 
-  publicityRestrictionsPublic = Document.PublicityRestrictionsEnum.publicityRestrictionsPublic;
-  publicityRestrictionsPrivate = Document.PublicityRestrictionsEnum.publicityRestrictionsPrivate;
+  publicityRestrictionsPublic = 'MZ.publicityRestrictionsPublic';
+  publicityRestrictionsPrivate = 'MZ.publicityRestrictionsPrivate';
 
   readonly vm$: Observable<IViewerState>;
 

--- a/projects/laji/src/app/shared/service/document-info.service.ts
+++ b/projects/laji/src/app/shared/service/document-info.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Document } from '../model/Document';
-import { Units } from '../model/Units';
+import { Units as OldUnits } from '../model/Units';
 import { Global } from '../../../environments/global';
 import { components } from 'projects/laji-api-client-b/generated/api.d';
 
 type FormListing = components['schemas']['FormListing'];
+type Unit = components['schemas']['store-unit'];
 
 interface Info {
   dateBegin: string | null;
@@ -49,7 +50,7 @@ export class DocumentInfoService {
         DocumentInfoService.updateMinMaxDates(info, gathering.dateEnd);
 
         if (gathering.units) {
-          gathering.units.reduce((result: string[], unit: Units) => {
+          gathering.units.reduce((result: string[], unit: OldUnits) => {
             if (this.isEmptyUnit(unit, form)) { return result; }
 
             let taxon = unit.informalNameString || '';
@@ -94,10 +95,10 @@ export class DocumentInfoService {
     }
   }
 
-  public static isEmptyUnit(unit: Units, form: FormListing) {
+  public static isEmptyUnit(unit: OldUnits | Unit, form: FormListing) {
     if (form?.options?.prepopulateWithInformalTaxonGroups || form?.options?.emptyOnNoCount) {
       let result = true;
-      (Global.documentCountUnitProperties as (keyof Units)[]).forEach(key => {
+      (Global.documentCountUnitProperties as (keyof OldUnits & keyof Unit)[]).forEach(key => {
         if (typeof unit[key] !== 'undefined' && unit[key] !== '' && unit[key] !== null) {
           result = false;
         }


### PR DESCRIPTION
I had to do a few temporary unsafe type casts to limit the scope of the changes

Also had to stick to the old api for `api/warehouse/query/sample/aggregate` since that path appears to not exist in the new api yet