### PR TITLE
Small refactor to label designer to get rid of old laji api client.

### DIFF
--- a/projects/laji/src/app/+haseka/tools/label-designer/label-designer.component.ts
+++ b/projects/laji/src/app/+haseka/tools/label-designer/label-designer.component.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { ILabelField, ILabelPdf, ISetup, IViewSettings, Presets } from '@luomus/label-designer';
-import { LajiApi, LajiApiService } from '../../../shared/service/laji-api.service';
 import * as FileSaver from 'file-saver';
 import { PdfLabelService } from '../../../shared/service/pdf-label.service';
 import { Observable, of } from 'rxjs';
@@ -10,6 +9,7 @@ import { LocalStorage } from 'ngx-webstorage';
 import { environment } from '../../../../environments/environment';
 import { Global } from '../../../../environments/global';
 import { PlatformService } from '../../../root/platform.service';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
     selector: 'laji-label-designer',
@@ -33,7 +33,7 @@ export class LabelDesignerComponent implements OnInit {
 
   constructor(
     private platformService: PlatformService,
-    private lajiApiService: LajiApiService,
+    private httpClient: HttpClient,
     private pdfLabelService: PdfLabelService,
     private translateService: TranslateService,
     private cdr: ChangeDetectorRef
@@ -85,7 +85,8 @@ export class LabelDesignerComponent implements OnInit {
 
   htmlToPdf(data: ILabelPdf) {
     if (this.platformService.isBrowser) {
-      this.lajiApiService.post(LajiApi.Endpoints.htmlToPdf, data.html)
+      //TODO replace with new api client when/if responseType is supported
+      this.httpClient.post('api/html-to-pdf', data.html, { responseType: 'blob' })
         .subscribe(
           (response) => {
             this.downloading = false;


### PR DESCRIPTION
Uses HttpClient as LajiApiClientB does not support responseType.