### PR TITLE
Api refactors

### DIFF
--- a/projects/laji/src/app/+observation/count/observation-count.component.ts
+++ b/projects/laji/src/app/+observation/count/observation-count.component.ts
@@ -63,7 +63,7 @@ export class ObservationCountComponent implements OnChanges {
   }
 
   private normalCount(query: NormalCountQueryParams): Observable<number | undefined> {
-    return this.api.get('/warehouse/query/unit/count', { query: query as any }).pipe(
+    return this.api.get('/warehouse/query/unit/count', { query }).pipe(
       retryWhen(errors => errors.pipe(delay(1000), take(2), concatWith(throwError(() => errors)))),
       map((result: any) => result.total)
     );

--- a/projects/laji/src/app/+observation/count/observation-count.component.ts
+++ b/projects/laji/src/app/+observation/count/observation-count.component.ts
@@ -1,10 +1,13 @@
 import { catchError, concat, concatWith, delay, map, retryWhen, take, tap, throwError } from 'rxjs';
 import { Observable, of, throwError as observableThrowError } from 'rxjs';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
-import { WarehouseApi } from '../../shared/api/WarehouseApi';
 import { Logger } from '../../shared/logger/logger.service';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { paths } from 'projects/laji-api-client-b/generated/api';
 
+type NormalCountQueryParams = paths['/warehouse/query/unit/count']['get']['parameters']['query'];
+type AggregateQueryParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
 
 @Component({
     selector: 'laji-observation-count',
@@ -27,7 +30,7 @@ export class ObservationCountComponent implements OnChanges {
   private pageSize = 1000;
 
   constructor(
-    private warehouseService: WarehouseApi,
+    private api: LajiApiClientBService,
     private logger: Logger,
     private cdr: ChangeDetectorRef
   ) {
@@ -59,23 +62,23 @@ export class ObservationCountComponent implements OnChanges {
     );
   }
 
-  private normalCount(query: WarehouseQueryInterface): Observable<number | undefined> {
-    return this.warehouseService.warehouseQueryCountGet(query).pipe(
+  private normalCount(query: NormalCountQueryParams): Observable<number | undefined> {
+    return this.api.get('/warehouse/query/unit/count', { query: query as any }).pipe(
       retryWhen(errors => errors.pipe(delay(1000), take(2), concatWith(throwError(() => errors)))),
-      map(result => result.total)
+      map((result: any) => result.total)
     );
   }
 
-  private aggregatedCount(query: WarehouseQueryInterface): Observable<number> {
+  private aggregatedCount(query: AggregateQueryParams): Observable<number> {
     let pageSize = 1;
     if (this.pick) {
       pageSize = this.pageSize;
       this.pick = Array.isArray(this.pick) ? this.pick : [this.pick];
     }
 
-    return this.warehouseService.warehouseQueryAggregateGet(query, [this.field], undefined, pageSize).pipe(
+    return this.api.get('/warehouse/query/unit/aggregate', { query: { ...query, aggregateBy: [this.field as any], pageSize } }).pipe(
       retryWhen(errors => errors.pipe(delay(1000), take(2), concatWith(throwError(() => errors)))),
-      map(result => {
+      map((result: any) => {
         if (this.pick && result.results) {
           return result.results
             .filter((value: any) => this.pick.indexOf(value.aggregateBy[this.field]) > -1)

--- a/projects/laji/src/app/+observation/observation-data.service.ts
+++ b/projects/laji/src/app/+observation/observation-data.service.ts
@@ -18,10 +18,13 @@ export interface ObservationCounts {
   securedCount: number | null;
 }
 
+export type DataFetchMode = 'unit' | 'sample';
+
 @Injectable({
   providedIn: 'root'
 })
 export class ObservationDataService {
+  dataFetchMode: DataFetchMode = 'unit';
   cacheCount$?: Observable<ObservationCounts>;
   lastQuery?: WarehouseQueryInterface;
 
@@ -29,7 +32,6 @@ export class ObservationDataService {
     private searchQueryService: SearchQueryService,
     private platformService: PlatformService,
     private api: LajiApiClientBService,
-    private oldApi: WarehouseApi
   ) { }
 
   getData(query: WarehouseQueryInterface): Observable<ObservationCounts> {
@@ -51,9 +53,9 @@ export class ObservationDataService {
     }, query);
 
     this.lastQuery = newQuery;
-    const obs$ = this.oldApi.subPath === WarehouseSubPath.default
+    const obs$: Observable<any> = this.dataFetchMode === 'unit'
       ? this.api.get('/warehouse/query/unit/aggregate', { query: query as WarehouseQueryUnitAggregateQParams })
-      : this.oldApi.warehouseQueryAggregateGet(query);
+      : this.api.get('/warehouse/query/sample/aggregate' as any, { query: query as WarehouseQueryUnitAggregateQParams });
     this.cacheCount$ = obs$.pipe(
       filter(data => typeof data !== 'string'),
       map(data => data.results?.[0]),

--- a/projects/laji/src/app/+observation/observation.facade.ts
+++ b/projects/laji/src/app/+observation/observation.facade.ts
@@ -6,7 +6,7 @@ import { hotObjectObserver } from '../shared/observable/hot-object-observer';
 import { BrowserService } from '../shared/service/browser.service';
 import { UserService } from '../shared/service/user.service';
 import { FooterService } from '../shared/service/footer.service';
-import { ObservationDataService } from './observation-data.service';
+import { DataFetchMode, ObservationDataService } from './observation-data.service';
 import { SearchQueryService } from './search-query.service';
 import * as Util from '../shared/utils';
 import { LocalStorage } from 'ngx-webstorage';
@@ -109,6 +109,10 @@ export class ObservationFacade {
     private observationDataService: ObservationDataService
   ) {
     this.updateState({..._state, ...this.persistentState});
+  }
+
+  setDataFetchMode(m: DataFetchMode) {
+    this.observationDataService.dataFetchMode = m;
   }
 
   activeTab(tab?: string) {

--- a/projects/laji/src/app/+observation/result/observation-result.component.ts
+++ b/projects/laji/src/app/+observation/result/observation-result.component.ts
@@ -18,6 +18,8 @@ import { ToastsService } from '../../shared/service/toasts.service';
 import { TranslateService } from '@ngx-translate/core';
 import G from 'geojson';
 import * as Util from '../../shared/utils';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { geoJSONToWKT } from '@luomus/laji-map/lib/utils';
 
 const tabOrder = ['list', 'map', 'images', 'species', 'statistics', 'annotations', 'own'];
 @Component({
@@ -101,6 +103,7 @@ export class ObservationResultComponent implements OnChanges {
     private storage: LocalStorageService,
     private route: ActivatedRoute,
     private warehouseApi: WarehouseApi,
+    private api: LajiApiClientBService,
     private userService: UserService,
     private toastsService: ToastsService,
     private translate: TranslateService
@@ -212,7 +215,9 @@ export class ObservationResultComponent implements OnChanges {
   }
 
   registerPolygon$(polygon: G.Polygon) {
-    return this.warehouseApi.registerPolygon(polygon, this.userService.getToken(), 'WGS84').pipe(
+    const wkt = geoJSONToWKT(polygon);
+    const crs = 'WGS84';
+    return this.api.post('/warehouse/polygon', { query: { wkt, crs } } as any).pipe(
       map((response: any) => '' + response.id),
       catchError(e => {
         const { error } = e;

--- a/projects/laji/src/app/+observation/view/observation-view.component.ts
+++ b/projects/laji/src/app/+observation/view/observation-view.component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { ChangeDetectionStrategy, Component, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, ViewChild } from '@angular/core';
 import { combineLatest, Observable, Subscription } from 'rxjs';
 import { TranslateService } from '@ngx-translate/core';
 import { ObservationResultComponent } from '../result/observation-result.component';
@@ -17,6 +17,7 @@ import { SidebarComponent } from 'projects/laji-ui/src/lib/sidebar/sidebar.compo
 import { ActiveToast } from 'ngx-toastr';
 import { ObservationFormQuery } from '../form/observation-form-query.interface';
 import { LocalStorageService } from 'ngx-webstorage';
+import { DataFetchMode as ObservationFormType } from '../observation-data.service';
 
 export interface VisibleSections {
   finnish?: boolean;
@@ -40,9 +41,8 @@ export interface VisibleSections {
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })
-export class ObservationViewComponent implements OnInit, OnDestroy {
-
-  @Input() formType: 'unit'|'sample' = 'unit';
+export class ObservationViewComponent implements OnInit, OnDestroy, OnChanges {
+  @Input() formType: ObservationFormType = 'unit';
   @Input() basePath = '/observation';
   @Input() visible: VisibleSections = {
     finnish: true,
@@ -98,6 +98,12 @@ export class ObservationViewComponent implements OnInit, OnDestroy {
     private toastsService: ToastsService,
     private localStorageService: LocalStorageService
   ) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes.formType) {
+      this.observationFacade.setDataFetchMode(changes.formType.currentValue);
+    }
+  }
 
   @Input({ required: true })
   set activeTab(tab: string) {


### PR DESCRIPTION
couple of notes:
- the `/sample` route doesn't exist in the openapi defs, and it doesn't sound like it's coming soon so forcing it with `any`
- some api routes, like register polygon, have a required person token param. But the api client auto fills that now... I forced any here, but in the future should figure out a proper solution