### PR TITLE
New api client migration 

### DIFF
--- a/projects/laji-api-client-b/src/laji-api-client-b.service.ts
+++ b/projects/laji-api-client-b/src/laji-api-client-b.service.ts
@@ -4,12 +4,47 @@ import { HttpClient } from '@angular/common/http';
 import { Observable, of } from 'rxjs';
 import { share, tap } from 'rxjs';
 
+type WithResponses<T> = T & { responses: unknown };
+
 type ResponseType = 'json' | 'text' | 'arraybuffer' | 'blob';
 
-type WithResponses<T> = T & { responses: unknown };
-interface HttpClientOptions { responseType?: ResponseType }
-type Parameters<T> = 'parameters' extends keyof T ? T['parameters'] & HttpClientOptions : HttpClientOptions;
-type ExtractContentIfExists<R> = R extends { content: infer C } ? C[keyof C] : null;
+interface HttpClientOptions<RT extends ResponseType | undefined> {
+  responseType?: RT;
+};
+
+type Parameters<T, RT extends ResponseType | undefined> =
+  'parameters' extends keyof T
+    ? T['parameters'] & HttpClientOptions<RT>
+    : HttpClientOptions<RT>;
+
+interface ResponseTypeToContentTypes {
+  json: 'application/json';
+  text: 'text/plain' | 'text/csv' | 'application/xml' | 'text/tab-separated-values';
+  blob: 'application/pdf';
+  arraybuffer: never;
+};
+
+type BinaryContent<T> =
+  T extends string ? Blob : T;
+
+type ExtractContentByResponseType<
+  R,
+  RT extends ResponseType | undefined
+> =
+  R extends { content: infer C extends Record<string, any> }
+    ? RT extends undefined | 'json'
+      ? C extends { 'application/json': infer J }
+        ? J
+        : never
+      : RT extends 'text'
+        ? C[Extract<keyof C, ResponseTypeToContentTypes['text']>]
+        : RT extends 'blob'
+          ? BinaryContent<
+              C[Extract<keyof C, ResponseTypeToContentTypes['blob']>]
+            >
+          : never
+    : null;
+
 type ExtractRequestContentIfExists<R> =
   R extends { requestBody: { content: infer C } } | { requestBody?: { content: infer C } }
     ? C
@@ -59,7 +94,8 @@ const hashRecord = (record: any): string => JSON.stringify(sortRecordRecursively
 const splitAndResolvePath = <
   P extends Path,
   M extends Method<P>,
->(path: P, params?: Parameters<paths[P][M]>): string[] => {
+  RT extends ResponseType | undefined
+>(path: P, params?: Parameters<paths[P][M], RT>): string[] => {
   // parse path into segments based on path parameters
   // eg. "/person/{personToken}/profile" -> ["/person", "/{personToken}", "/profile"]
   const segments = path.split(/(\/\{[^}]+\})/).filter(Boolean);
@@ -100,11 +136,19 @@ export class LajiApiClientBService {
     this.personToken = personToken;
   }
 
-  get<P extends PathWithMethod<'get'>, R extends Responses<P, 'get' extends Method<P> ? 'get' : never>>(
+  get<
+    P extends PathWithMethod<'get'>,
+    R extends Responses<P,
+    'get' extends Method<P> ? 'get' : never>,
+    RT extends ResponseType | undefined = undefined
+>(
     path: P,
-    params?: Parameters<paths[P]['get']>,
+    params?: Parameters<paths[P]['get'], RT>,
     cacheInvalidationMs = ONE_DAY
-  ): Observable<ExtractContentIfExists<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>]>> {
+  ): Observable<
+    ExtractContentByResponseType<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>],
+    RT>
+> {
     return this.fetch(
       path,
       'get' as any,
@@ -114,12 +158,21 @@ export class LajiApiClientBService {
     );
   }
 
-  put<P extends PathWithMethod<'put'>, R extends Responses<P, 'put' extends Method<P> ? 'put' : never>>(
+  put<
+    P extends PathWithMethod<'put'>,
+    R extends Responses<P, 'put' extends Method<P> ? 'put' : never>,
+    RT extends ResponseType | undefined = undefined
+>(
     path: P,
-    params?: Parameters<paths[P]['put']>,
+    params?: Parameters<paths[P]['put'], RT>,
     requestBody?: RequestBodyFor<paths[P]['put']>,
     cacheInvalidationMs = ONE_DAY
-  ): Observable<ExtractContentIfExists<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>]>> {
+  ): Observable<
+ExtractContentByResponseType<
+    R[IntersectUnionTypes<keyof R, HttpSuccessCodes>],
+    Parameters<paths[P]['put'], RT>['responseType']
+  >
+> {
     return this.fetch(
       path,
       'put' as any,
@@ -129,12 +182,21 @@ export class LajiApiClientBService {
     );
   }
 
-  post<P extends PathWithMethod<'post'>, R extends Responses<P, 'post' extends Method<P> ? 'post' : never>>(
+  post<
+    P extends PathWithMethod<'post'>,
+    R extends Responses<P, 'post' extends Method<P> ? 'post' : never>,
+    RT extends ResponseType | undefined = undefined
+>(
     path: P,
-    params?: Parameters<paths[P]['post']>,
+    params?: Parameters<paths[P]['post'], RT>,
     requestBody?: RequestBodyFor<paths[P]['post']>,
     cacheInvalidationMs = ONE_DAY
-  ): Observable<ExtractContentIfExists<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>]>> {
+  ): Observable<
+ExtractContentByResponseType<
+    R[IntersectUnionTypes<keyof R, HttpSuccessCodes>],
+    Parameters<paths[P]['post'], RT>['responseType']
+  >
+> {
     return this.fetch(
       path,
       'post' as any,
@@ -144,11 +206,20 @@ export class LajiApiClientBService {
     );
   }
 
-  delete<P extends PathWithMethod<'delete'>, R extends Responses<P, 'delete' extends Method<P> ? 'delete' : never>>(
+  delete<
+    P extends PathWithMethod<'delete'>,
+    R extends Responses<P, 'delete' extends Method<P> ? 'delete' : never>,
+    RT extends ResponseType | undefined = undefined
+>(
     path: P,
-    params?: Parameters<paths[P]['delete']>,
+    params?: Parameters<paths[P]['delete'], RT>,
     cacheInvalidationMs = ONE_DAY
-  ): Observable<ExtractContentIfExists<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>]>> {
+  ): Observable<
+ExtractContentByResponseType<
+    R[IntersectUnionTypes<keyof R, HttpSuccessCodes>],
+    Parameters<paths[P]['delete'], RT>['responseType']
+  >
+> {
     return this.fetch(
       path,
       'delete' as any,
@@ -158,7 +229,13 @@ export class LajiApiClientBService {
     );
   }
 
-  private getRequestOptions(queryParams: any, requestBody: any, lang: string, personToken?: string, responseType?: ResponseType) {
+  private getRequestOptions(
+    queryParams: any,
+    requestBody: any,
+    lang: string,
+    personToken?: string,
+    responseType: ResponseType = 'json'
+  ) {
     const params = Object.keys((queryParams || {})).reduce((filteredQueryParams, key) => {
       const param = (queryParams || {})[key];
       if (param === undefined) {
@@ -178,13 +255,23 @@ export class LajiApiClientBService {
     return { params, body: requestBody, headers, responseType };
   }
 
-  fetch<P extends Path, M extends Method<P>, R extends Responses<P, M>>(
+  fetch<
+    P extends Path,
+    M extends Method<P>,
+    R extends Responses<P, M>,
+    RT extends ResponseType | undefined = undefined
+>(
     path: P,
     method: M,
-    params?: Parameters<paths[P][M]>,
+    params?: Parameters<paths[P][M], RT>,
     requestBody?: RequestBodyFor<paths[P][M]>,
     cacheInvalidationMs = ONE_DAY
-  ): Observable<ExtractContentIfExists<R[IntersectUnionTypes<keyof R, HttpSuccessCodes>]>> {
+  ): Observable<
+ExtractContentByResponseType<
+    R[IntersectUnionTypes<keyof R, HttpSuccessCodes>],
+    Parameters<paths[P][M], RT>['responseType']
+  >
+> {
     const pathSegments = splitAndResolvePath(path, params);
     const requestUrl = this.baseUrl + pathSegments.join('');
 
@@ -239,14 +326,14 @@ export class LajiApiClientBService {
 
   flush<P extends Path, M extends Method<P>>(
     path: P,
-    params?: Parameters<paths[P][M]>
+    params?: Parameters<paths[P][M], never>
   ) {
     this._flush(splitAndResolvePath(path, params), params);
   }
 
   private _flush<P extends Path, M extends Method<P>>(
     pathSegments: string[],
-    params?: Parameters<paths[P][M]>
+    params?: Parameters<paths[P][M], never>
   ) {
     while (pathSegments.length) {
       const cachedPath = this.pathSegmentsToCacheLevels(pathSegments);

--- a/projects/laji/src/app/+project-form/results/biomon-result/biomon-result-statistics/biomon-result-statistics.component.ts
+++ b/projects/laji/src/app/+project-form/results/biomon-result/biomon-result-statistics/biomon-result-statistics.component.ts
@@ -55,7 +55,6 @@ export class BiomonResultStatisticsComponent implements OnInit {
     );
 
     this.rows$ = query$.pipe(
-      filter((response): response is AggregateResponse => typeof response !== 'string'),
       map((response) => response.results
         .map(r => ({ observer: r.aggregateBy['gathering.team.memberName'], gatherings: r.count }))
         .sort((a, b) => b.gatherings - a.gatherings)

--- a/projects/laji/src/app/+project-form/results/bird-point-count-result/bird-point-count-result-chart/bird-point-count-result-chart.component.ts
+++ b/projects/laji/src/app/+project-form/results/bird-point-count-result/bird-point-count-result-chart/bird-point-count-result-chart.component.ts
@@ -124,7 +124,6 @@ export class BirdPointCountResultChartComponent implements OnInit, OnDestroy {
           }
         },
       )),
-      filter((response): response is AggregateResponse => typeof response !== 'string'),
       map(res => res.results.map(item => ({ year: item.aggregateBy['gathering.conversions.year'], pairCount: item.pairCountSum })))
     );
   }
@@ -144,7 +143,6 @@ export class BirdPointCountResultChartComponent implements OnInit, OnDestroy {
           }
         }
       )),
-      filter((response): response is AggregateResponse => typeof response !== 'string'),
       map((res) => {
         const documentCountArray: DocumentCountObject[] = [];
         res.results.forEach(documentResult => {

--- a/projects/laji/src/app/+project-form/results/line-transect-result/line-transect-result-chart/line-transect-result-chart.component.ts
+++ b/projects/laji/src/app/+project-form/results/line-transect-result/line-transect-result-chart/line-transect-result-chart.component.ts
@@ -276,10 +276,7 @@ export class LineTransectResultChartComponent implements OnInit, OnDestroy {
         : of(null);
 
     this.fetchSub = combineLatest([stats$, gathering$])
-      .pipe(
-        map(([value]) => value),
-        filter((response): response is AggregateResponse => typeof response !== 'string')
-      )
+      .pipe(map(([value]) => value))
       .subscribe(
         data => {
           this.result = data;

--- a/projects/laji/src/app/+theme/quality/most-active-users-table/most-active-users-table.component.ts
+++ b/projects/laji/src/app/+theme/quality/most-active-users-table/most-active-users-table.component.ts
@@ -54,7 +54,7 @@ export class MostActiveUsersTableComponent implements OnInit, OnChanges {
 
     this.tables.map((table) => {
       observables.push(
-        this.qualityService.getMostActiveUsers(this.maxLength, [this.group], table.date)
+        this.qualityService.getMostActiveUsers(this.maxLength, this.group, table.date)
       );
     });
 

--- a/projects/laji/src/app/+theme/service/quality.service.ts
+++ b/projects/laji/src/app/+theme/service/quality.service.ts
@@ -1,120 +1,46 @@
-import { map, tap } from 'rxjs';
+import { map } from 'rxjs';
 import { Injectable } from '@angular/core';
-import { WarehouseApi } from '../../shared/api/WarehouseApi';
-import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
-import { Observable, Observer, of as ObservableOf } from 'rxjs';
-
-interface SubState {
-  key: string;
-  data: any[];
-  pending: Observable<any> | undefined;
-  pendingKey: string;
-}
-
-interface State {
-  annotations: SubState;
-  users: SubState;
-}
+import { Observable } from 'rxjs';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 @Injectable()
 export class QualityService {
-  private state: State = {
-    annotations: {
-      key: '',
-      data: [],
-      pending: undefined,
-      pendingKey: ''
-    },
-    users: {
-      key: '',
-      data: [],
-      pending: undefined,
-      pendingKey: ''
-    }
-  };
-
   constructor(
-    private warehouseApi: WarehouseApi
+    private api: LajiApiClientBService
   ) { }
 
-  getAnnotationList(page = 1, pageSize = 50, orderBy?: string[], informalTaxonGroup?: string, timeStart?: string, timeEnd?: string): Observable<any> {
-    const query: WarehouseQueryInterface = {cache: true};
-    query.annotationType = ['USER_EFFECTIVE', 'COMMENT'];
-    if (informalTaxonGroup) {
-      query.informalTaxonGroupId = <string[]><unknown>informalTaxonGroup;
-    }
-    if (timeStart) {
-      query.annotatedSameOrAfter = timeStart;
-    }
-    if (timeEnd) {
-      query.annotatedSameOrBefore = timeEnd;
-    }
-
-    const cacheKey = JSON.stringify({page, pageSize, orderBy, informalTaxonGroup, timeStart, timeEnd});
-
-    return this._fetch('annotations', cacheKey,
-      this.warehouseApi.warehouseQueryAnnotationListGet(
-        query,
-        ['annotation', 'unit.media', 'document.documentId', 'unit.unitId', 'gathering.team', 'unit.taxonVerbatim',
-        'unit.linkings.originalTaxon', 'unit.reportedInformalTaxonGroup'],
-        orderBy,
-        pageSize,
-        page
-    ));
+  getAnnotationList(page = 1, pageSize = 50, orderBy?: string[], informalTaxonGroupId?: string, timeStart?: string, timeEnd?: string) {
+    return this.api.get('/warehouse/query/annotation/list', { query: {
+      cache: true,
+      annotationType: ['USER_EFFECTIVE', 'COMMENT'] as any,
+      informalTaxonGroupId,
+      annotatedSameOrAfter: timeStart,
+      annotatedSameOrBefore: timeEnd,
+      selected: [
+        'annotation', 'unit.media', 'document.documentId', 'unit.unitId', 'gathering.team', 'unit.taxonVerbatim',
+        'unit.linkings.originalTaxon', 'unit.reportedInformalTaxonGroup'
+      ] as any,
+      orderBy: orderBy as any,
+      pageSize,
+      page
+    } });
   }
 
-  getMostActiveUsers(maxLength = 50, informalTaxonGroup?: string[], lastDate?: string): Observable<any> {
-    const query: WarehouseQueryInterface = {cache: true};
-    query.annotationType = ['USER_EFFECTIVE'];
-    if (informalTaxonGroup) {
-      query.informalTaxonGroupId = informalTaxonGroup;
-    }
-    if (lastDate) {
-      query.annotatedSameOrAfter = lastDate;
-    }
-
-    const cacheKey = JSON.stringify({maxLength, informalTaxonGroup, lastDate});
-
-    return this._fetch('users', cacheKey,
-      this.warehouseApi.warehouseQueryAnnotationAggregateGet(
-        query,
-        ['unit.annotations.annotationByPerson', 'unit.annotations.annotationByPersonName'],
-        undefined,
-        maxLength,
-        1,
-        false,
-        true
-    )).pipe(
+  getMostActiveUsers(pageSize = 50, informalTaxonGroupId?: string, lastDate?: string): Observable<any> {
+    return this.api.get('/warehouse/query/annotation/aggregate', { query: {
+      cache: true,
+      annotationType: 'USER_EFFECTIVE',
+      informalTaxonGroupId,
+      annotatedSameOrAfter: lastDate,
+      aggregateBy: ['unit.annotations.annotationByPerson', 'unit.annotations.annotationByPersonName'],
+      pageSize,
+      page: 1,
+      onlyCount: true
+    } }).pipe(
       map(data => data.results),
       map(data => data.map((row: any) => {
           row.userId = row.aggregateBy['unit.annotations.annotationByPersonName'] || '';
           return row;
         })), );
-  }
-
-  private _fetch(type: 'annotations'|'users', cacheKey: string, request: Observable<any>): Observable<any> {
-    if (this.state[type].key === cacheKey) {
-      return ObservableOf(this.state[type].data);
-    } else if (this.state[type].pendingKey === cacheKey && this.state[type].pending) {
-      return Observable.create((observer: Observer<any>) => {
-        const onComplete = (res: any) => {
-          observer.next(res);
-          observer.complete();
-        };
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.state[type].pending!.subscribe(
-          (data) => { onComplete(data); }
-        );
-      });
-    }
-    this.state[type].pendingKey = cacheKey;
-    this.state[type].pending    = request.pipe(
-      tap(data => {
-        this.state[type].data = data;
-        this.state[type].key  = cacheKey;
-      })
-    );
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    return this.state[type].pending!;
   }
 }

--- a/projects/vir/src/app/+geoapi/geoapi.component.ts
+++ b/projects/vir/src/app/+geoapi/geoapi.component.ts
@@ -2,12 +2,9 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/
 import {
   ApiKeyRequest
 } from '../../../../laji/src/app/shared-modules/download-modal/apikey-modal/apikey-modal.component';
-import { UserService } from '../../../../laji/src/app/shared/service/user.service';
-import { WarehouseApi } from '../../../../laji/src/app/shared/api/WarehouseApi';
 import { Logger } from '../../../../laji/src/app/shared/logger';
-import { TranslateService } from '@ngx-translate/core';
 import { VIR_FILTER_SHORTCUT_QUERY_PARAMS } from '../../../../laji/src/app/+observation/form/observation-form.component';
-import { SearchQueryService } from '../../../../laji/src/app/+observation/search-query.service';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 @Component({
     selector: 'vir-geoapi',
@@ -17,12 +14,9 @@ import { SearchQueryService } from '../../../../laji/src/app/+observation/search
 })
 export class GeoapiComponent {
   constructor(
-    private warehouseService: WarehouseApi,
-    private searchQueryService: SearchQueryService,
-    private userService: UserService,
     private logger: Logger,
-    private translate: TranslateService,
-    private cd: ChangeDetectorRef
+    private cd: ChangeDetectorRef,
+    private api: LajiApiClientBService
   ) {}
 
   apiKey = '';
@@ -31,18 +25,15 @@ export class GeoapiComponent {
   onApiKeyRequest(req: ApiKeyRequest) {
     this.apiKeyLoading = true;
     this.apiKey = '';
-    this.warehouseService.download(
-      this.userService.getToken(),
-      'TSV_FLAT',
-      'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
-      this.searchQueryService.getQueryFromUrlQueryParams(VIR_FILTER_SHORTCUT_QUERY_PARAMS),
-      this.translate.getCurrentLang(),
-      'AUTHORITIES_VIRVA_GEOAPI_KEY',
-      {
-        dataUsePurpose: [req.reasonEnum, req.reason].filter(r => !!r).join(': '),
-        apiKeyExpires: req.expiration
-      }
-    ).subscribe(res => {
+    // The endpoint is not documented by laji-api's OpenAPI document.
+    this.api.post('/warehouse/query/download' as any, { query: {
+      downloadFormat: 'TSV_FLAT',
+      downloadIncludes: 'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
+      downloadType: 'AUTHORITIES_VIRVA_GEOAPI_KEY',
+      dataUsePurpose: [req.reasonEnum, req.reason].filter(r => !!r).join(': '),
+      apiKeyExpires: req.expiration,
+      ...VIR_FILTER_SHORTCUT_QUERY_PARAMS,
+    } }).subscribe(res => {
       this.apiKeyLoading = false;
       this.apiKey = res.apiKey;
       this.cd.markForCheck();


### PR DESCRIPTION
Api client infers the correct content type from the used response type option (defaults to json).

Fixes the issue when the open api doc has several response content types, like warehouse endpoints have:

```
...
        "responses": {
          "200": {
            "description": "Succesful query. Schema varies based on content-type of the response.",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/WarehouseDwQuery_ListResponse"
                }
              },
              "application/geo+json": {
                "schema": {
                  "type": "string"
                }
              },
              "application/xml": {
                "schema": {
                  "type": "string"
                }
              },
              "application/rdf+xml": {
                "schema": {
                  "type": "string"
                }
              }
            }
          },

```

Without the fix, the response type is union of all the possible content types (in practice warehouse result has always ` | string`).

Migrated also some of the warehouse queries to use  the new api client.