### PR TITLE
Api-client migrations

### DIFF
--- a/projects/laji/src/app/+observation/download/observation-download.component.ts
+++ b/projects/laji/src/app/+observation/download/observation-download.component.ts
@@ -40,6 +40,8 @@ import { GeoConvertService, isGeoConvertError } from '../../shared/service/geo-c
 import { DialogService } from '../../shared/service/dialog.service';
 import { ModalRef, ModalService } from 'projects/laji-ui/src/lib/modal/modal.service';
 import { PlatformService } from '../../root/platform.service';
+import { paths } from 'projects/laji-api-client-b/generated/api';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 
 enum RequestStatus {
@@ -106,6 +108,7 @@ export class ObservationDownloadComponent implements OnDestroy {
   private gisDownloadGeometryField = 'gathering.conversions.wgs84WKT';
 
   constructor(
+    private api: LajiApiClientBService,
     private platformService: PlatformService,
     public searchQuery: SearchQueryService,
     public userService: UserService,
@@ -229,45 +232,67 @@ export class ObservationDownloadComponent implements OnDestroy {
   }
 
   makePrivateRequest() {
-    this.makeRequest('downloadApprovalRequest');
+    const type = 'downloadApprovalRequest';
+    if (this.requests[type] === RequestStatus.loading || this.requests[type] === RequestStatus.done) {
+      return;
+    }
+    this.requests[type] = RequestStatus.loading;
+    const queryParams = {
+      downloadFormat: 'TSV_FLAT',
+      downloadIncludes: 'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
+    };
+    this.searchQuery.getURLSearchParams(this.query, queryParams);
+    this.api.post(
+      '/warehouse/private-query/downloadApprovalRequest' as any,
+      { query: queryParams }
+    ).subscribe(
+      () => {
+        this.toastsService.showSuccess(
+          this.translate.instant('result.load.thanksRequest'),
+          undefined,
+          {timeOut: 0, closeButton: true}
+        );
+        this.requests[type] = RequestStatus.done;
+        this.closeModal();
+        this.cd.markForCheck();
+      },
+      (err: any) => {
+        this.requests[type] = RequestStatus.error;
+        this.toastsService.showError(this.translate.instant(err?.status === 429 ?
+          'observation.download.limitExceededException' :
+          'observation.download.error'
+        ));
+        this.logger.warn('Failed to make download request', err);
+        this.cd.markForCheck();
+      }
+    );
   }
 
   makePublicRequest(requireReason = false) {
     if (requireReason && !this.reason) {
       return;
     }
-    this.makeRequest('download');
-  }
 
-  makeRequest(type: string) {
+    const type = 'download';
     if (this.requests[type] === RequestStatus.loading || this.requests[type] === RequestStatus.done) {
       return;
     }
     this.requests[type] = RequestStatus.loading;
-    this.userService.getToken();
-    (this.warehouseService as any)[type](
-      this.userService.getToken(),
-      'TSV_FLAT',
-      'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
-      this.query,
-      this.translate.getCurrentLang(),
-      undefined,
-      {
-        dataUsePurpose: [this.reasonEnum, this.reason].filter(r => !!r).join(': ')
-      }
+
+    const queryParams = {
+      downloadFormat: 'TSV_FLAT',
+      downloadIncludes: 'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
+      dataUsePurpose: [this.reasonEnum, this.reason].filter(r => !!r).join(': ')
+    };
+    this.searchQuery.getURLSearchParams(this.query, queryParams);
+    this.api.post(
+      '/warehouse/query/download' as any,
+      { query: queryParams }
     ).subscribe(
       () => {
-        if (type === 'downloadApprovalRequest') {
-          this.toastsService.showSuccess(
-            this.translate.instant('result.load.thanksRequest'),
-            undefined,
-            {timeOut: 0, closeButton: true}
-          );
-        } else {
-          this.toastsService.showSuccess(
-            this.translate.instant('result.load.thanksPublic')
-          );
-        }
+        this.toastsService.showSuccess(
+          this.translate.instant('result.load.thanksPublic')
+        );
         this.requests[type] = RequestStatus.done;
         this.closeModal();
         this.cd.markForCheck();
@@ -328,27 +353,29 @@ export class ObservationDownloadComponent implements OnDestroy {
   onApiKeyRequest(req: ApiKeyRequest) {
     this.apiKeyLoading = true;
     this.apiKey = '';
-    this.warehouseService.download(
-      this.userService.getToken(),
-      'TSV_FLAT',
-      'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
-      this.query,
-      this.translate.getCurrentLang(),
-      'AUTHORITIES_API_KEY',
-      {
-        dataUsePurpose: [req.reasonEnum, req.reason].filter(r => !!r).join(': '),
-        apiKeyExpires: req.expiration
-      }
-    ).subscribe(res => {
-      this.apiKeyLoading = false;
-      this.apiKey = res.apiKey;
-      this.cd.markForCheck();
-    }, err => {
-      this.logger.error('Apikey request failed', err);
-      this.apiKeyLoading = false;
-      this.apiKey = '';
-      this.cd.markForCheck();
-    });
+
+    const queryParams = {
+      downloadFormat: 'TSV_FLAT',
+      downloadIncludes: 'DOCUMENT_FACTS,GATHERING_FACTS,UNIT_FACTS',
+      downloadType: 'AUTHORITIES_API_KEY',
+      dataUsePurpose: [req.reasonEnum, req.reason].filter(r => !!r).join(': '),
+      apiKeyExpires: req.expiration,
+    };
+    this.searchQuery.getURLSearchParams(this.query, queryParams);
+    this.api.post(
+      '/warehouse/query/download' as any,
+      { query: queryParams }
+    ).subscribe(
+      (res: any) => {
+        this.apiKeyLoading = false;
+        this.apiKey = res.apiKey;
+        this.cd.markForCheck();
+      }, err => {
+        this.logger.error('Apikey request failed', err);
+        this.apiKeyLoading = false;
+        this.apiKey = '';
+        this.cd.markForCheck();
+      });
   }
 
   openColumnSelectModal() {

--- a/projects/laji/src/app/+observation/download/observation-download.component.ts
+++ b/projects/laji/src/app/+observation/download/observation-download.component.ts
@@ -13,7 +13,6 @@ import {
 import { SearchQueryService } from '../search-query.service';
 import { UserSettingsResultList, UserService } from '../../shared/service/user.service';
 import { TranslateService } from '@ngx-translate/core';
-import { WarehouseApi } from '../../shared/api/WarehouseApi';
 import { ToastsService } from '../../shared/service/toasts.service';
 import { Logger } from '../../shared/logger/logger.service';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
@@ -30,7 +29,7 @@ import {
 import { ColumnSelector } from '../../shared/columnselector/ColumnSelector';
 import { ObservationTableColumn } from '../../shared-modules/observation-result/model/observation-table-column';
 import { IColumns } from '../../shared-modules/datatable/service/observation-table-column.service';
-import { ObservationDataService } from '../observation-data.service';
+import { DataFetchMode, ObservationDataService } from '../observation-data.service';
 import { environment } from '../../../environments/environment';
 import { DownloadService } from '../../shared/service/download.service';
 import { ApiKeyRequest } from '../../shared-modules/download-modal/apikey-modal/apikey-modal.component';
@@ -40,7 +39,6 @@ import { GeoConvertService, isGeoConvertError } from '../../shared/service/geo-c
 import { DialogService } from '../../shared/service/dialog.service';
 import { ModalRef, ModalService } from 'projects/laji-ui/src/lib/modal/modal.service';
 import { PlatformService } from '../../root/platform.service';
-import { paths } from 'projects/laji-api-client-b/generated/api';
 import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 
 
@@ -63,6 +61,7 @@ export class ObservationDownloadComponent implements OnDestroy {
   @ViewChild(DownloadComponent) downloadTypeSelectModal!: DownloadComponent;
   @ViewChild('downloadModal', { static: true }) downloadModal!: TemplateRef<any>;
 
+  @Input() mode: DataFetchMode = 'unit';
   @Input() unitCount!: number;
   @Input() speciesCount!: number;
   @Input() taxaLimit = 3000;
@@ -115,7 +114,6 @@ export class ObservationDownloadComponent implements OnDestroy {
     public translate: TranslateService,
     private observationResultService: ObservationResultService,
     private toastsService: ToastsService,
-    private warehouseService: WarehouseApi,
     private logger: Logger,
     private cd: ChangeDetectorRef,
     private tableColumnService: TableColumnService<ObservationTableColumn, IColumns>,
@@ -324,7 +322,7 @@ export class ObservationDownloadComponent implements OnDestroy {
       this._originalQuery,
       this.tableColumnService.getSelectFields(selected, this.query),
       [],
-      this.translate.getCurrentLang(),
+      this.mode,
       true,
       environment.type === Global.type.vir || isGisDownload,
       [this.reasonEnum, this.reason].filter(r => !!r).join(': ')

--- a/projects/laji/src/app/+observation/main-result/main-result.component.html
+++ b/projects/laji/src/app/+observation/main-result/main-result.component.html
@@ -19,6 +19,7 @@
       @if (aggrQuery) {
         <laji-observation-table
           #aggregatedDataTable
+          [mode]="dataMode"
           (rowSelect)="onAggregateSelect($event)"
           (selectChange)="setAggregateBy($event)"
           (resetColumns)="resetSelectedFields()"
@@ -37,6 +38,7 @@
       <div>
         @if (listQuery) {
           <laji-observation-table
+            [mode]="dataMode"
             (rowSelect)="showDocument($event)"
             (selectChange)="setSelectedFields($event)"
             (resetColumns)="resetSelectedFields()"

--- a/projects/laji/src/app/+observation/main-result/main-result.component.ts
+++ b/projects/laji/src/app/+observation/main-result/main-result.component.ts
@@ -18,6 +18,7 @@ import { DocumentViewerFacade } from '../../shared-modules/document-viewer/docum
 import { Subscription } from 'rxjs';
 import { startWith, tap } from 'rxjs/operators';
 import { LocalStorageService } from 'ngx-webstorage';
+import { DataFetchMode } from '../observation-data.service';
 
 const DEFAULT_PAGE_SIZE = 1000;
 
@@ -35,6 +36,7 @@ export class MainResultComponent implements OnInit, OnChanges {
 
   @ViewChild('aggregatedDataTable') public aggregatedDataTable?: ObservationTableComponent;
 
+  @Input() dataMode: DataFetchMode = 'unit';
   @Input({ required: true }) query!: WarehouseQueryInterface;
   @Input({ required: true }) visible!: boolean;
 

--- a/projects/laji/src/app/+observation/observation-filters/observation-filters.component.html
+++ b/projects/laji/src/app/+observation/observation-filters/observation-filters.component.html
@@ -2,6 +2,7 @@
   <div class="col-sm-6">
     <h4>{{ 'observation.filterBy.recordBasis' | translate }}</h4>
     <laji-observation-table
+      [mode]="dataMode"
       [visible]="visible"
       (rowSelect)="onRecordBasis($event)"
       [showHeader]="false"
@@ -18,6 +19,7 @@
   <div class="col-sm-6">
     <h4>{{ 'observation.filterBy.image' | translate }}</h4>
     <laji-observation-table
+      [mode]="dataMode"
       [visible]="visible"
       (rowSelect)="onMediaSelect()"
       [showHeader]="false"
@@ -36,6 +38,7 @@
   <div class="col-sm-12">
     <h4>{{ 'observation.filterBy.collectionId' | translate }}</h4>
     <laji-observation-table
+      [mode]="dataMode"
       [visible]="visible"
       (rowSelect)="onCollectionSelect($event)"
       [height]="'350px'"

--- a/projects/laji/src/app/+observation/observation-filters/observation-filters.component.ts
+++ b/projects/laji/src/app/+observation/observation-filters/observation-filters.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
 import { IdService } from '../../shared/service/id.service';
+import { DataFetchMode } from '../observation-data.service';
 
 @Component({
     selector: 'laji-observation-filters',
@@ -8,7 +9,7 @@ import { IdService } from '../../shared/service/id.service';
     standalone: false
 })
 export class ObservationFiltersComponent {
-
+  @Input() dataMode: DataFetchMode = 'unit';
   @Input({ required: true }) query!: WarehouseQueryInterface;
   @Input({ required: true }) visible!: boolean;
   @Input() onlyCount = true;

--- a/projects/laji/src/app/+observation/result-front/observation-result-front.component.html
+++ b/projects/laji/src/app/+observation/result-front/observation-result-front.component.html
@@ -11,6 +11,7 @@
 
   <h4>{{ 'observation.front.sources' | translate }}</h4>
   <laji-observation-table
+    [mode]="dataMode"
     [height]="'350px'"
     [pageSize]="100"
     [query]="query"

--- a/projects/laji/src/app/+observation/result-front/observation-result-front.component.ts
+++ b/projects/laji/src/app/+observation/result-front/observation-result-front.component.ts
@@ -1,5 +1,6 @@
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
+import { DataFetchMode } from '../observation-data.service';
 
 @Component({
     selector: 'laji-observation-result-front',
@@ -9,5 +10,6 @@ import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterf
     standalone: false
 })
 export class ObservationResultFrontComponent {
+  @Input() dataMode: DataFetchMode = 'unit';
   @Input({ required: true }) query!: WarehouseQueryInterface;
 }

--- a/projects/laji/src/app/+observation/result-list/observation-result-list.component.html
+++ b/projects/laji/src/app/+observation/result-list/observation-result-list.component.html
@@ -1,4 +1,5 @@
 <laji-observation-table
+  [mode]="resultBase"
   [luFillHeight]="{ minHeight: 500 }"
   class="d-block"
   #datatable
@@ -17,4 +18,3 @@
   [required]="requiredFields"
   [allAggregateFields]="[]"
 ></laji-observation-table>
-

--- a/projects/laji/src/app/+observation/result/observation-result.component.html
+++ b/projects/laji/src/app/+observation/result/observation-result.component.html
@@ -125,6 +125,7 @@
             <div class="row">
               <div class="col-sm-12">
                 <laji-observation-table
+                  [mode]="dataMode"
                   [visible]="activeTab === 'species'"
                   [pageSize]="100"
                   [height]="'calc(80vh - 40px)'"
@@ -211,7 +212,7 @@
           </div>
           <div class="form-group spacer">
             <div class="col-lg-12">
-              <laji-observation-filters [visible]="activeTab === 'statistics'" [query]="activeQuery" [onlyCount]="onlyCount" (queryChange)="activeQueryChange.emit($event)"></laji-observation-filters>
+              <laji-observation-filters [dataMode]="dataMode" [visible]="activeTab === 'statistics'" [query]="activeQuery" [onlyCount]="onlyCount" (queryChange)="activeQueryChange.emit($event)"></laji-observation-filters>
             </div>
           </div>
           <div class="lu">
@@ -240,6 +241,7 @@
       <lu-tab [heading]="'haseka.ownSubmissions.title' | translate">
         <div>
           <laji-observation-table-own-documents
+            [mode]="dataMode"
             [visible]="true"
             [pageSize]="100"
             [height]="'calc(80vh - 40px)'"
@@ -257,17 +259,19 @@
 }
 @if (mode === 'all' && !activeTab) {
   <laji-observation-result-front
+    [dataMode]="dataMode"
     [query]="activeQuery"
   ></laji-observation-result-front>
 }
 
 @if (loadedModes.isLoaded('finnish') && visible.finnish) {
   <div [hidden]="mode !== 'finnish'">
-    <laji-main-result [query]="activeQuery" [visible]="mode === 'finnish'"></laji-main-result>
+    <laji-main-result [dataMode]="dataMode" [query]="activeQuery" [visible]="mode === 'finnish'"></laji-main-result>
   </div>
 }
 
 <laji-observation-download
+  [mode]="dataMode"
   [settings]="listSettings"
   (settingsChange)="listSettingsChange.emit($event)"
   [speciesCount]="speciesCount"

--- a/projects/laji/src/app/+observation/result/observation-result.component.ts
+++ b/projects/laji/src/app/+observation/result/observation-result.component.ts
@@ -19,6 +19,7 @@ import G from 'geojson';
 import * as Util from '../../shared/utils';
 import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 import { geoJSONToWKT } from '@luomus/laji-map/lib/utils';
+import { DataFetchMode } from '../observation-data.service';
 
 const tabOrder = ['list', 'map', 'images', 'species', 'statistics', 'annotations', 'own'];
 @Component({
@@ -42,6 +43,7 @@ export class ObservationResultComponent implements OnChanges {
     annotations: true,
     own: true
   };
+  @Input() dataMode: DataFetchMode = 'unit';
   @Input() set visible(v: VisibleSections) {
     this._visible = v;
     const tabs = Object.entries(v).filter(([key, val]) => val && tabOrder.includes(key)).map(([key, val]) => key);

--- a/projects/laji/src/app/+observation/view/observation-view.component.html
+++ b/projects/laji/src/app/+observation/view/observation-view.component.html
@@ -3,6 +3,7 @@
     <main>
       <laji-technical-news></laji-technical-news>
       <laji-observation-result
+        [dataMode]="formType"
         [resultBase]="formType"
         [visible]="visible"
         [skipUrlParameters]="skipUrlParameters"

--- a/projects/laji/src/app/shared-modules/observation-result/observation-table-own-documents/observation-table-own-documents.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-table-own-documents/observation-table-own-documents.component.ts
@@ -37,6 +37,7 @@ import { ToQNamePipe } from 'projects/laji/src/app/shared/pipe/to-qname.pipe';
 import { RowDocument } from '../../own-submissions/own-datatable/own-datatable.component';
 import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-document.service';
 import { components } from 'projects/laji-api-client-b/generated/api';
+import { DataFetchMode } from '../../../+observation/observation-data.service';
 
 type Document = components['schemas']['store-document'];
 
@@ -52,6 +53,7 @@ type Document = components['schemas']['store-document'];
 export class ObservationTableOwnDocumentsComponent implements OnInit, OnChanges, OnDestroy {
   @ViewChild('dataTableOwn', { static: true }) public datatable?: DatatableOwnSubmissionsComponent;
 
+  @Input() mode: DataFetchMode = 'unit';
   @Input() query!: WarehouseQueryInterface;
   @Input() overrideInQuery!: WarehouseQueryInterface;
   @Input() pageSize?: number;
@@ -414,7 +416,7 @@ export class ObservationTableOwnDocumentsComponent implements OnInit, OnChanges,
       this.tableColumnService.getSelectFields(this.columnSelector.columns, this.query),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       [...this.orderBy, this.defaultOrder!],
-      this.lang
+      this.mode
     ).pipe(
       switchMap(data => this.exportService.exportFromData(data.results, columns, type as BookType, 'laji-data'))
     ).subscribe(

--- a/projects/laji/src/app/shared-modules/observation-result/observation-table/observation-table.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-table/observation-table.component.ts
@@ -29,6 +29,7 @@ import { BookType } from 'xlsx';
 import { Global } from '../../../../environments/global';
 import { IColumns } from '../../datatable/service/observation-table-column.service';
 import { ObservationTableSettingsComponent } from './observation-table-settings.component';
+import { DataFetchMode } from '../../../+observation/observation-data.service';
 
 const replaceColSortLang = (sort: string, lang: string) => (
   (sort || '').replace(/%longLang%/g, {
@@ -62,6 +63,7 @@ export class ObservationTableComponent implements OnInit, OnChanges {
   @ViewChild('dataTable', { static: true }) public datatable?: DatatableComponent;
   @ViewChild(ObservationTableSettingsComponent, { static: true }) public settingsModal!: ObservationTableSettingsComponent;
 
+  @Input() mode: DataFetchMode = 'unit';
   @Input() query!: WarehouseQueryInterface;
   @Input() pageSize?: number;
   @Input() page = 1;
@@ -291,14 +293,17 @@ export class ObservationTableComponent implements OnInit, OnChanges {
       this.lang,
       this.useStatistics
     );
+    const orderBy = [...this.orderBy];
+    if (this.defaultOrder) {
+      orderBy.push(this.defaultOrder);
+    }
     const list$ = this.resultService.getList(
       this.query,
       this.getSelectFields(this.columnSelector.columns, this.query),
       page,
       this.pageSize,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      [...this.orderBy, this.defaultOrder!],
-      this.lang
+      this.mode,
+      orderBy
     );
 
     this.fetchSub = (this.isAggregate ? aggregate$ : list$)
@@ -332,7 +337,7 @@ export class ObservationTableComponent implements OnInit, OnChanges {
       this.tableColumnService.getSelectFields(this.columnSelector.columns, this.query),
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       [...this.orderBy, this.defaultOrder!],
-      this.lang
+      this.mode
     ).pipe(
       switchMap(data => this.exportService.exportFromData(data.results, columns, type as BookType, 'laji-data'))
     ).subscribe(

--- a/projects/laji/src/app/shared-modules/observation-result/service/observation-result.service.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/service/observation-result.service.ts
@@ -28,7 +28,9 @@ import { TableColumnService } from '../../datatable/service/table-column.service
 import { ObservationTableColumn } from '../model/observation-table-column';
 import { DatatableUtil } from '../../datatable/service/datatable-util.service';
 import { IColumns } from '../../datatable/service/observation-table-column.service';
-import { UserService } from '../../../shared/service/user.service';
+import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
+import { SearchQueryService } from '../../../+observation/search-query.service';
+import { DataFetchMode } from '../../../+observation/observation-data.service';
 
 interface IInternalObservationTableColumn extends ObservationTableColumn {
   _paths: string[];
@@ -57,9 +59,10 @@ export class ObservationResultService {
 
   constructor(
     private warehouseApi: WarehouseApi,
+    private api: LajiApiClientBService,
+    private searchQuery: SearchQueryService,
     private tableColumnService: TableColumnService<ObservationTableColumn, IColumns>,
     private datatableUtil: DatatableUtil,
-    private userService: UserService
   ) { }
 
   getAggregate(
@@ -108,22 +111,30 @@ export class ObservationResultService {
     selected: string[],
     page: number,
     pageSize: number,
+    mode: DataFetchMode,
     orderBy: string[] = [],
-    lang: string
   ): Observable<PagedResult<any>> {
-    const key = JSON.stringify(query) + [this.prepareFields(selected, false).join(','), orderBy.join(','), lang, page, pageSize].join(':');
+    const key = JSON.stringify(query) + [this.prepareFields(selected, false).join(','), orderBy.join(','), page, pageSize].join(':');
     if (this.key !== key) {
       this.key = key;
       this.data = undefined;
     }
     if (!this.data) {
-      this.data = this.warehouseApi.warehouseQueryListGet(
-        {...query, cache: (query.cache || WarehouseApi.isEmptyQuery(query))},
-        [...this.prepareFields(selected), ...this.idFields],
+      const cache = (query.cache || WarehouseApi.isEmptyQuery(query));
+      const preparedFields = [...this.prepareFields(selected), ...this.idFields];
+      const queryParams = {
+        ...query,
+        cache,
+        aggregateBy: preparedFields,
+        selected: preparedFields,
         orderBy,
         pageSize,
         page
-      ).pipe(
+      };
+      const obs$ = mode === 'unit'
+        ? this.api.get('/warehouse/query/unit/list', { query: queryParams as any })
+        : this.api.get('/warehouse/query/sample/list', { query: queryParams as any });
+      this.data = obs$.pipe(
         retryWhen(errors => errors.pipe(delay(1000), take(3), concatWith(throwError(() => errors)), ))).pipe(
         map(data => Util.clone(data))).pipe(
         switchMap(data => this.openValues(data, selected)),
@@ -137,7 +148,7 @@ export class ObservationResultService {
     query: WarehouseQueryInterface,
     selected: string[],
     orderBy: string[],
-    lang: string,
+    mode: DataFetchMode,
     sendDownloadMark = false,
     blockOnDownloadMarkFail = false,
     reason = ''
@@ -147,12 +158,12 @@ export class ObservationResultService {
       query,
       selected,
       orderBy,
-      lang
+      mode
     );
 
     if (sendDownloadMark) {
       if (blockOnDownloadMarkFail) {
-        return this.sendDownloadMark(query, lang, reason).pipe(
+        return this.sendDownloadMark(query, reason).pipe(
           switchMap((download) => all$.pipe(
             map(all => ({
               id: IdService.getId(download.id),
@@ -161,41 +172,38 @@ export class ObservationResultService {
           ))
         );
       }
-      this.sendDownloadMark(query, lang, reason).pipe(
+      this.sendDownloadMark(query, reason).pipe(
         catchError(() => of(null))
       ).subscribe();
     }
     return all$.pipe(map(all => ({id: null, results: all})));
   }
 
-  private sendDownloadMark(query: WarehouseQueryInterface, lang: string, reason: string): Observable<any> {
-    return this.warehouseApi.download(
-      this.userService.getToken(),
-      '',
-      '',
-      query,
-      lang,
-      'LIGHTWEIGHT',
-      {
-        dataUsePurpose: reason
-      }
-    );
+  private sendDownloadMark(query: WarehouseQueryInterface, reason: string): Observable<any> {
+    const queryParams = {
+      downloadFormat: '',
+      downloadIncludes: '',
+      downloadType: 'LIGHTWEIGHT',
+      dataUsePurpose: reason
+    };
+    this.searchQuery.getURLSearchParams(query, queryParams);
+    return this.api.post('/warehouse/query/download' as any, { query: queryParams });
   }
 
   private _getAll(
     query: WarehouseQueryInterface,
     selected: string[],
     orderBy: string[],
-    lang: string,
+    mode: DataFetchMode,
     data: any[] = [],
     page = 1,
-    pageSize = 1000
+    pageSize = 1000,
   ): Observable<any> {
-    return this.getList(query, selected, page, pageSize, orderBy, lang).pipe(
+    return this.getList(query, selected, page, pageSize, mode, orderBy).pipe(
       switchMap(result => {
         data.push(...result.results);
         if (result.lastPage > result.currentPage) {
-          return this._getAll(query, selected, orderBy, lang, data, result.currentPage + 1);
+          return this._getAll(query, selected, orderBy, mode, data, result.currentPage + 1);
         } else {
           return of(data);
         }


### PR DESCRIPTION
~~Might need merging with #970 , I'll take a look~~

There are several more endpoints that aren't present in the openapi spec so `as any` is used