### PR TITLE
Use fi-locale to sort municipalities [Fixes #760]

### DIFF
--- a/projects/laji/src/app/shared-modules/select/metadata-select/metadata-select.component.ts
+++ b/projects/laji/src/app/shared-modules/select/metadata-select/metadata-select.component.ts
@@ -135,7 +135,7 @@ export class MetadataSelectComponent implements OnChanges, OnDestroy, ControlVal
       switchMap(options => this.mapToWarehouse ? this.optionsToWarehouseID(options) : of(options)),
       map(options => this.labelAsValue ? options.map(o => ({...o, id: o.value})) : options),
       map(options => this.firstOptions?.length > 0 ? this.sortOptionsByAnotherList(options) : (
-        this._shouldSort ? options.sort((a, b) => a.value && b.value ? a.value.localeCompare(b.value) : 0) : options
+        this._shouldSort ? options.sort((a, b) => a.value && b.value ? a.value.localeCompare(b.value, 'fi') : 0) : options
       ))
     ).subscribe(options => {
         this.setOptions(options);
@@ -275,12 +275,12 @@ export class MetadataSelectComponent implements OnChanges, OnDestroy, ControlVal
       const hasB = this.firstOptions.includes(b.id);
       if (hasA || hasB) {
         if (hasA && hasB) {
-          return a.value.localeCompare(b.value);
+          return a.value.localeCompare(b.value, 'fi');
         } else {
           return hasA ? -1 : 1;
         }
       }
-      return a.value.localeCompare(b.value);
+      return a.value.localeCompare(b.value, 'fi');
     });
   }
 


### PR DESCRIPTION
Issue: https://github.com/luomus/laji/issues/760
Branch: https://760.dev.laji.fi/observation/list

Use fi-locale to sort municipalities with nordic letters.