### PR TITLE
Fix informal taxon group select

### DIFF
--- a/projects/laji/src/app/shared-modules/extended-group-select/observation-extended-group-select.component.ts
+++ b/projects/laji/src/app/shared-modules/extended-group-select/observation-extended-group-select.component.ts
@@ -1,10 +1,20 @@
-import { ChangeDetectionStrategy, Component, EventEmitter, forwardRef, Input, Output, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  forwardRef,
+  Input,
+  Output,
+  OnInit,
+  OnChanges
+} from '@angular/core';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { LajiApiClientBService } from 'projects/laji-api-client-b/src/laji-api-client-b.service';
 import { components } from 'projects/laji-api-client-b/generated/api.d';
 import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterface';
 import { map, Observable, of, shareReplay } from 'rxjs';
 import { SelectedOption, TreeOptionsChangeEvent, TreeOptionsNode } from '../tree-select/tree-select.component';
+import { equalsArray } from '../../shared/utils';
 
 type InformalTaxonGroup = components['schemas']['store-informalTaxonGroup'];
 
@@ -26,7 +36,7 @@ export const OBSERVATION_GROUP_SELECT_VALUE_ACCESSOR: any = {
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: false
 })
-export class ObservationExtendedGroupSelectComponent implements OnInit {
+export class ObservationExtendedGroupSelectComponent implements OnInit, OnChanges {
 
   @Input() query!: WarehouseQueryInterface;
   @Input() modalButtonLabel = '';
@@ -53,6 +63,15 @@ export class ObservationExtendedGroupSelectComponent implements OnInit {
   ngOnInit() {
     this.groupsTree$ = this.initGroupTree().pipe(shareReplay(1));
     this.groups$ = this.initSelectionGroups(this.includedOptions, this.excludedOptions);
+  }
+
+  ngOnChanges() {
+    const [ includedOptions, excludedOptions ] = this.getOptions();
+    if (!equalsArray(this.includedOptions, includedOptions) || !equalsArray(this.excludedOptions, excludedOptions)) {
+      this.includedOptions = includedOptions;
+      this.excludedOptions = excludedOptions;
+      this.groups$ = this.initSelectionGroups(this.includedOptions, this.excludedOptions);
+    }
   }
 
   initGroupTree(): Observable<TreeOptionsNode[]> {


### PR DESCRIPTION
Bug: Go to https://beta.laji.fi/observation/map?informalTaxonGroupId=MVL.26&countryId=ML.206 -> Informal groups filter doesn't show the group "Reptiles and amphibians" active

The `ngOnChanges` function was probably accidentally removed from the `ObservationExtendedGroupSelectComponent` when refactoring (it was [in this removed component](https://github.com/luomus/laji/blob/f4be1a0b20e6814806148e3fa88ac95183646256/projects/laji/src/app/shared-modules/extended-group-select/extended-group-select.component.ts#L51) this component used to extend). Returning it fixes the bug