### PR TITLE
Fix observation box coordinate filter

### DIFF
--- a/projects/laji/src/app/observation/search-query.service.ts
+++ b/projects/laji/src/app/observation/search-query.service.ts
@@ -329,6 +329,8 @@ export class SearchQueryService implements SearchQueryInterface {
       delete result.observerPersonToken;
     }
 
+    delete result._coordinatesIntersection;
+
     return result;
   }
 

--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
@@ -366,8 +366,12 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
       return false;
     }
 
-    const bounds = (window.L as any).geoJSON(convertLajiEtlCoordinatesToGeometry(query.coordinates)).getBounds();
-    return this.lajiMap?.map.map.getBounds().contains(bounds);
+    if (window?.L) {
+      const bounds = (window.L as any).geoJSON(convertLajiEtlCoordinatesToGeometry(query.coordinates)).getBounds();
+      return this.lajiMap?.map.map.getBounds().contains(bounds);
+    } else {
+      return false;
+    }
   }
 
   private addViewPortCoordinatesParams(query: WarehouseQueryInterface, bounds?: any) {
@@ -513,6 +517,8 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
 
     this.addVisualizationParams(query);
     this.addViewPortCoordinatesParams(query, bounds);
+
+    delete query._coordinatesIntersection;
 
     return query;
   }


### PR DESCRIPTION
- missing window issue (probably related to hydration)?
- `_coordinatesIntersection` private property was exposed to api query params... I think this whole property is a huge red flag, but I took the easy way out and just deleted it from the api query