### PR TITLE
Fix grc filter form datepicker

### DIFF
--- a/projects/laji/src/app/observation/form-sample/form-sample.component.html
+++ b/projects/laji/src/app/observation/form-sample/form-sample.component.html
@@ -165,8 +165,7 @@
     </laji-info>
       <laji-datepicker
         [(ngModel)]="formQuery.timeStart"
-        (dateSelect)="onFormQueryChange()"
-        (change)="onFormQueryChange()"
+        (ngModelChange)="onFormQueryChange()"
         name="timeStart"></laji-datepicker>
     </div>
   </div>
@@ -174,9 +173,8 @@
     <div class="col-sm-12">
       <laji-datepicker
         [(ngModel)]="formQuery.timeEnd"
+        (ngModelChange)="onFormQueryChange()"
         [toLastOfYear]="true"
-        (dateSelect)="onFormQueryChange()"
-        (change)="onFormQueryChange()"
         name="timeEnd"></laji-datepicker>
     </div>
   </div>


### PR DESCRIPTION
onFormQueryChange was being called before the ngModel update, resetting the datepicker to the previous value