### PR TITLE
Fix line transect named place creation [Fixes #1001]

### DIFF
--- a/projects/laji/src/app/project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -287,7 +287,9 @@ export class NpEditFormComponent implements OnInit {
           prepopulatedNamedPlace[area] = undefined;
         }
       });
-      prepopulatedNamedPlace.collectionID = documentForm.collectionID;
+      if (placeForm.id !== 'MHL.103') {
+        prepopulatedNamedPlace.collectionID = documentForm.collectionID;
+      }
       return prepopulatedNamedPlace;
     }
   }

--- a/projects/laji/src/app/project-form/form/named-place/np-edit-form/np-edit-form.component.ts
+++ b/projects/laji/src/app/project-form/form/named-place/np-edit-form/np-edit-form.component.ts
@@ -287,7 +287,8 @@ export class NpEditFormComponent implements OnInit {
           prepopulatedNamedPlace[area] = undefined;
         }
       });
-      if (placeForm.id !== 'MHL.103') {
+      const allowedCollectionIdValues = (placeForm.uiSchema?.collectionID as any)?.['ui:options']?.enumOptions?.map((o: any) => o.value);
+      if (!allowedCollectionIdValues || allowedCollectionIdValues.includes(documentForm.collectionID)) {
         prepopulatedNamedPlace.collectionID = documentForm.collectionID;
       }
       return prepopulatedNamedPlace;


### PR DESCRIPTION
https://github.com/luomus/laji/issues/1001
https://1001.dev.laji.fi/project/MHL.1/form/MHL.27/places/new?birdAssociationArea=ML.1092

The documentForm.collectionID on MHL.103 is excluded from allowed named place collections on form schema, so now it won't be added as collectionID on that form.