### PR TITLE
Fix own observations qualityIssues -filter [Fixes #1005]

### DIFF
--- a/projects/laji/src/app/observation/form/own-observations-filter/own-observations-filter.component.html
+++ b/projects/laji/src/app/observation/form/own-observations-filter/own-observations-filter.component.html
@@ -31,8 +31,8 @@
 </div>
 @if (asEditor || asObserver || includeQualityIssues) {
   <laji-select
-    [selected]="includeQualityIssues ? [includeQualityIssues] : []"
-    (selectedChange)="onIncludeQualityIssuesChange($event[0])"
+    [selected]="includeQualityIssues"
+    (selectedChange)="onIncludeQualityIssuesChange($any($event))"
     [multiple]="false"
     [useFilter]="false"
     [title]="'observation.form.qualityIssues' | translate"


### PR DESCRIPTION
https://github.com/luomus/laji/issues/1005
(login first: https://1005.dev.laji.fi)
https://1005.dev.laji.fi/observation/list?qualityIssues=ONLY_ISSUES&observerPersonToken=true


Now selectedChange output is $event instead of $event[0], which is for example "qualityIssues=ONLY_ISSUES" instead of "qualityIssues=O".