### PR TITLE
confirm persontoken validity before setting api client to use it

### DIFF
--- a/projects/laji-api-client/src/laji-api-client.service.ts
+++ b/projects/laji-api-client/src/laji-api-client.service.ts
@@ -235,7 +235,7 @@ ExtractContentByResponseType<
     );
   }
 
-  protected getHeaders(lang: string, langFallback = true, personToken?: string) {
+  protected getFallbackHeaders(lang: string, langFallback = true, personToken?: string) {
     const headers: Record<string, string> = {
 			'API-Version': '1',
 			'Accept-Language': lang,
@@ -250,14 +250,14 @@ ExtractContentByResponseType<
   }
 
   private getRequestOptions(
-    queryParams: any,
+    params: any,
     requestBody: any,
     lang: string,
     langFallback = true,
-    personToken?: string,
-    responseType: ResponseType = 'json'
   ) {
-    const params = Object.keys((queryParams || {})).reduce((filteredQueryParams, key) => {
+    const responseType: ResponseType = params?.responseType ?? 'json';
+    const queryParams = params?.query;
+    const newParams = Object.keys((queryParams || {})).reduce((filteredQueryParams, key) => {
       const param = (queryParams || {})[key];
       if (param === undefined) {
         return filteredQueryParams;
@@ -266,8 +266,12 @@ ExtractContentByResponseType<
       return filteredQueryParams;
     }, {} as any);
 
-    const headers = this.getHeaders(lang, langFallback, personToken);
-    return { params, body: requestBody, headers, responseType };
+    const fallbackHeaders = this.getFallbackHeaders(lang, langFallback, this.personToken);
+    const headers = params ? {
+      ...fallbackHeaders,
+      ...params.header
+    } : fallbackHeaders;
+    return { params: newParams, body: requestBody, headers, responseType };
   }
 
   fetch<
@@ -295,7 +299,7 @@ ExtractContentByResponseType<
       return this.http.request(
         method as string,
         requestUrl,
-        this.getRequestOptions((params as any)?.query, requestBody, this.lang, langFallback, this.personToken, params?.responseType)
+        this.getRequestOptions(params, requestBody, this.lang, langFallback)
       ) as any;
     }
 
@@ -320,7 +324,7 @@ ExtractContentByResponseType<
     const obs = this.http.request(
       method,
       requestUrl,
-      this.getRequestOptions((params as any)?.query, requestBody, this.lang, langFallback, this.personToken, params?.responseType)
+      this.getRequestOptions(params, requestBody, this.lang, langFallback)
     ).pipe(
       tap(val => {
         cachedPath?.set(paramsHash, {

--- a/projects/laji/src/app/shared/service/user.service.ts
+++ b/projects/laji/src/app/shared/service/user.service.ts
@@ -212,9 +212,8 @@ export class UserService implements OnDestroy {
       this.setNotLoggedIn();
       return of(false);
     }
-    this.api.setPersonToken(token);
     this.store.next({ ...this.store.value, loginState: { _tag: 'loading' }, user: { _tag: 'loading' } });
-    return this.api.get('/person').pipe(
+    return this.api.get('/person', { header: { 'Person-Token': token } }).pipe(
       httpOkError([404, 400], null),
       retryWithBackoff(300),
       tap(person => {
@@ -224,6 +223,7 @@ export class UserService implements OnDestroy {
         }
         // if person is valid, we have succesfully logged in
         this.persistentState = { ...this.persistentState, loginState: { _tag: 'logged_in', token }};
+        this.api.setPersonToken(token);
         this.store.next({
           ...this.store.value,
           ...this.persistentState,


### PR DESCRIPTION
When the apiclient was updated to auto-fill the persontoken, the token was stored in apiclient before the validity of the token was confirmed as the validity check itself needed the persontoken. Fixed by allowing the apiclient user to overwrite the token header. Now the token is used only for the validity check, and then stored in the apiclient only after the check passes.