### PR TITLE
fix importer coordinates parsing

### DIFF
--- a/projects/laji/src/app/shared-modules/spreadsheet/importer/status-cell/status-cell.component.html
+++ b/projects/laji/src/app/shared-modules/spreadsheet/importer/status-cell/status-cell.component.html
@@ -6,7 +6,7 @@
       </span>
     }
     @case ('valid') {
-      <span class="label label-default" [luPopover]="'No errors' | translate" rootElement="body" placement="right">
+      <span class="label label-default" [luPopover]="valid" rootElement="body" placement="right">
         {{ 'No errors' | translate }}
       </span>
     }
@@ -21,12 +21,18 @@
       </span>
     }
     @case ('ignore') {
-      <span class="label label-warning link" [luPopover]="'excel.skip-row' | translate" rootElement="body" placement="right">
+      <span class="label label-warning link" [luPopover]="ignore" rootElement="body" placement="right">
         {{ 'excel.skip-status' | translate }}
       </span>
     }
   }
 }
+<ng-template #valid>
+  {{ 'No errors' | translate }}
+</ng-template>
 <ng-template #error>
   <laji-error-list [errors]="value!.error" [fields]="fields"></laji-error-list>
+</ng-template>
+<ng-template #ignore>
+  {{ 'excel.skip-row' | translate }}
 </ng-template>

--- a/projects/laji/src/app/shared-modules/spreadsheet/service/mapping.service.ts
+++ b/projects/laji/src/app/shared-modules/spreadsheet/service/mapping.service.ts
@@ -457,6 +457,7 @@ export class MappingService {
     } catch (e) {
       return null;
     }
+    return value;
   }
 
   private getMappedValue(value: any, field: IFormField) {


### PR DESCRIPTION
Regression caused by f953390b9c7a03b11e80c8305967a7083a662528 . `analyzeGeometry` was missing a return value. It appears to have been accidentally removed. The old code also had a path where `value` gets trimmed, but otherwise passed through unchanged, so I left that in. It's a bit difficult to tell what this function is supposed to return exactly since there are no types, but the caller code seems to accept `string` so I guess it's fine

Testable: https://120351835.dev.laji.fi/vihko/tools/import 