### PR TITLE
Fix download requests

### DIFF
--- a/projects/laji/src/app/citable-download/citable-download.component.ts
+++ b/projects/laji/src/app/citable-download/citable-download.component.ts
@@ -44,8 +44,7 @@ export class CitableDownloadComponent implements OnInit {
   ngOnInit() {
     this.downloadRequest$ = this.route.params.pipe(
       map(params => params['id']),
-      tap(id => { this.id = id; }),
-      switchMap(id => this.api.get('/warehouse/downloads/' as any, { path: { id } })),
+      switchMap(id => this.api.get(`/warehouse/downloads/${id}` as any)),
       tap((response: any) => this.updateHeaders(response))
     );
   }


### PR DESCRIPTION
https://34782.dev.laji.fi/citation/HBF.12992

The api call for the download request was missing the id. I assume the path variable didn't work here because the `/warehouse/downloads` is not a public endpoint