### PR TITLE
Remove internal observation search form state from warehouse queries

### DIFF
--- a/projects/laji/src/app/observation/annotations/annotations.component.ts
+++ b/projects/laji/src/app/observation/annotations/annotations.component.ts
@@ -8,6 +8,7 @@ import { AnnotationService } from '../../shared-modules/document-viewer/service/
 import { DeleteOwnDocumentService } from '../../shared/service/delete-own-document.service';
 import { components, paths } from 'projects/laji-api-client/generated/api.d';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
+import { SearchQueryService } from '../search-query.service';
 
 type AnnotationTag = components['schemas']['store-tag'];
 type WarehouseQueryListQuery = paths['/warehouse/query/unit/list']['get']['parameters']['query'];
@@ -52,7 +53,8 @@ export class AnnotationsComponent implements OnInit, OnChanges, OnDestroy {
     private translations: TranslateService,
     private cd: ChangeDetectorRef,
     private annotationService: AnnotationService,
-    private deleteOwnDocument: DeleteOwnDocumentService
+    private deleteOwnDocument: DeleteOwnDocumentService,
+    private searchQuery: SearchQueryService
   ) { }
 
   ngOnInit() {
@@ -126,7 +128,7 @@ export class AnnotationsComponent implements OnInit, OnChanges, OnDestroy {
       'unit.unitId'
     ];
     const query: WarehouseQueryListQuery = {
-      ...this.query as any,
+      ...this.searchQuery.getNormalizedApiQuery(this.query) as any,
       selected,
       orderBy: ['document.createdDate DESC', 'unit.unitId ASC'],
       pageSize: 18,

--- a/projects/laji/src/app/observation/count/observation-count.component.ts
+++ b/projects/laji/src/app/observation/count/observation-count.component.ts
@@ -6,6 +6,7 @@ import { WarehouseQueryInterface } from '../../shared/model/WarehouseQueryInterf
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { paths } from 'projects/laji-api-client/generated/api';
 import { DataFetchMode } from '../observation-data.service';
+import { SearchQueryService } from '../search-query.service';
 
 type NormalCountQueryParams = paths['/warehouse/query/unit/count']['get']['parameters']['query'];
 type AggregateQueryParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
@@ -33,7 +34,8 @@ export class ObservationCountComponent implements OnChanges {
   constructor(
     private api: LajiApiClientService,
     private logger: Logger,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private searchQuery: SearchQueryService
   ) {
   }
 
@@ -50,7 +52,9 @@ export class ObservationCountComponent implements OnChanges {
       return;
     }
 
-    const query = this.overrideInQuery ? {...this.query, ...this.overrideInQuery} : this.query;
+    const query = this.searchQuery.getNormalizedApiQuery(
+      this.overrideInQuery ? {...this.query, ...this.overrideInQuery} : this.query
+    );
     this.loading = true;
     this.count$ = (this.field ? this.aggregatedCount(query) : this.normalCount(query)).pipe(
       map(val => '' + val),

--- a/projects/laji/src/app/observation/download/observation-download.component.ts
+++ b/projects/laji/src/app/observation/download/observation-download.component.ts
@@ -193,7 +193,7 @@ export class ObservationDownloadComponent implements OnDestroy {
   }
 
   updateCsvLink() {
-    const queryParams = this.searchQuery.getQueryObject(this.query);
+    const queryParams = this.searchQuery.prepareDownloadApiQueryObject(this.query);
     queryParams['aggregateBy'] = this.taxaDownloadAggregateBy[this.translate.getCurrentLang() as keyof { en: string; fi: string; sv: string }];
     queryParams['includeNonValidTaxa'] = 'false';
     queryParams['pageSize'] = '' + this.taxaLimit;

--- a/projects/laji/src/app/observation/horizontal-chart/horizontal-chart.component.ts
+++ b/projects/laji/src/app/observation/horizontal-chart/horizontal-chart.component.ts
@@ -9,6 +9,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { HorizontalChartDataService, MAX_TAXA_SIZE } from './horizontal-chart-data.service';
 import {LocalStorageService, LocalStorage} from 'ngx-webstorage';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
+import { SearchQueryService } from '../search-query.service';
 
 @Component({
     selector: 'laji-horizontal-chart',
@@ -66,14 +67,15 @@ export class HorizontalChartComponent implements OnInit, OnChanges {
   subBackgroundColors: string[] = [];
   allBackgroundColors: string[] = [];
 
-  constructor(private api: LajiApiClientService,
-              private cd: ChangeDetectorRef,
-              private toQname: ToQNamePipe,
-              private translate: TranslateService,
-              private horizontalDataService: HorizontalChartDataService,
-              private localSt: LocalStorageService
-  ) {
-  }
+  constructor(
+    private api: LajiApiClientService,
+    private cd: ChangeDetectorRef,
+    private toQname: ToQNamePipe,
+    private translate: TranslateService,
+    private horizontalDataService: HorizontalChartDataService,
+    private localSt: LocalStorageService,
+    private searchQuery: SearchQueryService
+  ) { }
 
   ngOnInit() {
     (Tooltip.positioners as any).cursor = function(chartElements: any, coordinates: any) {
@@ -112,11 +114,12 @@ export class HorizontalChartComponent implements OnInit, OnChanges {
     this.barChartData = [{ data: [], backgroundColor: [], label: this.translate.instant('all') }];
 
     this.loading = true;
+    const apiQuery = this.searchQuery.getNormalizedApiQuery(this.query);
     this.api.get(
       '/warehouse/query/unit/aggregate',
       {
         query: {
-          ...this.query as any,
+          ...apiQuery as any,
           aggregateBy: ['unit.linkings.taxon.' + this.classificationValue],
           orderBy: [this.onlyCount === null ? 'count DESC' : this.onlyCount ? 'count DESC' : 'individualCountSum DESC'],
           pageSize: MAX_TAXA_SIZE,

--- a/projects/laji/src/app/observation/observation-data.service.ts
+++ b/projects/laji/src/app/observation/observation-data.service.ts
@@ -45,12 +45,12 @@ export class ObservationDataService {
       return this.cacheCount$!;
     }
 
-    query = this.searchQueryService.getQuery({
+    query = this.searchQueryService.getNormalizedApiQuery({
       ...query,
       onlyCount: false,
       taxonCounts: true,
       cache: typeof query.cache === 'undefined' ? isEmptyWarehouseQuery(query) : query.cache
-    }, query);
+    });
 
     this.lastQuery = newQuery;
     const obs$ = this.dataFetchMode === 'unit'

--- a/projects/laji/src/app/observation/pipe/to-safe-query.pipe.ts
+++ b/projects/laji/src/app/observation/pipe/to-safe-query.pipe.ts
@@ -16,7 +16,7 @@ export class ToSafeQueryPipe implements PipeTransform {
     if (!value) {
       return value;
     }
-    return this.searchQueryService.getQueryObject(value, skip);
+    return this.searchQueryService.prepareRouterQueryObject(value, skip);
   }
 
 }

--- a/projects/laji/src/app/observation/result/observation-result.component.ts
+++ b/projects/laji/src/app/observation/result/observation-result.component.ts
@@ -128,7 +128,7 @@ export class ObservationResultComponent implements OnChanges {
     this.router.navigate(
       this.localizeRouterService.translateRoute([this.basePath, tabName]), {
         // Query object should not be but directly to the request params! It can include person token and we don't want that to be visible!
-        queryParams: this.searchQueryService.getQueryObject(this.activeQuery, ['selected', 'pageSize', 'page'])
+        queryParams: this.searchQueryService.prepareRouterQueryObject(this.activeQuery, ['selected', 'pageSize', 'page'])
       }
     );
   }

--- a/projects/laji/src/app/observation/search-query.service.ts
+++ b/projects/laji/src/app/observation/search-query.service.ts
@@ -257,7 +257,7 @@ export class SearchQueryService implements SearchQueryInterface {
     return result;
   }
 
-  public getQueryObject(query: WarehouseSearchQuery, skipParams: string[] = [], obscure = true) {
+  private getNormalizedRouterQuery(query: WarehouseSearchQuery, skipParams: string[] = [], obscure = true) {
     const result: {[field: string]: string | string[]}  = {};
     if (query) {
       this.forEachType({
@@ -299,10 +299,58 @@ export class SearchQueryService implements SearchQueryInterface {
       }});
     }
 
-    return this.getQuery(result, query);
+    return this.normalizeQueryForInternalURL(result, query);
   }
 
-  public getQuery(result: any, query: WarehouseQueryInterface) {
+  /**
+   * Provided just in case for compatibility with observation-download.
+   * For some reason it uses an object with string values for an API call (I.e. an URL/router sorta query),
+   * I played it safe and kept it as is, but that component should be refactored sometime.
+   */
+  public prepareDownloadApiQueryObject(
+    query: WarehouseSearchQuery,
+    skipParams: string[] = [],
+    obscure = true
+  ) {
+    return this.getNormalizedRouterQuery(query, skipParams, obscure);
+  }
+
+  public prepareRouterQueryObject(
+    query: WarehouseSearchQuery,
+    skipParams: string[] = ['selected', 'pageSize', 'page']
+  ) {
+    return this.getNormalizedRouterQuery(query, skipParams, true);
+  }
+
+  private prepareInternalFields<T extends WarehouseQueryInterface>(internalQuery: T) {
+    if (Array.isArray(internalQuery.target)) {
+      internalQuery.target = internalQuery.target.map(target => target.replace(/http:\/\/tun\.fi\//g, ''));
+    }
+
+    if (
+      (internalQuery.editorOrObserverPersonToken && (internalQuery.editorPersonToken || internalQuery.observerPersonToken))
+      || internalQuery.editorOrObserverIsNotPersonToken
+    ) {
+      delete internalQuery.editorOrObserverPersonToken;
+    } else if (
+      internalQuery.editorPersonToken
+      && internalQuery.observerPersonToken
+      && internalQuery.observerPersonToken === internalQuery.editorPersonToken
+    ) {
+      internalQuery.editorOrObserverPersonToken = internalQuery.observerPersonToken;
+      delete internalQuery.editorPersonToken;
+      delete internalQuery.observerPersonToken;
+    }
+
+    delete internalQuery._coordinatesIntersection;
+
+    return internalQuery;
+  }
+
+  /**
+   * Mutates `result` to prepare internal query model into internal router query params
+   */
+  public normalizeQueryForInternalURL(result: any, query: WarehouseQueryInterface) {
     ['coordinates'].forEach(key => {
       const last = (query as any)[key]?.[0]?.split(':').pop();
       if (result[key] && typeof query._coordinatesIntersection !== 'undefined' && last !== undefined && isNaN(last)) {
@@ -310,26 +358,27 @@ export class SearchQueryService implements SearchQueryInterface {
       }
     });
 
-    if (Array.isArray(result['target'])) {
-      result['target'] = (result['target'] as string[]).map(target => target.replace(/http:\/\/tun\.fi\//g, ''));
+    this.prepareInternalFields(result);
+
+    return result;
+  }
+
+  /**
+   * Takes an internal observation search query object and returns a new query object that is ready for API calls
+   */
+  public getNormalizedApiQuery<T extends WarehouseQueryInterface>(internalQuery: T): T {
+    const result = { ...internalQuery };
+
+    if (Array.isArray(result.coordinates) && typeof internalQuery._coordinatesIntersection !== 'undefined') {
+      result.coordinates = result.coordinates.map((coordinate) => {
+        const last = coordinate.split(':').pop();
+        return last !== undefined && isNaN(parseFloat(last))
+          ? `${coordinate}:${internalQuery._coordinatesIntersection! / 100}`
+          : coordinate;
+      });
     }
 
-    if (
-      (result.editorOrObserverPersonToken && (result.editorPersonToken || result.observerPersonToken))
-      || result.editorOrObserverIsNotPersonToken
-    ) {
-      delete result.editorOrObserverPersonToken;
-    } else if (
-      result.editorPersonToken
-      && result.observerPersonToken
-      && result.observerPersonToken === result.editorPersonToken
-    ) {
-      result.editorOrObserverPersonToken = result.observerPersonToken;
-      delete result.editorPersonToken;
-      delete result.observerPersonToken;
-    }
-
-    delete result._coordinatesIntersection;
+    this.prepareInternalFields(result);
 
     return result;
   }
@@ -338,7 +387,7 @@ export class SearchQueryService implements SearchQueryInterface {
     if (!queryParameters) {
       queryParameters = {};
     }
-    const query = this.getQueryObject(dwQuery, skipParams, false);
+    const query = this.prepareDownloadApiQueryObject(dwQuery, skipParams, false);
     Object.keys(query).map((key) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       queryParameters![key] = query[key];
@@ -348,7 +397,7 @@ export class SearchQueryService implements SearchQueryInterface {
   }
 
   public updateUrl(query: WarehouseQueryInterface, skipParams: string[]): void {
-    const queryParams = this.getQueryObject(query, skipParams);
+    const queryParams = this.prepareRouterQueryObject(query, skipParams);
     const extra: NavigationExtras = {};
     if (Object.keys(queryParams).length > 0) {
       extra['queryParams'] = queryParams;

--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map-table/observation-map-table.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map-table/observation-map-table.component.ts
@@ -19,6 +19,7 @@ import { getSortsFromCols } from '../../../observation-result/observation-table/
 import { ObservationVisualizationMode } from '../observation-visualization';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { paths } from 'projects/laji-api-client/generated/api';
+import { SearchQueryService } from '../../../../observation/search-query.service';
 
 type QueryListQuery = paths['/warehouse/query/unit/list']['get']['parameters']['query'];
 
@@ -73,7 +74,8 @@ const visualizationModeColNames = {
     private api: LajiApiClientService,
     private cdr: ChangeDetectorRef,
     private documentViewerFacade: DocumentViewerFacade,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private searchQuery: SearchQueryService
   ) {
     this.columnLookup = this.tableColumnService.getAllColumnLookup();
   }
@@ -153,7 +155,7 @@ const visualizationModeColNames = {
     }
     this.loading = true;
     const listQuery: QueryListQuery = {
-      ...query as any,
+      ...this.searchQuery.getNormalizedApiQuery(query) as any,
       selected,
       orderBy: this.orderBy,
       pageSize: this.pageSize,

--- a/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-map/observation-map/observation-map.component.ts
@@ -60,6 +60,7 @@ import { BoxCache } from './box-cache';
 import { Router } from '@angular/router';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { DataFetchMode } from '../../../observation/observation-data.service';
+import { SearchQueryService } from '../../../observation/search-query.service';
 
 interface AggregateQueryResponse {
   cacheTimestamp: number;
@@ -221,7 +222,8 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
     private logger: Logger,
     private cdr: ChangeDetectorRef,
     private zone: NgZone,
-    private router: Router
+    private router: Router,
+    private searchQueryService: SearchQueryService
   ) {
     this.mapOptions = {
       controls: {
@@ -396,9 +398,10 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
 
   private getPoints$(query: WarehouseQueryInterface): Observable<FeatureCollection> {
     const endpoint = this.dataMode === 'unit' ? '/warehouse/query/unit/aggregate' : '/warehouse/query/sample/aggregate';
+    const apiQuery = this.searchQueryService.getNormalizedApiQuery(query);
     return this.api.get(endpoint, {
       query: {
-        ...query as any,
+        ...apiQuery as any,
         featureType: 'CENTER_POINT',
         aggregateBy: [ 'gathering.interpretations.coordinateAccuracy' ],
         pageSize: this.pointGeometryPageSize,
@@ -441,9 +444,10 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
 
   private getBoxQuery$(query: WarehouseQueryInterface, aggregateBy: string[], page: number): Observable<AggregateQueryResponse> {
     const endpoint = this.dataMode === 'unit' ? '/warehouse/query/unit/aggregate' : '/warehouse/query/sample/aggregate';
+    const apiQuery = this.searchQueryService.getNormalizedApiQuery(query);
     return this.api.get(endpoint, {
       query: {
-        ...query as any,
+        ...apiQuery as any,
         aggregateBy,
         pageSize: this.boxGeometryPageSize,
         page,
@@ -521,8 +525,6 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
 
     this.addVisualizationParams(query);
     this.addViewPortCoordinatesParams(query, bounds);
-
-    delete query._coordinatesIntersection;
 
     return query;
   }
@@ -646,7 +648,8 @@ export class ObservationMapComponent implements OnInit, OnChanges, OnDestroy {
     this.cdr.markForCheck();
 
     const endpoint = this.dataMode === 'unit' ? '/warehouse/query/unit/count' : '/warehouse/query/sample/count';
-    return this.api.get(endpoint, { query: query as any }).pipe(
+    const apiQuery = this.searchQueryService.getNormalizedApiQuery(query);
+    return this.api.get(endpoint, { query: apiQuery as any }).pipe(
       switchMap(res => {
         if (!res.total) {
           return of({

--- a/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.facade.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.facade.ts
@@ -7,6 +7,7 @@ import { WarehouseValueMappingService } from '../../../shared/service/warehouse-
 import { TriplestoreLabelService } from '../../../shared/service/triplestore-label.service';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { paths } from 'projects/laji-api-client/generated/api';
+import { SearchQueryService } from '../../../observation/search-query.service';
 
 type AggregateQueryParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
 
@@ -29,12 +30,13 @@ export class ObservationMonthDayChartFacade {
     private api: LajiApiClientService,
     private valueMappingService: WarehouseValueMappingService,
     private triplestoreLabelService: TriplestoreLabelService,
-    private translate: TranslateService
+    private translate: TranslateService,
+    private searchQuery: SearchQueryService
   ) {}
 
   loadChartData(query: WarehouseQueryInterface, useIndividualCount: boolean) {
     const aggregateQuery: AggregateQueryParams = {
-      ...query as any,
+      ...this.searchQuery.getNormalizedApiQuery(query) as any,
       aggregateBy: ['gathering.conversions.month', 'gathering.conversions.day', 'unit.lifeStage'],
       orderBy: ['unit.lifeStage'],
       pageSize: 10000,

--- a/projects/laji/src/app/shared-modules/observation-result/observation-table-own-documents/observation-table-own-documents.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-table-own-documents/observation-table-own-documents.component.ts
@@ -38,6 +38,7 @@ import { DeleteOwnDocumentService } from '../../../shared/service/delete-own-doc
 import { components, paths } from 'projects/laji-api-client/generated/api';
 import { DataFetchMode } from '../../../observation/observation-data.service';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
+import { SearchQueryService } from '../../../observation/search-query.service';
 
 type Document = components['schemas']['store-document'];
 type AggregateQueryParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
@@ -156,6 +157,7 @@ export class ObservationTableOwnDocumentsComponent implements OnInit, OnChanges,
     private toQName: ToQNamePipe,
     private formService: FormService,
     private deleteOwnDocument: DeleteOwnDocumentService,
+    private searchQuery: SearchQueryService,
   ) {
     this.allColumns = tableColumnService.getAllColumns();
     this.columnGroups = tableColumnService.getColumnGroups();
@@ -309,7 +311,7 @@ export class ObservationTableOwnDocumentsComponent implements OnInit, OnChanges,
     this.changeDetectorRef.markForCheck();
 
     const query: AggregateQueryParams = {
-      ...this.query as any,
+      ...this.searchQuery.getNormalizedApiQuery(this.query) as any,
       aggregateBy: [
         'document.createdDate',
         'document.documentId',

--- a/projects/laji/src/app/shared-modules/observation-result/observation-year-chart/observation-year-chart.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-year-chart/observation-year-chart.component.ts
@@ -16,6 +16,7 @@ import { TranslateService } from '@ngx-translate/core';
 import {LocalStorageService, LocalStorage} from 'ngx-webstorage';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { paths } from 'projects/laji-api-client/generated/api';
+import { SearchQueryService } from '../../../observation/search-query.service';
 
 type AggregateQueryParams = paths['/warehouse/query/unit/aggregate']['get']['parameters']['query'];
 
@@ -56,7 +57,8 @@ export class ObservationYearChartComponent implements OnChanges, OnDestroy, OnIn
     private api: LajiApiClientService,
     private cd: ChangeDetectorRef,
     private translate: TranslateService,
-    private localSt: LocalStorageService
+    private localSt: LocalStorageService,
+    private searchQuery: SearchQueryService
   ) { }
 
 
@@ -125,7 +127,7 @@ export class ObservationYearChartComponent implements OnChanges, OnDestroy, OnIn
     }
 
     const query: AggregateQueryParams = {
-      ...this.query as any,
+      ...this.searchQuery.getNormalizedApiQuery(this.query) as any,
       aggregateBy: ['gathering.conversions.year'],
       orderBy: ['gathering.conversions.year'],
       pageSize: 10000,

--- a/projects/laji/src/app/shared-modules/observation-result/service/observation-result.service.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/service/observation-result.service.ts
@@ -83,8 +83,9 @@ export class ObservationResultService {
     }
 
     if (!this.aggregateData) {
+      const normalizedQuery = this.searchQuery.getNormalizedApiQuery(query);
       const queryParams = {
-        ...query,
+        ...normalizedQuery,
         cache: (query.cache || isEmptyWarehouseQuery(query)),
         aggregateBy: [..._aggregateBy],
         orderBy,
@@ -123,10 +124,11 @@ export class ObservationResultService {
       this.data = undefined;
     }
     if (!this.data) {
+      const normalizedQuery = this.searchQuery.getNormalizedApiQuery(query);
       const cache = (query.cache || isEmptyWarehouseQuery(query));
       const preparedFields = [...this.prepareFields(selected), ...this.idFields];
       const queryParams = {
-        ...query,
+        ...normalizedQuery,
         cache,
         aggregateBy: preparedFields,
         selected: preparedFields,

--- a/projects/laji/src/app/shared/gallery/service/gallery.service.ts
+++ b/projects/laji/src/app/shared/gallery/service/gallery.service.ts
@@ -6,16 +6,20 @@ import { Image } from '../image-gallery/image.interface';
 import { IdService } from '../../service/id.service';
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { paths } from 'projects/laji-api-client/generated/api';
+import { SearchQueryService } from '../../../observation/search-query.service';
 
 type MediaListQuery = paths['/warehouse/query/unitMedia/list']['get']['parameters']['query'];
 
 @Injectable({providedIn: 'root'})
 export class GalleryService {
-  constructor(private api: LajiApiClientService) {}
+  constructor(
+    private api: LajiApiClientService,
+    private searchQuery: SearchQueryService
+  ) {}
 
   getList(rawQuery: WarehouseQueryInterface, sort: string[] | undefined, pageSize: number, page: number): Observable<PagedResult<any>> {
     const query: MediaListQuery = {
-      ...rawQuery as any,
+      ...this.searchQuery.getNormalizedApiQuery(rawQuery) as any,
       hasUnitMedia: true,
       selected: [
         'unit.taxonVerbatim,unit.linkings.taxon.id,unit.linkings.taxon.vernacularName,'


### PR DESCRIPTION
^title

unfortunately the observation form has been structured in such a way that the internal query object doesn't actually match what API accepts. This PR runs all the warehouse queries used in observation search through normalization