### PR TITLE
Unify taxon overview media queries

### DIFF
--- a/projects/laji/src/app/shared/gallery/service/gallery.service.ts
+++ b/projects/laji/src/app/shared/gallery/service/gallery.service.ts
@@ -16,7 +16,6 @@ export class GalleryService {
   getList(rawQuery: WarehouseQueryInterface, sort: string[] | undefined, pageSize: number, page: number): Observable<PagedResult<any>> {
     const query: MediaListQuery = {
       ...rawQuery as any,
-      hasUnitMedia: true,
       selected: [
         'unit.taxonVerbatim,unit.linkings.taxon.id,unit.linkings.taxon.vernacularName,'
           + 'unit.linkings.taxon.scientificName,unit.reportedInformalTaxonGroup',

--- a/projects/laji/src/app/taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/taxonomy/taxon/info-card/info-card.component.ts
@@ -1,4 +1,4 @@
-import { map, switchMap } from 'rxjs';
+import { map, switchMap, tap } from 'rxjs';
 import { Observable, of, Subscription } from 'rxjs';
 import {
   ChangeDetectionStrategy,
@@ -23,6 +23,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { HeaderService } from '../../../shared/service/header.service';
 import { components } from 'projects/laji-api-client/generated/api.d';
 import { UserService } from '../../../shared/service/user.service';
+import { IMAGES_QUERY_PAGE_SIZE } from './taxon-images/taxon-images.component';
 
 type Taxon = components['schemas']['LajiBackendTaxon'];
 type TaxonDescription = components['schemas']['LajiBackendContent'][number];
@@ -156,43 +157,58 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
 
     this.images = [];
 
-    const nbrOfImages = this.taxon.species ? 1 : 9;
+    const goalImagesCount = this.taxon.species ? 1 : 9;
 
-    const taxonImages = (this.taxonImages || []).filter(image => !image['keywords']?.includes('skeletal')).slice(0, nbrOfImages);
+    const taxonImages = (this.taxonImages || []).filter(image => !image['keywords']?.includes('skeletal')).slice(0, goalImagesCount);
     if (taxonImages.length > 0) {
       this.hasImageData = true;
     }
-    let missingImages = nbrOfImages - taxonImages.length;
 
     const imageObs = this.userService.isLoggedIn$.pipe(
       switchMap(loggedIn => (
-        loggedIn && missingImages > 0 && this.isFromMasterChecklist
-        ? this.getImages(
-          InfoCardQueryService.getReliableHumanObservationQuery(this.taxon.id),
-          missingImages
-        ).pipe(
-          switchMap(observationImages => {
-            const images = taxonImages.concat(observationImages);
-            if (images.length > 0) {
-              this.hasImageData = true;
-              this.cd.markForCheck();
-            }
-            missingImages = nbrOfImages - images.length;
-
-            if (missingImages > 0) {
-              return this.getImages(
-                InfoCardQueryService.getSpecimenQuery(this.taxon.id),
-                missingImages
+        !(loggedIn && goalImagesCount - taxonImages.length > 0 && this.isFromMasterChecklist)
+          // default to images from parent
+          ? of(taxonImages)
+          // attempt to fill the rest of goal images count
+          : of(taxonImages).pipe(
+            // fallback 1
+            switchMap(images =>
+              goalImagesCount - images.length <= 0
+              ? of(images)
+              : this.getImages(
+                InfoCardQueryService.getSpecimenQuery(this.taxon.id, true),
+                IMAGES_QUERY_PAGE_SIZE
               ).pipe(
-                map(collectionImages => images.concat(collectionImages))
-              );
-            } else {
-              return of(images);
-            }
-          })
-        )
-        : of(taxonImages)
-      ))
+                map(images2 => { images.push(...images2); return images; })
+              )),
+            // fallback 2
+            switchMap(images =>
+              goalImagesCount - images.length <= 0
+              ? of(images)
+              : this.getImages(
+                InfoCardQueryService.getExpertVerifiedObservationQuery(this.taxon.id),
+                IMAGES_QUERY_PAGE_SIZE
+              ).pipe(
+                map(images2 => { images.push(...images2); return images; })
+              )),
+            // fallback 3
+            switchMap(images =>
+              goalImagesCount - images.length <= 0
+              ? of(images)
+              : this.getImages(
+                InfoCardQueryService.getSpecimenQuery(this.taxon.id, false),
+                IMAGES_QUERY_PAGE_SIZE
+              ).pipe(
+                map(images2 => { images.push(...images2); return images; })
+              )),
+          )
+      )),
+      tap(images => {
+        if (images.length > 0) {
+          this.hasImageData = true;
+          this.cd.markForCheck();
+        }
+      }),
     );
 
     this.imageSub = imageObs.subscribe(images => {

--- a/projects/laji/src/app/taxonomy/taxon/info-card/info-card.component.ts
+++ b/projects/laji/src/app/taxonomy/taxon/info-card/info-card.component.ts
@@ -176,7 +176,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
               goalImagesCount - images.length <= 0
               ? of(images)
               : this.getImages(
-                InfoCardQueryService.getSpecimenQuery(this.taxon.id, true),
+                InfoCardQueryService.getExpertVerifiedObservationQuery(this.taxon.id),
                 IMAGES_QUERY_PAGE_SIZE
               ).pipe(
                 map(images2 => { images.push(...images2); return images; })
@@ -186,7 +186,7 @@ export class InfoCardComponent implements OnInit, OnChanges, OnDestroy {
               goalImagesCount - images.length <= 0
               ? of(images)
               : this.getImages(
-                InfoCardQueryService.getExpertVerifiedObservationQuery(this.taxon.id),
+                InfoCardQueryService.getSpecimenQuery(this.taxon.id, true),
                 IMAGES_QUERY_PAGE_SIZE
               ).pipe(
                 map(images2 => { images.push(...images2); return images; })

--- a/projects/laji/src/app/taxonomy/taxon/info-card/shared/service/info-card-query.service.ts
+++ b/projects/laji/src/app/taxonomy/taxon/info-card/shared/service/info-card-query.service.ts
@@ -8,9 +8,8 @@ export class InfoCardQueryService {
       superRecordBasis: ['PRESERVED_SPECIMEN'],
       sourceId: ['KE.3', 'KE.167'],
       // eslint-disable-next-line max-len
-      collectionAndRecordQuality: 'PROFESSIONAL:EXPERT_VERIFIED,COMMUNITY_VERIFIED,NEUTRAL;HOBBYIST:EXPERT_VERIFIED,COMMUNITY_VERIFIED;AMATEUR:EXPERT_VERIFIED,COMMUNITY_VERIFIED;',
+      collectionQuality: ['PROFESSIONAL'],
       typeSpecimen,
-      includeNonValidTaxa: false,
       cache: true,
       needsCheck: false
     };
@@ -21,7 +20,6 @@ export class InfoCardQueryService {
       taxonId: [taxonId],
       superRecordBasis: ['HUMAN_OBSERVATION_UNSPECIFIED'],
       recordQuality: ['EXPERT_VERIFIED'],
-      includeNonValidTaxa: false,
       cache: true
     };
   }
@@ -31,7 +29,6 @@ export class InfoCardQueryService {
       taxonId: [taxonId],
       superRecordBasis: ['HUMAN_OBSERVATION_UNSPECIFIED'],
       reliability: ['RELIABLE'],
-      includeNonValidTaxa: false,
       cache: true
     };
   }

--- a/projects/laji/src/app/taxonomy/taxon/info-card/taxon-images/taxon-images.component.html
+++ b/projects/laji/src/app/taxonomy/taxon/info-card/taxon-images/taxon-images.component.html
@@ -21,7 +21,7 @@
           <laji-gallery
             [shortPager]="true"
             [query]="item.query"
-            [pageSize]="12"
+            [pageSize]="imagesQueryPageSize"
             [view]="'full2'"
             [shortcut]="false"
             [showExtraInfo]="false"

--- a/projects/laji/src/app/taxonomy/taxon/info-card/taxon-images/taxon-images.component.ts
+++ b/projects/laji/src/app/taxonomy/taxon/info-card/taxon-images/taxon-images.component.ts
@@ -8,6 +8,8 @@ import { UserService } from 'projects/laji/src/app/shared/service/user.service';
 
 type Taxon = components['schemas']['LajiBackendTaxon'];
 
+export const IMAGES_QUERY_PAGE_SIZE = 12;
+
 @Component({
     selector: 'laji-taxon-images',
     templateUrl: './taxon-images.component.html',
@@ -20,6 +22,7 @@ export class TaxonImagesComponent implements OnChanges, OnInit {
   @Input() taxonImages!: Array<Image>;
   @Input() isFromMasterChecklist!: boolean;
 
+  imagesQueryPageSize = IMAGES_QUERY_PAGE_SIZE;
   imageSets: { title: string; hasData?: boolean; query: WarehouseQueryInterface }[] = [];
   isLoggedIn$!: Observable<boolean>;
 


### PR DESCRIPTION
https://github.com/luomus/laji/issues/1030

https://luomus-ict.slack.com/archives/C014PNS2S3F/p1787055100337229?thread_ts=1786954306.928209&cid=C014PNS2S3F

Note: previously committed the associated login check directly to dev/beta

This PR updates the taxon overview image fallback queries to use the same filters as media page.

Also unified the page size to 12 so that both queries hit the same cache item.