### PR TITLE
Project form fail fast

### DIFF
--- a/projects/laji/src/app/project-form/form/document-form/document-form.component.html
+++ b/projects/laji/src/app/project-form/form/document-form/document-form.component.html
@@ -1,101 +1,65 @@
 @if (vm$ | async; as vm) {
   @if (!savingFromLocalStorage) {
     <div class="mt-5">
-      @if (vm | typeGuard: isFormError; as error) {
-        @switch (error) {
-          @case (errors.notFoundForm) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.formNotFound' | translate:{formId: formID} }}
-            </lu-alert>
-          }
-          @case (errors.notFoundDocument) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.documentNotFound' | translate:{documentId: documentID} }}
-            </lu-alert>
-          }
-          @case (errors.loadFailed) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.genericError' | translate }}
-            </lu-alert>
-          }
-          @case (errors.noAccessToDocument) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.noAccessToDocument' | translate }}
-            </lu-alert>
-          }
-          @case (errors.templateDisallowed) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.templateDisallowed' | translate }}
-            </lu-alert>
-          }
-          @case (errors.missingNamedPlace) {
-            <lu-alert type="danger">
-              {{ 'haseka.form.missingNamedPlace' | translate }}
-            </lu-alert>
-          }
-        }
+      @if (!vm.form.options?.mobile || vm.form.options?.openForm) {
+        <laji-project-form-header
+          [form]="vm.form"
+          [description]="vm.form.description"
+          lajiFormOption="description logo title options.hideTES">
+        </laji-project-form-header>
       }
-      @if (vm | typeGuard: isSaneViewModel; as vm) {
-        @if (!vm.form.options?.mobile || vm.form.options?.openForm) {
-          <laji-project-form-header
-            [form]="vm.form"
-            [description]="vm.form.description"
-            lajiFormOption="description logo title options.hideTES">
-          </laji-project-form-header>
-        }
-        <laji-named-place-linker-button [documentID]="documentID"></laji-named-place-linker-button>
-        @if (vm.formData?.locked) {
-          <lu-alert [type]="'danger'">
-            {{ 'document.locked' | translate }}
-          </lu-alert>
-        }
-        @if (vm.editingOldWarning) {
-          <lu-alert type="warning">{{ 'haseka.editingOldDocumentWarning' | translate: {date: vm.editingOldWarning} }}</lu-alert>
-        }
-        @if (vm.namedPlaceHeader.length) {
-          <div class="row mt-3">
-            <div class="col-sm-12">
-              <h3>@for (field of vm.namedPlaceHeader; track field; let i = $index) {
-                <span>
-                  @if ($any(vm.namedPlace)[field] | area | values; as val) {
-                    {{ val }}{{ $any(vm.namedPlace)[vm.namedPlaceHeader[i + 1]] ? ', ' : '' }}
-                  }
-                </span>
-              }</h3>
-            </div>
+      <laji-named-place-linker-button [documentID]="documentID"></laji-named-place-linker-button>
+      @if (vm.formData?.locked) {
+        <lu-alert [type]="'danger'">
+          {{ 'document.locked' | translate }}
+        </lu-alert>
+      }
+      @if (vm.editingOldWarning) {
+        <lu-alert type="warning">{{ 'haseka.editingOldDocumentWarning' | translate: {date: vm.editingOldWarning} }}</lu-alert>
+      }
+      @if (vm.namedPlaceHeader.length) {
+        <div class="row mt-3">
+          <div class="col-sm-12">
+            <h3>@for (field of vm.namedPlaceHeader; track field; let i = $index) {
+              <span>
+                @if ($any(vm.namedPlace)[field] | area | values; as val) {
+                  {{ val }}{{ $any(vm.namedPlace)[vm.namedPlaceHeader[i + 1]] ? ', ' : '' }}
+                }
+              </span>
+            }</h3>
           </div>
-        }
-        <div class="clear"></div>
-        <div class="laji-form">
-          <laji-form
-            [form]="vm.form"
-            [formData]="vm.formData"
-            [settingsKey]="vm.form.id"
-            [showShortcutButton]="!vm.form.options?.mobile"
-            (dataChange)="onChange($event)"
-            (dataSubmit)="onSubmit($event)"
-            (validationError)="onValidationError($event)"
-            (goBack)="onGoBack()"
-          ></laji-form>
-          <laji-form-footer
-            [form]="vm.form"
-            [dateEdited]="vm.formData.dateEdited"
-            [locked]="vm.locked!"
-            [isAdmin]="vm.isAdmin"
-            [status]="(vm.hasChanges && !vm.form.options.openForm) ? 'unsaved' : 'none'"
-            [readonly]="vm.readonly"
-            [edit]="!!documentID"
-            [errors]="validationErrors"
-            [touchedCounter]="(touchedCounter$ | async)!"
-            [lajiForm]="lajiForm"
-            [template]="template"
-            (lock)="lock($event)"
-            (submitPublic)="submitPublic()"
-            (submitPrivate)="submitPrivate()"
-            (submitTemplate)="submitTemplate()"
-          (leave)="onLeave()"></laji-form-footer>
         </div>
       }
+      <div class="clear"></div>
+      <div class="laji-form">
+        <laji-form
+          [form]="vm.form"
+          [formData]="vm.formData"
+          [settingsKey]="vm.form.id"
+          [showShortcutButton]="!vm.form.options?.mobile"
+          (dataChange)="onChange($event)"
+          (dataSubmit)="onSubmit($event)"
+          (validationError)="onValidationError($event)"
+          (goBack)="onGoBack()"
+        ></laji-form>
+        <laji-form-footer
+          [form]="vm.form"
+          [dateEdited]="vm.formData.dateEdited"
+          [locked]="vm.locked!"
+          [isAdmin]="vm.isAdmin"
+          [status]="(vm.hasChanges && !vm.form.options.openForm) ? 'unsaved' : 'none'"
+          [readonly]="vm.readonly"
+          [edit]="!!documentID"
+          [errors]="validationErrors"
+          [touchedCounter]="(touchedCounter$ | async)!"
+          [lajiForm]="lajiForm"
+          [template]="template"
+          (lock)="lock($event)"
+          (submitPublic)="submitPublic()"
+          (submitPrivate)="submitPrivate()"
+          (submitTemplate)="submitTemplate()"
+        (leave)="onLeave()"></laji-form-footer>
+      </div>
     </div>
   } @else {
     <laji-spinner #spinner [spinning]="true" [overlay]="true"></laji-spinner>

--- a/projects/laji/src/app/project-form/form/document-form/document-form.component.ts
+++ b/projects/laji/src/app/project-form/form/document-form/document-form.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, HostListener, Input, OnDestroy, OnInit, ViewChild } from '@angular/core';
-import { mergeMap, take, tap, delay, map, scan, filter, switchMap } from 'rxjs';
+import { mergeMap, take, tap, delay, map, scan, switchMap } from 'rxjs';
 import { combineLatest, Observable, of, Subject, Subscription } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { LocalizeRouterService } from '../../../locale/localize-router.service';
@@ -12,7 +12,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { UserService } from '../../../shared/service/user.service';
 import { DocumentStorage } from '../../../storage/document.storage';
 import { LajiFormComponent } from 'projects/laji/src/app/project-form/form/laji-form/laji-form/laji-form.component';
-import { DocumentFormFacade, FormError, isFormError, SaneViewModel, isSaneViewModel, ViewModel } from './document-form.facade';
+import { DocumentFormFacade, ViewModel } from './document-form.facade';
 import { ProjectFormService, RegistrationContact } from '../../../shared/service/project-form.service';
 import { ModalComponent } from 'projects/laji-ui/src/lib/modal/modal/modal.component';
 import { LocalStorage } from 'ngx-webstorage';
@@ -55,11 +55,7 @@ export class DocumentFormComponent implements OnInit, OnDestroy {
   };
   savingFromLocalStorage = false;
 
-  isFormError = isFormError;
-  isSaneViewModel = isSaneViewModel;
-  errors = FormError;
-
-  private vm!: SaneViewModel;
+  private vm!: ViewModel;
   private vmSub!: Subscription;
   private tmpID: string | undefined;
   private isFromCancel = false;
@@ -95,8 +91,7 @@ export class DocumentFormComponent implements OnInit, OnDestroy {
 
     this.vm$ = this.documentFormFacade.getViewModel(this.formID, this.documentID, this.namedPlaceID, this.template);
     this.vmSub = this.vm$.pipe(
-      filter(isSaneViewModel),
-      tap(_ => {
+      tap(() => {
         if (this.savingFromLocalStorage) {
           this.saveDocumentFromLocalStorage();
         }

--- a/projects/laji/src/app/project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/project-form/form/document-form/document-form.facade.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { catchError, map, mergeMap, switchMap, take, tap, filter, distinctUntilChanged, mapTo, shareReplay, distinctUntilKeyChanged } from 'rxjs';
+import { catchError, map, mergeMap, switchMap, take, tap, distinctUntilChanged, mapTo, shareReplay, distinctUntilKeyChanged } from 'rxjs';
 import { combineLatest, concat, merge, Observable, of, ReplaySubject, Subscription } from 'rxjs';
 import { TemplateForm } from '../../../shared-modules/own-submissions/models/template-form';
 import { FooterService } from '../../../shared/service/footer.service';
@@ -21,6 +21,7 @@ import { ProjectFormService } from '../../../shared/service/project-form.service
 import { LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { components } from 'projects/laji-api-client/generated/api.d';
 import { Unsaved } from '../../../shared/utils';
+import { LocalizedError } from '../../../shared/error/localized-error';
 
 type Form = components['schemas']['Form'];
 type Annotation = components['schemas']['store-annotation'];
@@ -28,27 +29,13 @@ type Document = components['schemas']['store-document'];
 type NamedPlace = components['schemas']['store-namedPlace'];
 type Person = components['schemas']['SensitivePerson'];
 
-export enum FormError {
-  notFoundForm = 'notFoundForm',
-  notFoundDocument = 'notFoundDocument',
-  loadFailed = 'loadFailed',
-  noAccess = 'noAccess',
-  noAccessToDocument = 'noAccessToDocument',
-  templateDisallowed = 'templateDisallowed',
-  missingNamedPlace = 'missingNamedPlace'
-}
-
-export function isFormError(any: any): any is FormError {
-  return typeof any === 'string' && !!FormError[any as keyof typeof FormError];
-}
-
 export enum Readonly {
   noEdit,
   false,
   true
 }
 
-export interface SaneInputModel {
+export interface InputModel {
   form: Form;
   formData: any;
   hasChanges: boolean;
@@ -56,21 +43,13 @@ export interface SaneInputModel {
   namedPlace?: NamedPlace;
 }
 
-export type InputModel = SaneInputModel | FormError;
-
-export interface SaneViewModel extends SaneInputModel {
+export interface ViewModel extends InputModel {
   readonly: Readonly;
   isAdmin: boolean;
   namedPlaceHeader: string[];
   locked?: boolean;
   editingOldWarning?: string;
 }
-
-export function isSaneViewModel(any: ViewModel): any is SaneViewModel {
-  return typeof any !== 'string' && any && !!any?.form;
-}
-
-export type ViewModel = SaneViewModel | FormError;
 
 interface DocumentAndHasChanges {
   document: Unsaved<Document>;
@@ -82,7 +61,7 @@ export class DocumentFormFacade {
   @LocalStorage('tmpDocId', 1) private tmpDocId!: number;
 
   vm$!: Observable<ViewModel>;
-  vm!: SaneViewModel;
+  vm!: ViewModel;
   private locked$!: Observable<boolean | undefined>;
   private formData$!: Observable<any>;
   private formDataChange$ = new ReplaySubject<any>();
@@ -107,36 +86,25 @@ export class DocumentFormFacade {
     this.footerService.footerVisible = false;
   }
 
-  getViewModel(_formID: string, _documentID: string, _namedPlaceID: string, _template: boolean) {
+  getViewModel(_formID: string, _documentID: string | undefined, _namedPlaceID: string | undefined, _template: boolean) {
     const formID$ = of(_formID);
     const documentID$ = of(_documentID);
     const namedPlaceID$ = of(_namedPlaceID);
     const template$ = of(_template);
     const user$ = this.userService.user$.pipe(take(1));
 
-    const isSane = filter(<T>(f: T | FormError): f is T => !isFormError(f));
-
-    const form$: Observable<Form | FormError> = combineLatest([formID$, template$]).pipe(
+    const form$: Observable<Form> = combineLatest([formID$, template$, documentID$]).pipe(
       switchMap(([formID, template]) => this.projectFormService.getForm$(formID).pipe(
-        switchMap(form => template && !form?.options?.allowTemplate
-          ? of(FormError.templateDisallowed)
-          : !form
-            ? of(FormError.notFoundForm)
-            : this.formPermissionService.getRights(form).pipe(map(rights =>
-              (rights.edit === false && !form?.options.openForm)
-                ? FormError.noAccess
-                : form
-            ))
-        ),
-        catchError((error) => {
-          this.logger.error('Failed to load form', {error});
-          return of(error.status === 404 ? FormError.notFoundForm :  FormError.loadFailed);
-        }),
+        map(form => {
+          if (template && !form?.options?.allowTemplate) {
+            throw new LocalizedError('haseka.form.templateDisallowed');
+          }
+          return form;
+        })
       ))
     );
 
-    const existingDocument$: Observable<DocumentAndHasChanges | FormError | null> = form$.pipe(
-      isSane,
+    const existingDocumentAndHasChanges$: Observable<DocumentAndHasChanges | null> = form$.pipe(
       switchMap(form => documentID$.pipe(switchMap(documentID => documentID
         ? this.fetchExistingDocument((form as Form), documentID)
         : of(null)
@@ -144,55 +112,41 @@ export class DocumentFormFacade {
       shareReplay()
     );
 
-    const namedPlace$: Observable<NamedPlace | FormError | null> = combineLatest([existingDocument$, namedPlaceID$]).pipe(
-      map(([existingDocument, namedPlaceID]): string =>
-        isFormError(existingDocument)
-          ? ''
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          : existingDocument?.document?.namedPlaceID || namedPlaceID
+    const namedPlace$: Observable<NamedPlace | null> = combineLatest([existingDocumentAndHasChanges$, namedPlaceID$]).pipe(
+      map(([existingDocument, namedPlaceID]) => existingDocument?.document?.namedPlaceID || namedPlaceID
       ),
       switchMap((namedPlaceID) => namedPlaceID
         ? this.api.get('/named-places/{id}', { path: { id: namedPlaceID } })
         : of(null)
       ),
       take(1),
-      catchError(() => of(FormError.missingNamedPlace))
-    ) as Observable<NamedPlace | FormError | null>;
+    ) as Observable<NamedPlace | null>;
 
     const inputModel$: Observable<InputModel> = combineLatest([form$, template$]).pipe(
       switchMap(([form, template]) =>
-        isFormError(form)
-          ? of(form)
-          : combineLatest([existingDocument$, namedPlace$, user$]).pipe(
+        combineLatest([existingDocumentAndHasChanges$, namedPlace$, user$]).pipe(
             switchMap(([existingDocument, namedPlace, user]) =>
-              isFormError(namedPlace)
-              ? of(namedPlace)
-              : (existingDocument
+              (existingDocument
                 ? of(existingDocument)
                 : this.fetchEmptyData(form, user, namedPlace as NamedPlace)
-              ).pipe(map(documentModel => {
-                if (isFormError(documentModel)) {
-                  return documentModel;
-                }
-                return {form, namedPlace, formData: documentModel.document, hasChanges: documentModel.hasChanges, template};
-              }))
+              ).pipe(map(documentModel =>
+                ({form, namedPlace, formData: documentModel.document, hasChanges: documentModel.hasChanges, template})))
             )
           )
-      )
+      ),
+      shareReplay()
     ) as Observable<InputModel>;
 
-    const saneInputModel$ = inputModel$.pipe(isSane, shareReplay());
-
-    this.formData$ = concat(saneInputModel$.pipe(take(1), map(({formData}) => formData)), this.formDataChange$);
+    this.formData$ = concat(inputModel$.pipe(take(1), map(({formData}) => formData)), this.formDataChange$);
     this.hasChanges$ = concat(
-      saneInputModel$.pipe(take(1), map(({hasChanges}) => hasChanges)),
+      inputModel$.pipe(take(1), map(({hasChanges}) => hasChanges)),
       merge(
         this.formDataChange$.pipe(mapTo(true)),
         this.onSaved$.pipe(mapTo(false))
       )
     ).pipe(distinctUntilChanged());
 
-    this.locked$ = saneInputModel$.pipe(switchMap(({form}) => this.formData$.pipe(
+    this.locked$ = inputModel$.pipe(switchMap(({form}) => this.formData$.pipe(
       map(formData => (form.id?.indexOf('T:') !== 0 && form.options?.adminLockable)
         ? (formData && !!formData.locked)
         : undefined
@@ -200,16 +154,14 @@ export class DocumentFormFacade {
       distinctUntilChanged()
     )));
 
-    const saneForm$ = form$.pipe(isSane);
-
-    const rights$ = saneForm$.pipe(switchMap(form => this.formPermissionService.getRights(form)));
+    const rights$ = form$.pipe(switchMap(form => this.formPermissionService.getRights(form)));
     const readonly$ = combineLatest([rights$, user$, this.formData$]).pipe(
       map(([rights, user, formData]) => this.documentService.getReadOnly(formData, rights, user))
     );
 
     const uiSchemaContext$ = combineLatest([
-      saneForm$.pipe(distinctUntilKeyChanged('id')),
-      namedPlace$.pipe(isSane, (distinctUntilKeyChanged as any)('id')),
+      form$.pipe(distinctUntilKeyChanged('id')),
+      namedPlace$.pipe((distinctUntilKeyChanged as any)('id')),
       user$,
       rights$,
       this.formData$.pipe(map(data => data.id), distinctUntilChanged())
@@ -221,7 +173,7 @@ export class DocumentFormFacade {
       this.locked$,
       readonly$,
       rights$,
-      saneForm$,
+      form$,
       template$
     ]).pipe(map(([locked, readonly, rights, form, template]) =>
       this.getUiSchema(form, locked as boolean, readonly, rights, template),
@@ -232,17 +184,10 @@ export class DocumentFormFacade {
     // View model is the combination of data derived from inputs and local state and other asynchronously fetched data,
     // containing everything that the view needs.
     this.vm$ = inputModel$.pipe(switchMap(inputModel => {
-      if (isFormError(inputModel)) {
-        return of(inputModel);
-      }
       const {form, formData} = inputModel;
 
       return combineLatest([inputModel$, this.locked$, readonly$, rights$, uiSchema$, uiSchemaContext$, this.hasChanges$, this.formData$, documentID$]).pipe(
-        map(([_inputModel, locked, readonly, rights, uiSchema, uiSchemaContext, hasChanges, _formData, documentID]) => {
-          if (isFormError(_inputModel)) {
-            return _inputModel;
-          }
-          return {
+        map(([_inputModel, locked, readonly, rights, uiSchema, uiSchemaContext, hasChanges, _formData, documentID]) => ({
             ..._inputModel,
             form: this.getMemoizedForm(_inputModel.form, uiSchema, uiSchemaContext),
             readonly,
@@ -252,13 +197,12 @@ export class DocumentFormFacade {
             formData: _formData,
             editingOldWarning: this.getEditingOldWarning(form, formData, documentID),
             namedPlaceHeader: this.getNamedPlaceHeader(form, _inputModel.namedPlace)
-          };
-        })
+          }))
       );
     }));
 
-    this.vmSub = this.vm$.pipe(isSane).subscribe(vm => {
-        this.vm = (vm as SaneViewModel);
+    this.vmSub = this.vm$.subscribe(vm => {
+        this.vm = vm;
     });
     this.saveTmpSub = combineLatest([
       user$,
@@ -361,7 +305,7 @@ export class DocumentFormFacade {
     return form.options?.namedPlaceOptions?.headerFields || ['alternativeIDs', 'name', 'municipality'];
   }
 
-  private fetchExistingDocument(form: Form, documentID: string): Observable<DocumentAndHasChanges | FormError> {
+  private fetchExistingDocument(form: Form, documentID: string): Observable<DocumentAndHasChanges> {
     if (FormService.isTmpId(documentID)) {
       return this.userService.user$.pipe(
         take(1),
@@ -390,11 +334,7 @@ export class DocumentFormFacade {
               return {hasChanges: true, document: local};
             }
             return {document, hasChanges: false};
-          }),
-          catchError(err => of(
-            err.status === 404 ? FormError.notFoundDocument :
-            (err.status === 403 ? FormError.noAccessToDocument : FormError.loadFailed)
-          ))
+          })
         ))
       ))
     );

--- a/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.ts
@@ -244,7 +244,7 @@ export class DocumentAnnotationComponent implements AfterViewInit, OnChanges, On
 
     docAndRights$
       .subscribe(({doc, rights}) => {
-        this.isEditor = rights.isEditor;
+        this.isEditor = rights.hasEditRights;
         this.parseDoc(doc, doc);
       },
         () => this.parseDoc(undefined, false)

--- a/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-local/document-local-viewer-view/document-local-viewer-view.component.ts
@@ -14,7 +14,7 @@ import { StoreDocument } from '../../document-viewer.facade';
 export class DocumentLocalViewerViewComponent implements OnChanges {
   @ViewChild(ViewerMapComponent) map?: ViewerMapComponent;
 
-  @Input() document?: StoreDocument;
+  @Input({ required: true }) document!: StoreDocument;
   @Input() fields: any;
   @Input() mapData: any[] = [];
   @Input() imageData: {[key: string]: any} = {};

--- a/projects/laji/src/app/shared-modules/document-viewer/service/document-permission.service.ts
+++ b/projects/laji/src/app/shared-modules/document-viewer/service/document-permission.service.ts
@@ -11,7 +11,6 @@ import type { components } from 'projects/laji-api-client/generated/api';
 type Person = components['schemas']['Person'];
 
 export interface DocumentRights {
-  isEditor: boolean;
   hasEditRights: boolean;
   hasDeleteRights: boolean;
 }
@@ -25,7 +24,7 @@ export class DocumentPermissionService {
   ) {}
 
   getRightsToWarehouseDocument(doc?: any): Observable<DocumentRights> {
-    const rights: DocumentRights = { isEditor: false, hasEditRights: false, hasDeleteRights: false };
+    const rights: DocumentRights = { hasEditRights: false, hasDeleteRights: false };
 
     return this.userService.user$.pipe(
       switchMap(user => {
@@ -34,8 +33,7 @@ export class DocumentPermissionService {
         }
 
         const editors = doc.linkings?.editors?.map((editor: any) => IdService.getId(editor.id)).filter((id: string|undefined) => !!id) || [];
-        rights.isEditor = editors.includes(user.id);
-        rights.hasEditRights = rights.isEditor;
+        rights.hasEditRights = editors.includes(user.id);
 
         const collectionId = IdService.getId(doc.collectionId);
 
@@ -49,13 +47,12 @@ export class DocumentPermissionService {
 
             const documentId = IdService.getId(doc.documentId);
 
-            if (!(rights.isEditor || editors.length === 0) || !documentId) {
+            if (!(rights.hasEditRights || editors.length === 0) || !documentId) {
               return of(rights);
             }
 
             return this.documentService.findById(documentId).pipe(
               map(localDoc => {
-                rights.isEditor = rights.isEditor || localDoc.editor === user.id;
                 rights.hasEditRights = rights.hasEditRights || localDoc.editor === user.id;
                 rights.hasDeleteRights = rights.hasDeleteRights || localDoc.creator === user.id;
                 return rights;
@@ -68,21 +65,29 @@ export class DocumentPermissionService {
     );
   }
 
-  getRightsToLocalDocument(doc?: StoreDocument): Observable<DocumentRights> {
+  getRightsToLocalDocument(doc: StoreDocument): Observable<DocumentRights> {
     return this.userService.user$.pipe(
       switchMap(user => {
-        if (!user?.id || !doc) {
-          return of({ isEditor: false, hasEditRights: false, hasDeleteRights: false });
+        if (!user?.id) {
+          return of({ hasEditRights: false, hasDeleteRights: false });
+        }
+
+        if (doc.creator === user.id) {
+          return of({ hasEditRights: true, hasDeleteRights: true });
         }
 
         const isFormAdmin$ = this.userIsFormAdmin(user, doc.collectionID);
 
         return isFormAdmin$.pipe(
-          map(isFormAdmin => ({
-            isEditor: doc.editor === user.id,
-            hasEditRights: isFormAdmin || doc.editor === user.id,
+          map(isFormAdmin => {
+            console.log('right', {
+            hasEditRights: isFormAdmin || doc.editors?.includes(user.id) || false,
             hasDeleteRights: isFormAdmin || doc.creator === user.id
-          }))
+          });
+            return {
+            hasEditRights: isFormAdmin || doc.editors?.includes(user.id) || false,
+            hasDeleteRights: isFormAdmin || doc.creator === user.id
+          }})
         );
       })
     );

--- a/projects/laji/src/app/shared/error/laji-error-handler.ts
+++ b/projects/laji/src/app/shared/error/laji-error-handler.ts
@@ -5,6 +5,7 @@ import { Logger } from '../logger/logger.service';
 import { LocationStrategy, PathLocationStrategy } from '@angular/common';
 import { RESPONSE } from '../../../express.tokens';
 import { environment } from '../../../environments/environment';
+import { LocalizedError } from './localized-error';
 
 const pauseBeforeResendError = 30000;
 const enabledEnvs = ['dev', 'beta'];
@@ -71,7 +72,12 @@ export class LajiErrorHandler extends ErrorHandler {
         ? {
           title: (error as any)?.error?.errorCode,
           message: (error as any)?.error?.message
-        } : {
+        } : error instanceof LocalizedError
+        ? {
+          title: this.getTranslateService().instant('error.500.title'),
+          message: this.getTranslateService().instant(error.message)
+        }
+        : {
           title: this.getTranslateService().instant('error.500.title'),
           message: this.getTranslateService().instant('error.500.intro')
         };

--- a/projects/laji/src/app/shared/error/localized-error.ts
+++ b/projects/laji/src/app/shared/error/localized-error.ts
@@ -1,0 +1,9 @@
+export class LocalizedError extends Error {
+	context?: Record<string, string>;
+	localized = true;
+	constructor(translationKey: string, context?: Record<string, string>)  {
+		super(translationKey);
+		this.context = context;
+	}
+}
+

--- a/projects/laji/src/app/shared/service/project-form.service.ts
+++ b/projects/laji/src/app/shared/service/project-form.service.ts
@@ -64,7 +64,7 @@ export class ProjectFormService {
   }
 
   private currentFormID?: string;
-  private form$?: ReplaySubject<Form | undefined>;
+  private form$?: ReplaySubject<Form>;
   private registrationContacts?: RegistrationContact[];
 
   /** LajiFormBuilder can change the language of the form, without changing the lang of the whole page. */
@@ -75,7 +75,7 @@ export class ProjectFormService {
     return this.getFormID(route).pipe(switchMap(formID => this.getForm$(formID)));
   }
 
-  getForm$(id: string): Observable<Form | undefined> {
+  getForm$(id: string): Observable<Form> {
     if (Global.formAliasMap[id]) {
       id = Global.formAliasMap[id];
     }


### PR DESCRIPTION
Fixes #736

I simplified the code so that it doesn't try to model different error situations and provide a message deduced on front-end code. Instead we fail fast and let API errors bubble to the error handler that displays the error.

API already allowed accessing document that the person is editor of, so letting API handle permissions is sufficient.