### PR TITLE
Fix life stage chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "apollo-angular": "^13",
         "chart.js": "^4.4.0",
         "chartjs-chart-treemap": "^2.3.0",
+        "chartjs-plugin-autocolors": "^0.3.1",
         "core-js": "^3.24.1",
         "cors": "~2.8.5",
         "d3-axis": "^1.0.12",
@@ -10432,6 +10433,16 @@
       "license": "MIT",
       "peerDependencies": {
         "chart.js": ">=3.0.0"
+      }
+    },
+    "node_modules/chartjs-plugin-autocolors": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-autocolors/-/chartjs-plugin-autocolors-0.3.1.tgz",
+      "integrity": "sha512-8FHemt0Ef5BM7kQimh4eAkCRFPBav4seUFi7nEaShX+DjZMU9V4LqEDgXNglKbnYTTn3QmoG4v9gyiQDUAk9WQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@kurkle/color": "^0.3.1",
+        "chart.js": ">=2"
       }
     },
     "node_modules/chokidar": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "leaflet.sync": "^0.2.4",
         "localforage": "^1.10.0",
         "moment": "^2.29.4",
-        "ng2-charts": "^5.0.3",
+        "ng2-charts": "^10.0.0",
         "ngx-clipboard": "^16.0.0",
         "ngx-moment": "^6.0.2",
         "ngx-quicklink": "0.4.9",
@@ -12329,6 +12329,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.52.0.tgz",
+      "integrity": "sha512-XTNEJQh1tY1ZJVcf6ayP/2n4ZPyaHlW2FWs7xvw5ddPuhUVjLD3olQVQS7kf58JbAB48iL0uL/jerTrjtV3lDA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types",
+        "tests/browser-compat"
+      ]
+    },
     "node_modules/es5-ext": {
       "version": "0.10.64",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
@@ -16552,19 +16564,19 @@
       }
     },
     "node_modules/ng2-charts": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-5.0.4.tgz",
-      "integrity": "sha512-AnOZ2KSRw7QjiMMNtXz9tdnO+XrIKP/2MX1TfqEEo2fwFU5c8LFJIYqmkMPkIzAEm/U9y/1psA5TDNmxxjEdgA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/ng2-charts/-/ng2-charts-10.0.0.tgz",
+      "integrity": "sha512-mdL75XJrk/0s0YO2ySPQpAHPja85ECDEGNWFlcElJiy/bYliTNGEpeCtctAqZuozTff/E2CwGjyfPFM1ScP2og==",
       "license": "MIT",
       "dependencies": {
-        "lodash-es": "^4.17.15",
+        "es-toolkit": "^1.39.7",
         "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/cdk": ">=16.0.0",
-        "@angular/common": ">=16.0.0",
-        "@angular/core": ">=16.0.0",
-        "@angular/platform-browser": ">=16.0.0",
+        "@angular/cdk": ">=21.0.0",
+        "@angular/common": ">=21.0.0",
+        "@angular/core": ">=21.0.0",
+        "@angular/platform-browser": ">=21.0.0",
         "chart.js": "^3.4.0 || ^4.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "apollo-angular": "^13",
     "chart.js": "^4.4.0",
     "chartjs-chart-treemap": "^2.3.0",
+    "chartjs-plugin-autocolors": "^0.3.1",
     "core-js": "^3.24.1",
     "cors": "~2.8.5",
     "d3-axis": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "leaflet.sync": "^0.2.4",
     "localforage": "^1.10.0",
     "moment": "^2.29.4",
-    "ng2-charts": "^5.0.3",
+    "ng2-charts": "^10.0.0",
     "ngx-clipboard": "^16.0.0",
     "ngx-moment": "^6.0.2",
     "ngx-quicklink": "0.4.9",

--- a/projects/laji/src/app/app.module.ts
+++ b/projects/laji/src/app/app.module.ts
@@ -20,6 +20,7 @@ import { GraphQLModule } from './graph-ql/graph-ql.module';
 import { QuicklinkModule } from 'ngx-quicklink';
 import { BrowserModule, provideClientHydration, Title } from '@angular/platform-browser';
 import { LajiTitle } from './shared/service/laji-title';
+import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 import { LocaleModule } from './locale/locale.module';
 import { API_BASE_URL, LajiApiClientService } from 'projects/laji-api-client/src/laji-api-client.service';
 import { setLocale } from './app-routing.modules';
@@ -96,6 +97,7 @@ export function detectLangFromPath(pathname: string, langs = ['en', 'sv'], defau
   		withLocalStorage(),
   		withSessionStorage()
     ),
+    provideCharts(withDefaultRegisterables()),
   ]
 })
 export class AppModule {

--- a/projects/laji/src/app/shared-modules/chart/chart.module.ts
+++ b/projects/laji/src/app/shared-modules/chart/chart.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ChartComponent } from './chart.component';
-import { NgChartsModule } from 'ng2-charts';
+import { BaseChartDirective } from 'ng2-charts';
 import { UtilitiesModule } from '../utilities/utilities.module';
 import { UtilitiesDumbDirectivesModule } from '../utilities/directive/dumb-directives/utilities-dumb-directives.module';
 
@@ -11,7 +11,7 @@ import { UtilitiesDumbDirectivesModule } from '../utilities/directive/dumb-direc
   declarations: [ChartComponent],
   imports: [
     CommonModule,
-    NgChartsModule,
+    BaseChartDirective,
     UtilitiesModule,
     UtilitiesDumbDirectivesModule
   ],

--- a/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.component.html
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.component.html
@@ -6,6 +6,7 @@
         [datasets]="chartData!.yearChartData"
         [labels]="yearChartLabels"
         [options]="barChartOptions"
+        [plugins]="plugins"
         [legend]="true"
         chartType="bar"
         (barClick)="onYearChartBarClick($event)"
@@ -22,6 +23,7 @@
         [datasets]="chartData!.monthChartDataArr[activeMonthIdx!]"
         [labels]="monthChartLabels"
         [options]="barChartOptions"
+        [plugins]="plugins"
         [legend]="true"
         chartType="bar"
       ></laji-chart>

--- a/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.component.ts
+++ b/projects/laji/src/app/shared-modules/observation-result/observation-month-day-chart/observation-month-day-chart.component.ts
@@ -13,6 +13,7 @@ import {
 } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 import { ChartOptions, Tooltip } from 'chart.js';
+import autocolors from 'chartjs-plugin-autocolors';
 import { LabelPipe } from '../../../shared/pipe/label.pipe';
 import { ChartData, ObservationMonthDayChartFacade, getNbrOfDaysInMonth } from './observation-month-day-chart.facade';
 import { WarehouseQueryInterface } from '../../../shared/model/WarehouseQueryInterface';
@@ -74,6 +75,7 @@ export class ObservationMonthDayChartComponent implements OnChanges, OnDestroy, 
   yearChartLabels = this.getYearChartLabels();
   monthChartLabels: string[] = [];
   barChartOptions = BAR_CHART_OPTIONS;
+  plugins = [autocolors];
   activeMonthIdx?: number;
   monthFormatting = this.getMonthLabel.bind(this);
 


### PR DESCRIPTION
Fixes #656

https://656.dev.laji.fi/observation/statistics?collectionId=HR.4471,HR.1747

Fixes the chart color bug by updating ng2-charts (it was not working properly with the current chartjs version). I also added `chartjs-plugin-autocolors` plugin because with the new version only a few distinct colors are provided by default