### PR TITLE
Fix wbc result maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -105,6 +105,7 @@
         "@types/leaflet": "^1.7.11",
         "@types/leaflet-draw": "^1.0.5",
         "@types/leaflet.markercluster": "^1.5.1",
+        "@types/leaflet.sync": "^0.2.4",
         "@types/node": "^14.18.26",
         "@types/object-hash": "^1.3.4",
         "@types/openseadragon": "^2.4.8",
@@ -8169,6 +8170,16 @@
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/@types/leaflet.markercluster/-/leaflet.markercluster-1.5.6.tgz",
       "integrity": "sha512-I7hZjO2+isVXGYWzKxBp8PsCzAYCJBc29qBdFpquOCkS7zFDqUsUvkEOyQHedsk/Cy5tocQzf+Ndorm5W9YKTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/leaflet": "^1.9"
+      }
+    },
+    "node_modules/@types/leaflet.sync": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@types/leaflet.sync/-/leaflet.sync-0.2.4.tgz",
+      "integrity": "sha512-t+JrN/x4N+kWLEEvbSNA1wBuLtnp6ml3y2i1GTa5neQq1L8HR0SLiJhQhINdI5bA1dRLpchYlITAohmseCpclQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/leaflet": "^1.9"

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "@types/leaflet": "^1.7.11",
     "@types/leaflet-draw": "^1.0.5",
     "@types/leaflet.markercluster": "^1.5.1",
+    "@types/leaflet.sync": "^0.2.4",
     "@types/node": "^14.18.26",
     "@types/object-hash": "^1.3.4",
     "@types/openseadragon": "^2.4.8",

--- a/projects/laji/src/app/project-form/results/wbc-result/wbc-result.service.ts
+++ b/projects/laji/src/app/project-form/results/wbc-result/wbc-result.service.ts
@@ -275,6 +275,7 @@ export class WbcResultService {
       ...this.getFilterParams(undefined, undefined, birdAssociationArea) as any,
       taxonId,
       taxonCensus: taxonCensus ? taxonCensus : undefined,
+      aggregateBy: ['gathering.conversions.year', 'gathering.conversions.month'],
       pageSize: 10000,
       page: 1,
       onlyCount: false

--- a/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-linecharts/wbc-species-linecharts.component.ts
+++ b/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-linecharts/wbc-species-linecharts.component.ts
@@ -60,7 +60,9 @@ export class WbcSpeciesLinechartsComponent implements OnInit, OnChanges {
         },
         point: {
           radius: 3,
-          hitRadius: 6
+          hitRadius: 6,
+          backgroundColor: 'rgb(70,130,180)',
+          borderColor: 'rgb(70,130,180)'
         }
       },
       hover: {

--- a/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-maps/wbc-species-maps.component.ts
+++ b/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-maps/wbc-species-maps.component.ts
@@ -65,12 +65,13 @@ export class WbcSpeciesMapsComponent implements OnChanges {
     if (!this.platformService.isBrowser) {
       return;
     }
-    require('leaflet.sync');
-    const maps = this.mapComponents.map(mapComponent => mapComponent.mapComponent.map);
-    if (maps.every(mapComponents => mapComponents)) {
-      this.maps = maps;
-      maps.forEach(m => this.initEventListeners(m));
-    }
+    import('leaflet.sync').then(() => {
+      const maps = this.mapComponents.map(mapComponent => mapComponent.mapComponent.map);
+      if (maps.every(mapComponents => mapComponents)) {
+        this.maps = maps;
+        maps.forEach(m => this.initEventListeners(m));
+      }
+    });
   }
 
 

--- a/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-maps/wbc-species-maps.component.ts
+++ b/projects/laji/src/app/project-form/results/wbc-result/wbc-species-charts/wbc-species-maps/wbc-species-maps.component.ts
@@ -92,8 +92,8 @@ export class WbcSpeciesMapsComponent implements OnChanges {
 
   private setQuery(nbr: number, season: SEASON) {
     const querys = this.getQuerys(season);
-    this.querys[nbr] = querys.query as WarehouseQueryInterface;
-    this.zeroQuerys[nbr] = querys.zeroQuery as WarehouseQueryInterface;
+    this.querys[nbr] = querys.query;
+    this.zeroQuerys[nbr] = querys.zeroQuery;
   }
 
   private setYearComparisonData() {
@@ -179,9 +179,12 @@ export class WbcSpeciesMapsComponent implements OnChanges {
     return this.ykjService.resultToGeoJson(result, '10kmCenter', zeroObservations);
   }
 
-  private getQuerys(season = this.season, year: number|number[] = this.year!) {
+  private getQuerys(season = this.season, year: number|number[] = this.year!): {query: WarehouseQueryInterface; zeroQuery: WarehouseQueryInterface} {
     const filterParams = this.resultService.getFilterParams(year, season, this.birdAssociationArea);
-    return {query: {...filterParams, taxonId: [this.taxonId]}, zeroQuery: {...filterParams, taxonCensus: [this.taxonCensus]}};
+    return {
+      query: {...filterParams, taxonId: this.taxonId},
+      zeroQuery: {...filterParams, taxonCensus: this.taxonCensus ? [this.taxonCensus] : undefined}
+    };
   }
 
   private initEventListeners(lajiMap: any) {


### PR DESCRIPTION
Fixes #1042

https://1042.dev.laji.fi/project/MHL.3/stats?tab=species&species=MX.34567&year=2015

Fixes several bugs on the wbc result maps page. The main problem was that some queries were wrong (one was missing `aggregateBy` parameter and the other had empty `taxonCensus` parameter). The other problem was that the 'leaflet.sync' import was in a wrong format.