### PR TITLE
Fix annotation view translation

### DIFF
--- a/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.html
+++ b/projects/laji/src/app/shared-modules/document-viewer/document-annotation/document-annotation.component.html
@@ -154,14 +154,7 @@
     <laji-row [title]="'viewer.loadDate' | translate" [value]="document.firstLoadDate | amDateFormat:'L'"></laji-row>
     <laji-row [noTitleSpace]="false" ngPreserveWhitespaces>
       <a href="view?uri={{document.documentId}}" target="_blank">
-        <span>{{ unitCnt }}
-          @if ((unitCnt ?? 0) > 1) {
-            <span> {{ 'annotation.observations.count' | translate }}</span>
-          }
-          @if (unitCnt === 1) {
-            <span> {{ 'annotation.observation.count' | translate }}</span>
-          }
-        </span>
+        <span>{{ unitCnt }} {{ 'annotation.observation.count' | translate }}</span>
       </a>
     </laji-row>
     @if (activeGathering) {


### PR DESCRIPTION
Fixes #898

https://898.dev.laji.fi/observation/list?annotated=true

The translation key `annotation.observations.count` doesn't exist and the `annotation.observation.count` is in a format that works for both one and multiple observations ("7 observation(s) in this document") so I just removed the `annotation.observations.count` from the code