### PR TITLE
Fix label pipe with an invalid url

### DIFF
--- a/projects/laji/src/app/shared/pipe/label.pipe.ts
+++ b/projects/laji/src/app/shared/pipe/label.pipe.ts
@@ -85,7 +85,9 @@ export class LabelPipe implements PipeTransform, OnDestroy {
         );
       case 'fullUri':
         return key.indexOf('http') === 0 ?
-          this.triplestoreLabelService.get(IdService.getId(key)) :
+          this.triplestoreLabelService.get(IdService.getId(key)).pipe(
+            map(value => value || key)
+          ) :
           of(key);
       case 'withKey':
         return this.triplestoreLabelService.get(key).pipe(


### PR DESCRIPTION
Fixes #1026

https://1026.dev.laji.fi/view?uri=http:%2F%2Ftun.fi%2FJX.349699

Fixes label pipe returning an empty string if the url is invalid