### PR TITLE
Fix autocomplete style issues [Fixes #776, Fixes #987]

### DIFF
--- a/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
+++ b/projects/laji/src/app/shared/service/taxon-autocomplete.service.ts
@@ -114,12 +114,15 @@ export class TaxonAutocompleteService {
       case 'MX.euringCode':
         return taxon['matchingName'].toLowerCase();
       case 'MX.vernacularName':
-        return taxon['vernacularName'] !== '' ? taxon['vernacularName'] : taxon['scientificName'];
       case 'MX.alternativeVernacularName':
       case 'MX.obsoleteVernacularName':
       case 'MX.tradeName':
       case 'MX.colloquialVernacularName':
-        return taxon['vernacularName'] !== '' ? taxon['vernacularName'] : taxon['scientificName'];
+        return (taxon['vernacularName'] && taxon['vernacularName'] !== '')
+          ? taxon['vernacularName']
+          : (taxon['scientificName'] && taxon['scientificName'] !== '')
+            ? taxon['scientificName']
+            : taxon['id'];
       default:
         return taxon['scientificName'];
     }


### PR DESCRIPTION
Issue 1: https://github.com/luomus/laji/issues/776
Issue 2: https://github.com/luomus/laji/issues/987
Branch: https://776.dev.laji.fi/observation

Autocomplete style fixes:

- No extra space after "("
- Result bolds only the matching parts, not the whole result
- Fix fallback logic from `taxon['vernacularName'] !== ''` to `taxon['vernacularName'] && taxon['vernacularName'] !== ''` to show scientificName for undefined vernacularNames