### PR TITLE
Fix tech news width [Fixes #1016]

### DIFF
--- a/projects/laji/src/app/shared-modules/technical-news/technical-news-dumb/technical-news-dumb.component.scss
+++ b/projects/laji/src/app/shared-modules/technical-news/technical-news-dumb/technical-news-dumb.component.scss
@@ -11,7 +11,6 @@
   border: 1px solid $danger-3;
   border-radius: 5px;
   padding: 10px;
-  width: max-content;
   a {
     color: $danger-6;
     &:hover {


### PR DESCRIPTION
Issue: https://github.com/luomus/laji/issues/1016
Branch: https://1016.dev.laji.fi/

Removes `width: max-content` to prevent tech news from overflowing on narrow screens.