### PR TITLE
Add tmp id to template documents [Fixes #562]

### DIFF
--- a/projects/laji/src/app/project-form/form/document-form/document-form.facade.ts
+++ b/projects/laji/src/app/project-form/form/document-form/document-form.facade.ts
@@ -377,7 +377,10 @@ export class DocumentFormFacade {
         mergeMap(local => this.documentService.findById(documentID).pipe(
           map((document: Document) => {
             if (document.isTemplate) {
-              const doc = this.documentService.removeMeta(document, ['isTemplate', 'templateName', 'templateDescription']);
+              let doc = this.documentService.removeMeta(document, ['isTemplate', 'templateName', 'templateDescription']);
+              if (!doc.id) {
+                doc = { ...doc, id: this.getNewTmpId() };
+              }
               return {
                 document: form.options?.prepopulatedDocument
                   ? deepmerge(form.options?.prepopulatedDocument, doc, { arrayMerge: Util.arrayCombineMerge })


### PR DESCRIPTION
Issue: https://github.com/luomus/meta/issues/562
Branch: https://562.dev.laji.fi/vihko/home

Because documents that are created from a template are not considered new, they ended up in `fetchExistingDocuments` and were never assigned a temporary ID. Therefore if user quit the browser, there was no record on unsaved events. Now `fetchExistingDocuments` adds a temporary ID to documents without an ID.